### PR TITLE
Configure portable build assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ El proyecto está configurado con **electron-builder** para generar un ejecutabl
    npm run dist
    ```
 
-   Esto crea el paquete en la carpeta `dist/` con un archivo `SummaCham-portable-<version>-x64.exe` listo para distribuirse sin instalación.
+   Esto crea el paquete en la carpeta `dist/` con un archivo `PanelAMCHAM-portable-<version>-x64.exe` listo para distribuirse sin instalación.
+
+   > 💡 En Linux y macOS se necesita tener instalados `wine`, `mono` y `icnsutils` para generar el ejecutable portable de Windows.
 
 3. Comparte el archivo portable generado. Los usuarios solo necesitan descargarlo y abrirlo.
 

--- a/main.js
+++ b/main.js
@@ -1,6 +1,10 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
+const resolveAssetPath = (...segments) => {
+  return path.join(app.getAppPath(), ...segments);
+};
+
 const createWindow = () => {
   const iconName = process.platform === 'win32' ? 'icono.ico' : 'icono.png';
 
@@ -11,10 +15,10 @@ const createWindow = () => {
     minHeight: 720,
     backgroundColor: '#f3f6f1',
     autoHideMenuBar: true,
-    icon: path.join(__dirname, 'icono', iconName)
+    icon: resolveAssetPath('icono', iconName)
   });
 
-  mainWindow.loadFile(path.join(__dirname, 'vistas', 'Vista3.html'));
+  mainWindow.loadFile(resolveAssetPath('vistas', 'Vista3.html'));
 };
 
 app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
         "to": "resources/vistas"
       }
     ],
+    "portable": {
+      "artifactName": "${productName}-portable-${version}-${arch}.${ext}",
+      "useZip": false,
+      "requestExecutionLevel": "user"
+    },
     "win": {
       "target": [
         {


### PR DESCRIPTION
## Summary
- resolve packaged asset paths from the app root so the portable executable can load icons and HTML when distributed
- extend the electron-builder configuration with portable specific options to generate a non-zipped executable
- document the updated artifact name and cross-platform requirements for building the portable setup

## Testing
- not run (build steps require Windows tooling that is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5a922ce78832d8f7463b19b6ad45c