### PR TITLE
Ensure native modules rebuild against Electron runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder --win portable"
+    "dist": "electron-builder --win portable",
+    "postinstall": "electron-builder install-app-deps"
   },
   "devDependencies": {
     "electron": "^38.2.2",


### PR DESCRIPTION
## Summary
- trigger electron-builder to rebuild native modules after install so better-sqlite3 matches the Electron runtime used for packaging

## Testing
- npm run postinstall

------
https://chatgpt.com/codex/tasks/task_e_6908eaca32b8832dbc7bd078f50fc61a