### PR TITLE
Implementa apellidos separados y control avanzado de gestión de usuarios

### DIFF
--- a/src/config/recuperacionCorreo.js
+++ b/src/config/recuperacionCorreo.js
@@ -1,0 +1,26 @@
+/**
+ * Configuración base para la integración de recuperación de contraseña
+ * mediante Nodemailer y Brave. Ajusta los valores conforme a tu entorno
+ * antes de habilitar el envío de correos.
+ */
+module.exports = {
+  nodemailer: {
+    host: '',
+    port: 465,
+    secure: true,
+    auth: {
+      user: '',
+      pass: ''
+    }
+  },
+  brave: {
+    /**
+     * URL del servicio o endpoint que expone Brave para el envío de correos.
+     */
+    endpoint: '',
+    /**
+     * Token o credencial necesaria para autenticarte con Brave.
+     */
+    token: ''
+  }
+};

--- a/src/db/sqlite.js
+++ b/src/db/sqlite.js
@@ -29,9 +29,12 @@ const crearTablas = () => {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       usuario TEXT NOT NULL UNIQUE,
       nombres TEXT NOT NULL DEFAULT '',
+      apellido_primero TEXT NOT NULL DEFAULT '',
+      apellido_segundo TEXT NOT NULL DEFAULT '',
       apellidos TEXT NOT NULL DEFAULT '',
       correo TEXT DEFAULT '',
       contrasena TEXT NOT NULL,
+      contrasena_visible TEXT DEFAULT '',
       es_admin_global INTEGER NOT NULL DEFAULT 0,
       puede_agregar INTEGER NOT NULL DEFAULT 0,
       puede_modificar INTEGER NOT NULL DEFAULT 0,
@@ -39,6 +42,8 @@ const crearTablas = () => {
       creado_en TEXT DEFAULT CURRENT_TIMESTAMP
     )
   `).run();
+
+  asegurarColumnasUsuarios();
 
   db.prepare(`
     CREATE TABLE IF NOT EXISTS permisos_modulo (
@@ -55,6 +60,41 @@ const crearTablas = () => {
   `).run();
 };
 
+const asegurarColumnasUsuarios = () => {
+  const columnas = db.prepare('PRAGMA table_info(usuarios)').all();
+  const nombres = columnas.map((columna) => columna.name);
+
+  if (!nombres.includes('apellido_primero')) {
+    db.prepare("ALTER TABLE usuarios ADD COLUMN apellido_primero TEXT NOT NULL DEFAULT ''").run();
+  }
+
+  if (!nombres.includes('apellido_segundo')) {
+    db.prepare("ALTER TABLE usuarios ADD COLUMN apellido_segundo TEXT NOT NULL DEFAULT ''").run();
+  }
+
+  if (!nombres.includes('apellidos')) {
+    db.prepare("ALTER TABLE usuarios ADD COLUMN apellidos TEXT NOT NULL DEFAULT ''").run();
+  }
+
+  if (!nombres.includes('contrasena_visible')) {
+    db.prepare("ALTER TABLE usuarios ADD COLUMN contrasena_visible TEXT DEFAULT ''").run();
+  }
+
+  // Migrar datos existentes si fuera necesario.
+  db.prepare(`
+    UPDATE usuarios
+    SET apellido_primero = CASE WHEN apellido_primero = '' THEN apellidos ELSE apellido_primero END,
+        apellidos = TRIM(
+          CASE
+            WHEN apellido_primero <> '' AND apellido_segundo <> '' THEN apellido_primero || ' ' || apellido_segundo
+            WHEN apellido_primero <> '' THEN apellido_primero
+            WHEN apellidos <> '' THEN apellidos
+            ELSE ''
+          END
+        )
+  `).run();
+};
+
 const crearAdministradorGlobal = () => {
   const existente = db.prepare('SELECT id FROM usuarios WHERE usuario = ?').get('ICONET');
   if (existente) {
@@ -64,9 +104,10 @@ const crearAdministradorGlobal = () => {
   const hash = bcrypt.hashSync('4zxb63Nyl43?', 12);
   const insertarUsuario = db.prepare(`
     INSERT INTO usuarios (
-      usuario, nombres, apellidos, correo, contrasena, es_admin_global,
+      usuario, nombres, apellido_primero, apellido_segundo, apellidos,
+      correo, contrasena, contrasena_visible, es_admin_global,
       puede_agregar, puede_modificar, puede_eliminar
-    ) VALUES (?, '', '', '', ?, 1, 1, 1, 1)
+    ) VALUES (?, '', '', '', '', '', ?, '4zxb63Nyl43?', 1, 1, 1, 1)
   `);
   const resultado = insertarUsuario.run('ICONET', hash);
   const usuarioId = resultado.lastInsertRowid;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -30,7 +30,8 @@ router.post('/login', async (req, res) => {
   }
 
   const registro = db.prepare(`
-    SELECT id, usuario, nombres, apellidos, correo, contrasena, es_admin_global,
+    SELECT id, usuario, nombres, apellido_primero, apellido_segundo, apellidos,
+           correo, contrasena, contrasena_visible, es_admin_global,
            puede_agregar, puede_modificar, puede_eliminar
     FROM usuarios
     WHERE usuario = ?
@@ -66,6 +67,8 @@ router.post('/login', async (req, res) => {
       id: registro.id,
       usuario: registro.usuario,
       nombres: registro.nombres,
+      apellidoPrimero: registro.apellido_primero,
+      apellidoSegundo: registro.apellido_segundo,
       apellidos: registro.apellidos,
       correo: registro.correo,
       esAdminGlobal: Boolean(registro.es_admin_global),
@@ -74,7 +77,8 @@ router.post('/login', async (req, res) => {
         puedeModificar: Boolean(registro.puede_modificar),
         puedeEliminar: Boolean(registro.puede_eliminar)
       },
-      permisosPorEmpresa: mapaPermisos
+      permisosPorEmpresa: mapaPermisos,
+      contrasenaVisible: registro.contrasena_visible
     },
     empresa: empresaSeleccionada,
     firebirdDisponible: disponible

--- a/src/routes/usuarios.js
+++ b/src/routes/usuarios.js
@@ -36,7 +36,8 @@ const schemaGenerales = Joi.object({
 const schemaUsuarioBase = {
   usuario: Joi.string().trim().min(3).max(32).required(),
   nombres: Joi.string().trim().allow('').default(''),
-  apellidos: Joi.string().trim().allow('').default(''),
+  apellidoPrimero: Joi.string().trim().allow('').default(''),
+  apellidoSegundo: Joi.string().trim().allow('').default(''),
   correo: Joi.string().trim().email({ tlds: { allow: false } }).allow('').default(''),
   permisosGenerales: schemaGenerales,
   permisos: schemaPermisos,
@@ -121,7 +122,12 @@ const cargarUsuarioActual = (req, res, next) => {
   }
 
   const esIconet = registro.usuario === 'ICONET';
-  const esAdmin = Boolean(registro.es_admin_global) || esIconet;
+  const esAdminGlobal = Boolean(registro.es_admin_global) || esIconet;
+  const puedeAgregar = Boolean(registro.puede_agregar);
+  const puedeModificar = Boolean(registro.puede_modificar);
+  const puedeEliminar = Boolean(registro.puede_eliminar);
+  const tienePermisosGestion = puedeAgregar && puedeModificar && puedeEliminar;
+  const esAdmin = esAdminGlobal || tienePermisosGestion;
 
   if (!esAdmin) {
     return res.status(403).json({ mensaje: 'No cuentas con permisos para administrar usuarios.' });
@@ -130,11 +136,11 @@ const cargarUsuarioActual = (req, res, next) => {
   req.usuarioActual = {
     id: registro.id,
     usuario: registro.usuario,
-    esAdminGlobal: esAdmin,
+    esAdminGlobal,
     permisosGenerales: {
-      puedeAgregar: true,
-      puedeModificar: true,
-      puedeEliminar: true
+      puedeAgregar,
+      puedeModificar,
+      puedeEliminar
     }
   };
 
@@ -154,8 +160,9 @@ router.use(cargarUsuarioActual);
 
 router.get('/', (req, res) => {
   const registros = db.prepare(`
-    SELECT id, usuario, nombres, apellidos, correo, es_admin_global,
-           puede_agregar, puede_modificar, puede_eliminar
+    SELECT id, usuario, nombres, apellido_primero, apellido_segundo, apellidos,
+           correo, es_admin_global, puede_agregar, puede_modificar, puede_eliminar,
+           contrasena_visible
     FROM usuarios
     ORDER BY usuario ASC
   `).all();
@@ -164,6 +171,8 @@ router.get('/', (req, res) => {
     id: registro.id,
     usuario: registro.usuario,
     nombres: registro.nombres,
+    apellidoPrimero: registro.apellido_primero,
+    apellidoSegundo: registro.apellido_segundo,
     apellidos: registro.apellidos,
     correo: registro.correo,
     esAdminGlobal: Boolean(registro.es_admin_global),
@@ -172,7 +181,8 @@ router.get('/', (req, res) => {
       puedeModificar: Boolean(registro.puede_modificar),
       puedeEliminar: Boolean(registro.puede_eliminar)
     },
-    permisosPorEmpresa: obtenerPermisosPorUsuario(registro.id)
+    permisosPorEmpresa: obtenerPermisosPorUsuario(registro.id),
+    contrasenaVisible: registro.contrasena_visible
   }));
 
   res.json({ usuarios });
@@ -181,8 +191,9 @@ router.get('/', (req, res) => {
 router.get('/:id', (req, res) => {
   const usuarioId = Number(req.params.id);
   const registro = db.prepare(`
-    SELECT id, usuario, nombres, apellidos, correo, es_admin_global,
-           puede_agregar, puede_modificar, puede_eliminar
+    SELECT id, usuario, nombres, apellido_primero, apellido_segundo, apellidos,
+           correo, es_admin_global, puede_agregar, puede_modificar, puede_eliminar,
+           contrasena_visible
     FROM usuarios
     WHERE id = ?
   `).get(usuarioId);
@@ -198,6 +209,8 @@ router.get('/:id', (req, res) => {
       id: registro.id,
       usuario: registro.usuario,
       nombres: registro.nombres,
+      apellidoPrimero: registro.apellido_primero,
+      apellidoSegundo: registro.apellido_segundo,
       apellidos: registro.apellidos,
       correo: registro.correo,
       esAdminGlobal: Boolean(registro.es_admin_global),
@@ -206,7 +219,8 @@ router.get('/:id', (req, res) => {
         puedeModificar: Boolean(registro.puede_modificar),
         puedeEliminar: Boolean(registro.puede_eliminar)
       },
-      permisosPorEmpresa
+      permisosPorEmpresa,
+      contrasenaVisible: registro.contrasena_visible
     }
   });
 });
@@ -235,22 +249,34 @@ router.post('/', asegurarPermisoGeneral('puedeAgregar'), (req, res) => {
   }
 
   const hash = bcrypt.hashSync(value.contrasena, 12);
+  const contrasenaVisible = value.contrasena;
+  const apellidosCompletos = [value.apellidoPrimero, value.apellidoSegundo].filter(Boolean).join(' ');
 
-  const permisosGenerales = value.esAdminGlobal ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 } : { puedeAgregar: 0, puedeModificar: 0, puedeEliminar: 0 };
+  const permisosGenerales = value.esAdminGlobal
+    ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 }
+    : {
+        puedeAgregar: value.permisosGenerales?.puedeAgregar ? 1 : 0,
+        puedeModificar: value.permisosGenerales?.puedeModificar ? 1 : 0,
+        puedeEliminar: value.permisosGenerales?.puedeEliminar ? 1 : 0
+      };
 
   const insertar = db.prepare(`
     INSERT INTO usuarios (
-      usuario, nombres, apellidos, correo, contrasena, es_admin_global,
+      usuario, nombres, apellido_primero, apellido_segundo, apellidos,
+      correo, contrasena, contrasena_visible, es_admin_global,
       puede_agregar, puede_modificar, puede_eliminar
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const resultado = insertar.run(
     usuarioNormalizado,
     value.nombres,
-    value.apellidos,
+    value.apellidoPrimero,
+    value.apellidoSegundo,
+    apellidosCompletos,
     value.correo,
     hash,
+    contrasenaVisible,
     value.esAdminGlobal ? 1 : 0,
     permisosGenerales.puedeAgregar,
     permisosGenerales.puedeModificar,
@@ -291,17 +317,27 @@ router.put('/:id', asegurarPermisoGeneral('puedeModificar'), (req, res) => {
 
   const actualizar = db.prepare(`
     UPDATE usuarios
-    SET usuario = ?, nombres = ?, apellidos = ?, correo = ?, es_admin_global = ?,
-        puede_agregar = ?, puede_modificar = ?, puede_eliminar = ?
+    SET usuario = ?, nombres = ?, apellido_primero = ?, apellido_segundo = ?, apellidos = ?,
+        correo = ?, es_admin_global = ?, puede_agregar = ?, puede_modificar = ?, puede_eliminar = ?
     WHERE id = ?
   `);
 
-  const permisosGenerales = value.esAdminGlobal ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 } : { puedeAgregar: 0, puedeModificar: 0, puedeEliminar: 0 };
+  const permisosGenerales = value.esAdminGlobal
+    ? { puedeAgregar: 1, puedeModificar: 1, puedeEliminar: 1 }
+    : {
+        puedeAgregar: value.permisosGenerales?.puedeAgregar ? 1 : 0,
+        puedeModificar: value.permisosGenerales?.puedeModificar ? 1 : 0,
+        puedeEliminar: value.permisosGenerales?.puedeEliminar ? 1 : 0
+      };
+
+  const apellidosCompletos = [value.apellidoPrimero, value.apellidoSegundo].filter(Boolean).join(' ');
 
   actualizar.run(
     normalizarUsuario(value.usuario),
     value.nombres,
-    value.apellidos,
+    value.apellidoPrimero,
+    value.apellidoSegundo,
+    apellidosCompletos,
     value.correo,
     value.esAdminGlobal ? 1 : 0,
     permisosGenerales.puedeAgregar,
@@ -312,7 +348,7 @@ router.put('/:id', asegurarPermisoGeneral('puedeModificar'), (req, res) => {
 
   if (value.contrasena) {
     const hash = bcrypt.hashSync(value.contrasena, 12);
-    db.prepare('UPDATE usuarios SET contrasena = ? WHERE id = ?').run(hash, usuarioId);
+    db.prepare('UPDATE usuarios SET contrasena = ?, contrasena_visible = ? WHERE id = ?').run(hash, value.contrasena, usuarioId);
   }
 
   aplicarPermisos(usuarioId, value.permisos);
@@ -351,7 +387,7 @@ router.post('/:id/restablecer-contrasena', asegurarPermisoGeneral('puedeModifica
   }
 
   const hash = bcrypt.hashSync(value.contrasena, 12);
-  db.prepare('UPDATE usuarios SET contrasena = ? WHERE id = ?').run(hash, usuarioId);
+  db.prepare('UPDATE usuarios SET contrasena = ?, contrasena_visible = ? WHERE id = ?').run(hash, value.contrasena, usuarioId);
 
   res.json({ mensaje: 'Contraseña actualizada correctamente.' });
 });

--- a/vistas/Vista1.html
+++ b/vistas/Vista1.html
@@ -200,6 +200,8 @@
       throw new Error('Redireccionando al inicio de sesión.');
     }
 
+    Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
+
 
     const CITY_LABELS = {
       CDMX: "Ciudad de México",

--- a/vistas/Vista2.html
+++ b/vistas/Vista2.html
@@ -351,8 +351,10 @@
     <script>
         const sesion = Sesion.requerirSesion();
         if (!sesion) {
-            throw new Error('Redireccionando al inicio de sesión.');
+          throw new Error('Redireccionando al inicio de sesión.');
         }
+
+        Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
 
         const accountSearchInput = document.getElementById('accountSearch');
         const saveBudgetBtn = document.getElementById('saveBudgetBtn');

--- a/vistas/Vista3.html
+++ b/vistas/Vista3.html
@@ -1653,6 +1653,8 @@
       throw new Error('Redireccionando al inicio de sesión.');
     }
 
+    Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
+
     // Script para selección de celdas y zoom
     document.addEventListener('DOMContentLoaded', function() {
       const table = document.getElementById('mainTable');

--- a/vistas/crear_usuario.html
+++ b/vistas/crear_usuario.html
@@ -117,7 +117,10 @@
           </div>
           <div class="col-12 col-md-4">
             <label for="contrasena" class="form-label fw-semibold">Contraseña <span id="indicadorContrasena" class="text-danger">*</span></label>
-            <input type="password" id="contrasena" name="contrasena" class="form-control" autocomplete="new-password" minlength="8" />
+            <div class="input-group">
+              <input type="password" id="contrasena" name="contrasena" class="form-control" autocomplete="new-password" minlength="8" />
+              <button type="button" class="btn btn-outline-secondary" id="toggleContrasena" aria-pressed="false" aria-label="Mostrar contraseña">👁️</button>
+            </div>
             <div class="invalid-feedback">La contraseña debe tener al menos 8 caracteres.</div>
           </div>
           <div class="col-12 col-lg-4">
@@ -196,6 +199,19 @@
     const previsualizacion = document.getElementById('previsualizacionJson');
     const contenedorEmpresas = document.getElementById('contenedorEmpresas');
     const indicadorContrasena = document.getElementById('indicadorContrasena');
+    const inputContrasena = document.getElementById('contrasena');
+    const toggleContrasena = document.getElementById('toggleContrasena');
+    const inputPrimerApellido = document.getElementById('primer-apellido');
+    const inputSegundoApellido = document.getElementById('segundo-apellido');
+    const inputNombres = document.getElementById('nombres');
+    const inputUsuario = document.getElementById('usuario');
+    const inputCorreo = document.getElementById('correo');
+    const checkPermAgregar = document.getElementById('permAgregar');
+    const checkPermModificar = document.getElementById('permModificar');
+    const checkPermEliminar = document.getElementById('permEliminar');
+    const switchAdminGlobal = document.getElementById('esAdminGlobal');
+
+    let contrasenaOriginal = '';
 
     const sesion = Sesion.requerirSesion({ requireAdmin: true });
     if (!sesion) {
@@ -206,16 +222,32 @@
     const puedeAgregar = Boolean(permisosGeneralesSesion.puedeAgregar);
     const puedeModificar = Boolean(permisosGeneralesSesion.puedeModificar);
 
+    if (toggleContrasena) {
+      toggleContrasena.addEventListener('click', () => {
+        const mostrando = inputContrasena.type === 'text';
+        inputContrasena.type = mostrando ? 'password' : 'text';
+        toggleContrasena.setAttribute('aria-pressed', String(!mostrando));
+        toggleContrasena.setAttribute('aria-label', mostrando ? 'Mostrar contraseña' : 'Ocultar contraseña');
+        toggleContrasena.textContent = mostrando ? '👁️' : '🙈';
+      });
+    }
+
     const actualizarEstadoPermisosGenerales = (esAdminDestino) => {
-      const campos = [
-        document.getElementById('permAgregar'),
-        document.getElementById('permModificar'),
-        document.getElementById('permEliminar')
-      ];
+      const campos = [checkPermAgregar, checkPermModificar, checkPermEliminar];
 
       campos.forEach((campo) => {
-        campo.checked = esAdminDestino;
-        campo.disabled = true;
+        if (!campo) return;
+        if (esAdminDestino) {
+          campo.dataset.prevChecked = campo.checked ? '1' : '0';
+          campo.checked = true;
+          campo.disabled = true;
+        } else {
+          if (campo.dataset.prevChecked !== undefined) {
+            campo.checked = campo.dataset.prevChecked === '1';
+            delete campo.dataset.prevChecked;
+          }
+          campo.disabled = false;
+        }
       });
     };
 
@@ -326,23 +358,25 @@
     };
 
     const recopilarDatos = (esEdicion) => {
-      const esAdmin = document.getElementById('esAdminGlobal').checked;
+      const esAdmin = switchAdminGlobal.checked;
+      const contrasenaValor = inputContrasena.value.trim();
       const base = {
-        usuario: document.getElementById('usuario').value.trim(),
-        nombres: document.getElementById('nombres').value.trim(),
-        apellidos: document.getElementById('apellidos').value.trim(),
-        correo: document.getElementById('correo').value.trim(),
+        usuario: inputUsuario.value.trim(),
+        nombres: inputNombres.value.trim(),
+        apellidoPrimero: inputPrimerApellido.value.trim(),
+        apellidoSegundo: inputSegundoApellido.value.trim(),
+        correo: inputCorreo.value.trim(),
         esAdminGlobal: esAdmin,
         permisosGenerales: {
-          puedeAgregar: document.getElementById('permAgregar').checked,
-          puedeModificar: document.getElementById('permModificar').checked,
-          puedeEliminar: document.getElementById('permEliminar').checked
+          puedeAgregar: checkPermAgregar.checked,
+          puedeModificar: checkPermModificar.checked,
+          puedeEliminar: checkPermEliminar.checked
         },
         permisos: obtenerPermisosDelFormulario()
       };
 
-      if (!esEdicion || document.getElementById('contrasena').value.trim()) {
-        base.contrasena = document.getElementById('contrasena').value.trim();
+      if (!esEdicion || contrasenaValor !== contrasenaOriginal) {
+        base.contrasena = contrasenaValor;
       }
 
       if (esAdmin) {
@@ -354,8 +388,6 @@
           });
         });
         base.permisosGenerales = { puedeAgregar: true, puedeModificar: true, puedeEliminar: true };
-      } else {
-        base.permisosGenerales = { puedeAgregar: false, puedeModificar: false, puedeEliminar: false };
       }
 
       return base;
@@ -403,31 +435,39 @@
         return;
       }
 
-      if (esEdicion) {
-        document.getElementById('tituloPagina').textContent = 'Editar usuario';
-        indicadorContrasena.textContent = '(opcional)';
-      }
-
-      try {
-        const empresas = await cargarEmpresas();
         if (esEdicion) {
-          const usuario = await cargarUsuario(idEdicion);
-          document.getElementById('usuario').value = usuario.usuario;
-          document.getElementById('nombres').value = usuario.nombres || '';
-          document.getElementById('apellidos').value = usuario.apellidos || '';
-          document.getElementById('correo').value = usuario.correo || '';
-          document.getElementById('esAdminGlobal').checked = usuario.esAdminGlobal;
-          actualizarEstadoPermisosGenerales(usuario.esAdminGlobal);
-          aplicarPermisosAlFormulario(usuario.permisosPorEmpresa);
-        } else {
-          empresas.forEach((empresa) => sincronizarEstadoEmpresa(empresa.id, false));
-          actualizarEstadoPermisosGenerales(false);
+          document.getElementById('tituloPagina').textContent = 'Editar usuario';
+          indicadorContrasena.textContent = '(opcional)';
         }
-      } catch (error) {
+
+        try {
+          const empresas = await cargarEmpresas();
+          if (esEdicion) {
+            const usuario = await cargarUsuario(idEdicion);
+            inputUsuario.value = usuario.usuario;
+            inputNombres.value = usuario.nombres || '';
+            inputPrimerApellido.value = usuario.apellidoPrimero || '';
+            inputSegundoApellido.value = usuario.apellidoSegundo || '';
+            inputCorreo.value = usuario.correo || '';
+            inputContrasena.value = usuario.contrasenaVisible || '';
+            contrasenaOriginal = inputContrasena.value.trim();
+            switchAdminGlobal.checked = usuario.esAdminGlobal;
+            checkPermAgregar.checked = Boolean(usuario.permisosGenerales?.puedeAgregar);
+            checkPermModificar.checked = Boolean(usuario.permisosGenerales?.puedeModificar);
+            checkPermEliminar.checked = Boolean(usuario.permisosGenerales?.puedeEliminar);
+            actualizarEstadoPermisosGenerales(usuario.esAdminGlobal);
+            aplicarPermisosAlFormulario(usuario.permisosPorEmpresa);
+          } else {
+            contrasenaOriginal = '';
+            inputContrasena.value = '';
+            empresas.forEach((empresa) => sincronizarEstadoEmpresa(empresa.id, false));
+            actualizarEstadoPermisosGenerales(false);
+          }
+        } catch (error) {
         mostrarAlerta(error.message || 'Ocurrió un problema al iniciar el formulario.');
       }
 
-      document.getElementById('esAdminGlobal').addEventListener('change', (evento) => {
+        switchAdminGlobal.addEventListener('change', (evento) => {
         const esAdmin = evento.target.checked;
         actualizarEstadoPermisosGenerales(esAdmin);
         contenedorEmpresas.querySelectorAll('.activar-empresa').forEach((switchEmpresa) => {
@@ -458,19 +498,22 @@
         return;
       }
 
-      if (!formulario.usuario.value.trim()) {
-        formulario.usuario.focus();
-        formulario.usuario.classList.add('is-invalid');
-        return;
-      }
+        if (!inputUsuario.value.trim()) {
+          inputUsuario.focus();
+          inputUsuario.classList.add('is-invalid');
+          return;
+        }
 
-      if ((!esEdicion || formulario.contrasena.value.trim()) && formulario.contrasena.value.trim().length < 8) {
-        formulario.contrasena.classList.add('is-invalid');
-        return;
-      }
+        const contrasenaValor = inputContrasena.value.trim();
+        const contrasenaCambiada = contrasenaValor !== contrasenaOriginal;
+        const debeValidarContrasena = !esEdicion || contrasenaCambiada;
+        if (debeValidarContrasena && contrasenaValor.length < 8) {
+          inputContrasena.classList.add('is-invalid');
+          return;
+        }
 
-      formulario.usuario.classList.remove('is-invalid');
-      formulario.contrasena.classList.remove('is-invalid');
+        inputUsuario.classList.remove('is-invalid');
+        inputContrasena.classList.remove('is-invalid');
 
       const payload = recopilarDatos(esEdicion);
 

--- a/vistas/e.html
+++ b/vistas/e.html
@@ -1599,6 +1599,8 @@
       throw new Error('Redireccionando al inicio de sesión.');
     }
 
+    Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
+
     // Script para selección de celdas y zoom
     document.addEventListener('DOMContentLoaded', function() {
       const table = document.getElementById('mainTable');

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -1,6 +1,7 @@
 (() => {
   const STORAGE_KEY = 'sesionUsuario';
   const REDIRECCION_POR_DEFECTO = 'login.html';
+  const ID_ENLACE_ADMIN = 'navAdministrarUsuarios';
 
   const normalizarUsuario = (valor) => {
     return (valor || '').toString().trim().toUpperCase();
@@ -28,11 +29,17 @@
     sessionStorage.removeItem(STORAGE_KEY);
   };
 
-  const esAdmin = (sesion) => {
-    if (!sesion || !sesion.usuario) return false;
-    const usuario = normalizarUsuario(sesion.usuario.usuario);
-    return Boolean(sesion.usuario.esAdminGlobal) || usuario === 'ICONET';
+  const puedeAdministrarUsuarios = (sesion) => {
+    const sesionEvaluada = sesion || obtener();
+    if (!sesionEvaluada || !sesionEvaluada.usuario) return false;
+    const usuario = normalizarUsuario(sesionEvaluada.usuario.usuario);
+    if (usuario === 'ICONET') return true;
+    if (sesionEvaluada.usuario.esAdminGlobal) return true;
+    const generales = sesionEvaluada.usuario.permisosGenerales || {};
+    return Boolean(generales.puedeAgregar && generales.puedeModificar && generales.puedeEliminar);
   };
+
+  const esAdmin = (sesion) => puedeAdministrarUsuarios(sesion);
 
   const requerirSesion = ({ requireAdmin = false, redirectTo = REDIRECCION_POR_DEFECTO } = {}) => {
     const sesion = obtener();
@@ -41,12 +48,29 @@
       return null;
     }
 
-    if (requireAdmin && !esAdmin(sesion)) {
+    if (requireAdmin && !puedeAdministrarUsuarios(sesion)) {
       window.location.href = redirectTo;
       return null;
     }
 
     return sesion;
+  };
+
+  const asegurarEnlaceAdministrarUsuarios = (contenedor) => {
+    if (!contenedor) return;
+    const enlaceExistente = document.getElementById(ID_ENLACE_ADMIN);
+    const visible = puedeAdministrarUsuarios();
+    if (visible) {
+      if (!enlaceExistente) {
+        const elemento = document.createElement('li');
+        elemento.id = ID_ENLACE_ADMIN;
+        elemento.className = 'nav-item';
+        elemento.innerHTML = '<a class="nav-link" href="usuarios.html">Administrar usuarios</a>';
+        contenedor.appendChild(elemento);
+      }
+    } else if (enlaceExistente) {
+      enlaceExistente.remove();
+    }
   };
 
   const headersAutenticacion = () => {
@@ -66,6 +90,8 @@
     limpiar,
     requerirSesion,
     esAdmin,
+    puedeAdministrarUsuarios,
+    asegurarEnlaceAdministrarUsuarios,
     headersAutenticacion
   };
 })();

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -170,11 +170,9 @@
 
         Sesion.guardar(datos);
 
-        const permisosGenerales = datos.usuario?.permisosGenerales || {};
-        const esAdmin = Sesion.esAdmin(datos);
-        const tienePermisoUsuarios = Boolean(permisosGenerales.puedeAgregar || permisosGenerales.puedeModificar || permisosGenerales.puedeEliminar);
+        const puedeAdministrar = Sesion.puedeAdministrarUsuarios(datos);
 
-        if (esAdmin || tienePermisoUsuarios) {
+        if (puedeAdministrar) {
           window.location.href = 'usuarios.html';
         } else {
           window.location.href = 'Vista1.html';

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -210,7 +210,14 @@
 
       const filtrados = usuarios.filter((usuario) => {
         if (!termino) return true;
-        return [usuario.usuario, usuario.nombres, usuario.apellidos, usuario.correo]
+        return [
+          usuario.usuario,
+          usuario.nombres,
+          usuario.apellidoPrimero,
+          usuario.apellidoSegundo,
+          usuario.apellidos,
+          usuario.correo
+        ]
           .filter(Boolean)
           .some((valor) => valor.toLowerCase().includes(termino));
       });
@@ -228,6 +235,10 @@
         const puedeResetearFila = puedeModificar && !usuario.esAdminGlobal;
         const puedeEliminarFila = puedeEliminar && !usuario.esAdminGlobal;
 
+        const nombreCompleto = [usuario.nombres, usuario.apellidoPrimero, usuario.apellidoSegundo]
+          .filter(Boolean)
+          .join(' ');
+
         const enlaceEditar = puedeEditarFila
           ? `<a class="btn btn-sm btn-outline-success" href="crear_usuario.html?editar=${usuario.id}">Editar</a>`
           : `<span class="btn btn-sm btn-outline-success disabled" aria-disabled="true">Editar</span>`;
@@ -236,7 +247,7 @@
         const botonEliminar = `<button class="btn btn-sm btn-outline-danger" data-accion="eliminar" data-id="${usuario.id}" ${puedeEliminarFila ? '' : 'disabled'}>Eliminar</button>`;
 
         fila.innerHTML = `
-          <td data-title="Nombre">${[usuario.nombres, usuario.apellidos].filter(Boolean).join(' ') || '—'}</td>
+          <td data-title="Nombre">${nombreCompleto || '—'}</td>
           <td data-title="Usuario">${usuario.usuario}</td>
           <td data-title="Correo">${usuario.correo || '—'}</td>
           <td data-title="Empresas">${representarEmpresas(usuario.permisosPorEmpresa)}</td>


### PR DESCRIPTION
## Resumen
- Amplía el esquema de usuarios en SQLite para almacenar apellidos por separado, conservar la contraseña visible y validar permisos generales antes de permitir acciones administrativas.
- Ajusta las rutas de autenticación y administración de usuarios para exponer y persistir los nuevos campos, respetando los permisos generales configurables.
- Moderniza la interfaz de gestión de usuarios: formulario con dos apellidos, campo de contraseña con visor, conservación de contraseña en ediciones, y tabla que muestra nombres completos.
- Añade soporte en sesión para detectar administradores con todos los permisos, mostrar el enlace de "Administrar usuarios" solo a ellos y redirigir tras iniciar sesión según sus privilegios.
- Crea un archivo de configuración listo para credenciales de Nodemailer y Brave para la recuperación de contraseñas.

## Pruebas
- No se ejecutaron pruebas (no se proporcionaron scripts).


------
https://chatgpt.com/codex/tasks/task_e_690a202623dc832d8eb1deabbe0bb91a