### PR TITLE
Protege vistas con autenticación y refuerza permisos de administración

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const createWindow = () => {
     icon: resolveAssetPath('icono', iconName)
   });
 
-  mainWindow.loadFile(resolveAssetPath('vistas', 'Vista1.html'));
+  mainWindow.loadFile(resolveAssetPath('vistas', 'login.html'));
 };
 
 app.whenReady().then(() => {

--- a/src/routes/usuarios.js
+++ b/src/routes/usuarios.js
@@ -7,6 +7,8 @@ const { MODULOS, construirMapaPermisos } = require('../services/permisosService'
 
 const router = express.Router();
 
+const normalizarUsuario = (valor = '') => valor.toString().trim().toUpperCase();
+
 const schemaPermisosModulo = Joi.object(
   MODULOS.reduce((acumulado, modulo) => {
     acumulado[modulo] = Joi.object({
@@ -55,6 +57,12 @@ const schemaRestablecer = Joi.object({
   contrasena: Joi.string().min(8).required()
 });
 
+const MENSAJES_PERMISOS = {
+  puedeAgregar: 'agregar usuarios',
+  puedeModificar: 'modificar usuarios',
+  puedeEliminar: 'eliminar usuarios'
+};
+
 const obtenerPermisosPorUsuario = (usuarioId) => {
   const permisos = db.prepare(`
     SELECT empresa_id, modulo, puede_cargar_guardar, puede_revisar, puede_aprobar
@@ -95,6 +103,54 @@ const aplicarPermisos = (usuarioId, permisos) => {
 
   transaccion();
 };
+
+const cargarUsuarioActual = (req, res, next) => {
+  const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
+  if (!usuarioEncabezado) {
+    return res.status(401).json({ mensaje: 'No se pudo validar al usuario actual.' });
+  }
+
+  const registro = db.prepare(`
+    SELECT id, usuario, es_admin_global, puede_agregar, puede_modificar, puede_eliminar
+    FROM usuarios
+    WHERE usuario = ?
+  `).get(usuarioEncabezado);
+
+  if (!registro) {
+    return res.status(401).json({ mensaje: 'No se pudo validar al usuario actual.' });
+  }
+
+  const esIconet = registro.usuario === 'ICONET';
+  const esAdmin = Boolean(registro.es_admin_global) || esIconet;
+
+  if (!esAdmin) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para administrar usuarios.' });
+  }
+
+  req.usuarioActual = {
+    id: registro.id,
+    usuario: registro.usuario,
+    esAdminGlobal: esAdmin,
+    permisosGenerales: {
+      puedeAgregar: true,
+      puedeModificar: true,
+      puedeEliminar: true
+    }
+  };
+
+  next();
+};
+
+const asegurarPermisoGeneral = (campo) => (req, res, next) => {
+  const permitido = req.usuarioActual?.permisosGenerales?.[campo];
+  if (!permitido) {
+    const descripcion = MENSAJES_PERMISOS[campo] || 'realizar esta acción';
+    return res.status(403).json({ mensaje: `No cuentas con permiso para ${descripcion}.` });
+  }
+  next();
+};
+
+router.use(cargarUsuarioActual);
 
 router.get('/', (req, res) => {
   const registros = db.prepare(`
@@ -155,7 +211,7 @@ router.get('/:id', (req, res) => {
   });
 });
 
-router.post('/', (req, res) => {
+router.post('/', asegurarPermisoGeneral('puedeAgregar'), (req, res) => {
   const { error, value } = schemaCrearUsuario.validate(req.body || {}, { abortEarly: false });
   if (error) {
     return res.status(400).json({
@@ -164,7 +220,7 @@ router.post('/', (req, res) => {
     });
   }
 
-  const usuarioNormalizado = value.usuario.toUpperCase();
+  const usuarioNormalizado = normalizarUsuario(value.usuario);
   const existente = db.prepare('SELECT id FROM usuarios WHERE usuario = ?').get(usuarioNormalizado);
   if (existente) {
     return res.status(409).json({ mensaje: 'El usuario ya existe.' });
@@ -180,6 +236,8 @@ router.post('/', (req, res) => {
 
   const hash = bcrypt.hashSync(value.contrasena, 12);
 
+  const permisosGenerales = value.esAdminGlobal ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 } : { puedeAgregar: 0, puedeModificar: 0, puedeEliminar: 0 };
+
   const insertar = db.prepare(`
     INSERT INTO usuarios (
       usuario, nombres, apellidos, correo, contrasena, es_admin_global,
@@ -194,9 +252,9 @@ router.post('/', (req, res) => {
     value.correo,
     hash,
     value.esAdminGlobal ? 1 : 0,
-    value.permisosGenerales.puedeAgregar ? 1 : 0,
-    value.permisosGenerales.puedeModificar ? 1 : 0,
-    value.permisosGenerales.puedeEliminar ? 1 : 0
+    permisosGenerales.puedeAgregar,
+    permisosGenerales.puedeModificar,
+    permisosGenerales.puedeEliminar
   );
 
   aplicarPermisos(resultado.lastInsertRowid, value.permisos);
@@ -204,7 +262,7 @@ router.post('/', (req, res) => {
   res.status(201).json({ mensaje: 'Usuario creado correctamente.' });
 });
 
-router.put('/:id', (req, res) => {
+router.put('/:id', asegurarPermisoGeneral('puedeModificar'), (req, res) => {
   const { error, value } = schemaActualizarUsuario.validate(req.body || {}, { abortEarly: false });
   if (error) {
     return res.status(400).json({
@@ -238,15 +296,17 @@ router.put('/:id', (req, res) => {
     WHERE id = ?
   `);
 
+  const permisosGenerales = value.esAdminGlobal ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 } : { puedeAgregar: 0, puedeModificar: 0, puedeEliminar: 0 };
+
   actualizar.run(
-    value.usuario.toUpperCase(),
+    normalizarUsuario(value.usuario),
     value.nombres,
     value.apellidos,
     value.correo,
     value.esAdminGlobal ? 1 : 0,
-    value.permisosGenerales.puedeAgregar ? 1 : 0,
-    value.permisosGenerales.puedeModificar ? 1 : 0,
-    value.permisosGenerales.puedeEliminar ? 1 : 0,
+    permisosGenerales.puedeAgregar,
+    permisosGenerales.puedeModificar,
+    permisosGenerales.puedeEliminar,
     usuarioId
   );
 
@@ -260,7 +320,7 @@ router.put('/:id', (req, res) => {
   res.json({ mensaje: 'Usuario actualizado correctamente.' });
 });
 
-router.delete('/:id', (req, res) => {
+router.delete('/:id', asegurarPermisoGeneral('puedeEliminar'), (req, res) => {
   const usuarioId = Number(req.params.id);
   const existente = db.prepare('SELECT es_admin_global FROM usuarios WHERE id = ?').get(usuarioId);
   if (!existente) {
@@ -275,7 +335,7 @@ router.delete('/:id', (req, res) => {
   res.json({ mensaje: 'Usuario eliminado correctamente.' });
 });
 
-router.post('/:id/restablecer-contrasena', (req, res) => {
+router.post('/:id/restablecer-contrasena', asegurarPermisoGeneral('puedeModificar'), (req, res) => {
   const { error, value } = schemaRestablecer.validate(req.body || {}, { abortEarly: false });
   if (error) {
     return res.status(400).json({

--- a/vistas/Vista1.html
+++ b/vistas/Vista1.html
@@ -191,9 +191,15 @@
     </div>
   </div>
 
+  <script src="js/sesion.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <script>
+    const sesion = Sesion.requerirSesion();
+    if (!sesion) {
+      throw new Error('Redireccionando al inicio de sesión.');
+    }
+
 
     const CITY_LABELS = {
       CDMX: "Ciudad de México",

--- a/vistas/Vista2.html
+++ b/vistas/Vista2.html
@@ -346,8 +346,14 @@
         </div>
     </div>
 
+    <script src="js/sesion.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>
+        const sesion = Sesion.requerirSesion();
+        if (!sesion) {
+            throw new Error('Redireccionando al inicio de sesión.');
+        }
+
         const accountSearchInput = document.getElementById('accountSearch');
         const saveBudgetBtn = document.getElementById('saveBudgetBtn');
         const loadBudgetBtn = document.getElementById('loadBudgetBtn');

--- a/vistas/Vista3.html
+++ b/vistas/Vista3.html
@@ -1645,8 +1645,14 @@
     </div>
   </div>
 
+  <script src="js/sesion.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
+    const sesion = Sesion.requerirSesion();
+    if (!sesion) {
+      throw new Error('Redireccionando al inicio de sesión.');
+    }
+
     // Script para selección de celdas y zoom
     document.addEventListener('DOMContentLoaded', function() {
       const table = document.getElementById('mainTable');

--- a/vistas/crear_usuario.html
+++ b/vistas/crear_usuario.html
@@ -180,6 +180,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/sesion.js"></script>
 
   <script>
     const API_BASE = 'http://localhost:3000/api';
@@ -193,13 +194,26 @@
     const contenedorEmpresas = document.getElementById('contenedorEmpresas');
     const indicadorContrasena = document.getElementById('indicadorContrasena');
 
-    const obtenerSesion = () => {
-      try {
-        const sesion = JSON.parse(sessionStorage.getItem('sesionUsuario'));
-        return sesion || null;
-      } catch (error) {
-        return null;
-      }
+    const sesion = Sesion.requerirSesion({ requireAdmin: true });
+    if (!sesion) {
+      throw new Error('Redireccionando al inicio de sesión.');
+    }
+
+    const permisosGeneralesSesion = sesion.usuario?.permisosGenerales || {};
+    const puedeAgregar = Boolean(permisosGeneralesSesion.puedeAgregar);
+    const puedeModificar = Boolean(permisosGeneralesSesion.puedeModificar);
+
+    const actualizarEstadoPermisosGenerales = (esAdminDestino) => {
+      const campos = [
+        document.getElementById('permAgregar'),
+        document.getElementById('permModificar'),
+        document.getElementById('permEliminar')
+      ];
+
+      campos.forEach((campo) => {
+        campo.checked = esAdminDestino;
+        campo.disabled = true;
+      });
     };
 
     const mostrarAlerta = (mensaje, tipo = 'danger') => {
@@ -337,6 +351,8 @@
           });
         });
         base.permisosGenerales = { puedeAgregar: true, puedeModificar: true, puedeEliminar: true };
+      } else {
+        base.permisosGenerales = { puedeAgregar: false, puedeModificar: false, puedeEliminar: false };
       }
 
       return base;
@@ -359,7 +375,8 @@
     };
 
     const cargarUsuario = async (id) => {
-      const respuesta = await fetch(`${API_BASE}/usuarios/${id}`);
+      const respuesta = await fetch(`${API_BASE}/usuarios/${id}`,
+        { headers: Sesion.headersAutenticacion() });
       const datos = await respuesta.json();
       if (!respuesta.ok) {
         throw new Error(datos.mensaje || 'No fue posible obtener la información del usuario.');
@@ -368,14 +385,20 @@
     };
 
     const inicializar = async () => {
-      const sesion = obtenerSesion();
-      if (!sesion || !sesion.usuario?.esAdminGlobal) {
-        window.location.href = 'login.html';
+      const idEdicion = obtenerParametroEdicion();
+      const esEdicion = Boolean(idEdicion);
+
+      if (esEdicion && !puedeModificar) {
+        mostrarAlerta('No cuentas con permiso para modificar usuarios.');
+        setTimeout(() => { window.location.href = 'usuarios.html'; }, 1500);
         return;
       }
 
-      const idEdicion = obtenerParametroEdicion();
-      const esEdicion = Boolean(idEdicion);
+      if (!esEdicion && !puedeAgregar) {
+        mostrarAlerta('No cuentas con permiso para agregar usuarios.');
+        setTimeout(() => { window.location.href = 'usuarios.html'; }, 1500);
+        return;
+      }
 
       if (esEdicion) {
         document.getElementById('tituloPagina').textContent = 'Editar usuario';
@@ -390,13 +413,12 @@
           document.getElementById('nombres').value = usuario.nombres || '';
           document.getElementById('apellidos').value = usuario.apellidos || '';
           document.getElementById('correo').value = usuario.correo || '';
-          document.getElementById('permAgregar').checked = usuario.permisosGenerales.puedeAgregar;
-          document.getElementById('permModificar').checked = usuario.permisosGenerales.puedeModificar;
-          document.getElementById('permEliminar').checked = usuario.permisosGenerales.puedeEliminar;
           document.getElementById('esAdminGlobal').checked = usuario.esAdminGlobal;
+          actualizarEstadoPermisosGenerales(usuario.esAdminGlobal);
           aplicarPermisosAlFormulario(usuario.permisosPorEmpresa);
         } else {
           empresas.forEach((empresa) => sincronizarEstadoEmpresa(empresa.id, false));
+          actualizarEstadoPermisosGenerales(false);
         }
       } catch (error) {
         mostrarAlerta(error.message || 'Ocurrió un problema al iniciar el formulario.');
@@ -404,9 +426,7 @@
 
       document.getElementById('esAdminGlobal').addEventListener('change', (evento) => {
         const esAdmin = evento.target.checked;
-        document.getElementById('permAgregar').checked = esAdmin;
-        document.getElementById('permModificar').checked = esAdmin;
-        document.getElementById('permEliminar').checked = esAdmin;
+        actualizarEstadoPermisosGenerales(esAdmin);
         contenedorEmpresas.querySelectorAll('.activar-empresa').forEach((switchEmpresa) => {
           switchEmpresa.checked = esAdmin;
           sincronizarEstadoEmpresa(switchEmpresa.dataset.empresa, esAdmin);
@@ -424,6 +444,16 @@
 
       const idEdicion = obtenerParametroEdicion();
       const esEdicion = Boolean(idEdicion);
+
+      if (esEdicion && !puedeModificar) {
+        mostrarAlerta('No cuentas con permiso para modificar usuarios.');
+        return;
+      }
+
+      if (!esEdicion && !puedeAgregar) {
+        mostrarAlerta('No cuentas con permiso para agregar usuarios.');
+        return;
+      }
 
       if (!formulario.usuario.value.trim()) {
         formulario.usuario.focus();
@@ -444,7 +474,10 @@
       try {
         const respuesta = await fetch(`${API_BASE}/usuarios${esEdicion ? `/${idEdicion}` : ''}`, {
           method: esEdicion ? 'PUT' : 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            ...Sesion.headersAutenticacion(),
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify(payload)
         });
         const datos = await respuesta.json();

--- a/vistas/e.html
+++ b/vistas/e.html
@@ -1591,8 +1591,14 @@
     </div>
   </div>
 
+  <script src="js/sesion.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
+    const sesion = Sesion.requerirSesion();
+    if (!sesion) {
+      throw new Error('Redireccionando al inicio de sesión.');
+    }
+
     // Script para selección de celdas y zoom
     document.addEventListener('DOMContentLoaded', function() {
       const table = document.getElementById('mainTable');

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -1,0 +1,71 @@
+(() => {
+  const STORAGE_KEY = 'sesionUsuario';
+  const REDIRECCION_POR_DEFECTO = 'login.html';
+
+  const normalizarUsuario = (valor) => {
+    return (valor || '').toString().trim().toUpperCase();
+  };
+
+  const obtener = () => {
+    try {
+      const datos = sessionStorage.getItem(STORAGE_KEY);
+      return datos ? JSON.parse(datos) : null;
+    } catch (error) {
+      console.warn('No fue posible leer la sesión almacenada.', error);
+      return null;
+    }
+  };
+
+  const guardar = (valor) => {
+    if (!valor) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(valor));
+  };
+
+  const limpiar = () => {
+    sessionStorage.removeItem(STORAGE_KEY);
+  };
+
+  const esAdmin = (sesion) => {
+    if (!sesion || !sesion.usuario) return false;
+    const usuario = normalizarUsuario(sesion.usuario.usuario);
+    return Boolean(sesion.usuario.esAdminGlobal) || usuario === 'ICONET';
+  };
+
+  const requerirSesion = ({ requireAdmin = false, redirectTo = REDIRECCION_POR_DEFECTO } = {}) => {
+    const sesion = obtener();
+    if (!sesion) {
+      window.location.href = redirectTo;
+      return null;
+    }
+
+    if (requireAdmin && !esAdmin(sesion)) {
+      window.location.href = redirectTo;
+      return null;
+    }
+
+    return sesion;
+  };
+
+  const headersAutenticacion = () => {
+    const sesion = obtener();
+    if (!sesion || !sesion.usuario) {
+      return {};
+    }
+
+    return {
+      'X-Usuario-Actual': normalizarUsuario(sesion.usuario.usuario)
+    };
+  };
+
+  window.Sesion = {
+    obtener,
+    guardar,
+    limpiar,
+    requerirSesion,
+    esAdmin,
+    headersAutenticacion
+  };
+})();

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -103,6 +103,7 @@
     </form>
   </main>
 
+  <script src="js/sesion.js"></script>
   <script>
     const API_BASE = 'http://localhost:3000/api';
     const selectEmpresa = document.getElementById('empresa');
@@ -169,9 +170,13 @@
           throw new Error(datos.mensaje || 'No fue posible iniciar sesión.');
         }
 
-        sessionStorage.setItem('sesionUsuario', JSON.stringify(datos));
+        Sesion.guardar(datos);
 
-        if (datos.usuario.esAdminGlobal) {
+        const permisosGenerales = datos.usuario?.permisosGenerales || {};
+        const esAdmin = Sesion.esAdmin(datos);
+        const tienePermisoUsuarios = Boolean(permisosGenerales.puedeAgregar || permisosGenerales.puedeModificar || permisosGenerales.puedeEliminar);
+
+        if (esAdmin || tienePermisoUsuarios) {
           window.location.href = 'usuarios.html';
         } else {
           window.location.href = 'Vista1.html';
@@ -184,7 +189,10 @@
       }
     });
 
-    document.addEventListener('DOMContentLoaded', cargarEmpresas);
+    document.addEventListener('DOMContentLoaded', () => {
+      Sesion.limpiar();
+      cargarEmpresas();
+    });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -129,8 +129,8 @@
         <p class="text-muted mb-0">Gestiona accesos, permisos y contraseñas del panel.</p>
       </div>
       <div class="d-flex gap-2">
-        <a href="crear_usuario.html" class="btn btn-primario">Agregar usuario</a>
-        <a href="login.html" class="btn btn-outline-secondary">Cerrar sesión</a>
+        <a href="crear_usuario.html" class="btn btn-primario" id="btnAgregarUsuario">Agregar usuario</a>
+        <button type="button" class="btn btn-outline-secondary" id="btnCerrarSesion">Cerrar sesión</button>
       </div>
     </header>
 
@@ -167,22 +167,26 @@
     </section>
   </div>
 
+  <script src="js/sesion.js"></script>
   <script>
     const API_BASE = 'http://localhost:3000/api';
+    const sesion = Sesion.requerirSesion({ requireAdmin: true });
+    if (!sesion) {
+      throw new Error('Redireccionando al inicio de sesión.');
+    }
+
     const alerta = document.getElementById('alerta');
     const tabla = document.getElementById('tablaUsuarios').querySelector('tbody');
     const buscador = document.getElementById('busqueda');
+    const btnAgregar = document.getElementById('btnAgregarUsuario');
+    const btnCerrarSesion = document.getElementById('btnCerrarSesion');
+
+    const permisosGenerales = sesion.usuario?.permisosGenerales || {};
+    const puedeAgregar = Boolean(permisosGenerales.puedeAgregar);
+    const puedeModificar = Boolean(permisosGenerales.puedeModificar);
+    const puedeEliminar = Boolean(permisosGenerales.puedeEliminar);
 
     let usuarios = [];
-
-    const obtenerSesion = () => {
-      try {
-        const sesion = JSON.parse(sessionStorage.getItem('sesionUsuario'));
-        return sesion || null;
-      } catch (error) {
-        return null;
-      }
-    };
 
     const mostrarAlerta = (mensaje, tipo = 'danger') => {
       alerta.textContent = mensaje;
@@ -223,6 +227,17 @@
 
       filtrados.forEach((usuario) => {
         const fila = document.createElement('tr');
+        const puedeEditarFila = puedeModificar;
+        const puedeResetearFila = puedeModificar && !usuario.esAdminGlobal;
+        const puedeEliminarFila = puedeEliminar && !usuario.esAdminGlobal;
+
+        const enlaceEditar = puedeEditarFila
+          ? `<a class="btn btn-sm btn-outline-success" href="crear_usuario.html?editar=${usuario.id}">Editar</a>`
+          : `<span class="btn btn-sm btn-outline-success disabled" aria-disabled="true">Editar</span>`;
+
+        const botonReset = `<button class="btn btn-sm btn-outline-secondary" data-accion="reset" data-id="${usuario.id}" ${puedeResetearFila ? '' : 'disabled'}>Restablecer contraseña</button>`;
+        const botonEliminar = `<button class="btn btn-sm btn-outline-danger" data-accion="eliminar" data-id="${usuario.id}" ${puedeEliminarFila ? '' : 'disabled'}>Eliminar</button>`;
+
         fila.innerHTML = `
           <td data-title="Nombre">${[usuario.nombres, usuario.apellidos].filter(Boolean).join(' ') || '—'}</td>
           <td data-title="Usuario">${usuario.usuario}</td>
@@ -231,9 +246,9 @@
           <td data-title="Rol"><span class="role-badge ${usuario.esAdminGlobal ? 'role-admin' : 'role-user'}">${usuario.esAdminGlobal ? 'Administrador global' : 'Usuario'}</span></td>
           <td data-title="Acciones" class="text-end acciones">
             <div class="btn-group">
-              <a class="btn btn-sm btn-outline-success" href="crear_usuario.html?editar=${usuario.id}">Editar</a>
-              <button class="btn btn-sm btn-outline-secondary" data-accion="reset" data-id="${usuario.id}" ${usuario.esAdminGlobal ? 'disabled' : ''}>Restablecer contraseña</button>
-              <button class="btn btn-sm btn-outline-danger" data-accion="eliminar" data-id="${usuario.id}" ${usuario.esAdminGlobal ? 'disabled' : ''}>Eliminar</button>
+              ${enlaceEditar}
+              ${botonReset}
+              ${botonEliminar}
             </div>
           </td>`;
         tabla.appendChild(fila);
@@ -243,7 +258,9 @@
     const cargarUsuarios = async () => {
       limpiarAlerta();
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios`);
+        const respuesta = await fetch(`${API_BASE}/usuarios`, {
+          headers: Sesion.headersAutenticacion()
+        });
         const datos = await respuesta.json();
         if (!respuesta.ok) {
           throw new Error(datos.mensaje || 'No fue posible obtener los usuarios.');
@@ -256,11 +273,18 @@
     };
 
     const eliminarUsuario = async (id) => {
+      if (!puedeEliminar) {
+        mostrarAlerta('No cuentas con permiso para eliminar usuarios.');
+        return;
+      }
       if (!confirm('¿Deseas eliminar al usuario seleccionado? Esta acción no se puede deshacer.')) {
         return;
       }
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios/${id}`, { method: 'DELETE' });
+        const respuesta = await fetch(`${API_BASE}/usuarios/${id}`, {
+          method: 'DELETE',
+          headers: Sesion.headersAutenticacion()
+        });
         const datos = await respuesta.json();
         if (!respuesta.ok) {
           throw new Error(datos.mensaje || 'No fue posible eliminar al usuario.');
@@ -273,6 +297,10 @@
     };
 
     const restablecerContrasena = async (id) => {
+      if (!puedeModificar) {
+        mostrarAlerta('No cuentas con permiso para modificar usuarios.');
+        return;
+      }
       const nueva = prompt('Ingresa la nueva contraseña (mínimo 8 caracteres):');
       if (!nueva) return;
       if (nueva.length < 8) {
@@ -282,7 +310,10 @@
       try {
         const respuesta = await fetch(`${API_BASE}/usuarios/${id}/restablecer-contrasena`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            ...Sesion.headersAutenticacion(),
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify({ contrasena: nueva })
         });
         const datos = await respuesta.json();
@@ -297,7 +328,7 @@
 
     tabla.addEventListener('click', (evento) => {
       const boton = evento.target.closest('button[data-accion]');
-      if (!boton) return;
+      if (!boton || boton.disabled) return;
       const id = boton.getAttribute('data-id');
       const accion = boton.getAttribute('data-accion');
       if (accion === 'eliminar') {
@@ -309,14 +340,24 @@
 
     buscador.addEventListener('input', renderizarTabla);
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const sesion = obtenerSesion();
-      if (!sesion || !sesion.usuario?.esAdminGlobal) {
+    if (!puedeAgregar && btnAgregar) {
+      btnAgregar.classList.add('disabled');
+      btnAgregar.setAttribute('aria-disabled', 'true');
+      btnAgregar.setAttribute('tabindex', '-1');
+      btnAgregar.addEventListener('click', (evento) => {
+        evento.preventDefault();
+        mostrarAlerta('No cuentas con permiso para agregar usuarios.');
+      });
+    }
+
+    if (btnCerrarSesion) {
+      btnCerrarSesion.addEventListener('click', () => {
+        Sesion.limpiar();
         window.location.href = 'login.html';
-        return;
-      }
-      cargarUsuarios();
-    });
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', cargarUsuarios);
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- inicializa la aplicación mostrando primero la pantalla de inicio de sesión y reutiliza un helper de sesión en las vistas
- refuerza el backend de usuarios exigiendo encabezados de autenticación y limitando las operaciones de alta, edición y baja al rol administrador/Iconet
- ajusta las vistas de administración para respetar los permisos generales, limpiar sesión al cerrar y enviar la identidad en cada petición

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69093a6f7464832d8022c97e9167b3e2