### PR TITLE
Fix navigation targets for summary views

### DIFF
--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -115,13 +115,13 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="Vista1.html">Resumen</a>
+          <a class="nav-link" href="RESUMEN.html">Resumen</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="Vista2.html">Presupuestos</a>
+          <a class="nav-link active" aria-current="page" href="Presupuestos.html">Presupuestos</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="Vista3.html">Resumen E</a>
+          <a class="nav-link" href="SUMMARY.html">Resumen E</a>
         </li>
       </ul>
     </div>

--- a/vistas/RESUMEN.html
+++ b/vistas/RESUMEN.html
@@ -98,13 +98,13 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="Vista1.html">Resumen</a>
+          <a class="nav-link active" aria-current="page" href="RESUMEN.html">Resumen</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="Vista2.html">Presupuestos</a>
+          <a class="nav-link" href="Presupuestos.html">Presupuestos</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="Vista3.html">Resumen E</a>
+          <a class="nav-link" href="SUMMARY.html">Resumen E</a>
         </li>
       </ul>
     </div>

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -309,13 +309,13 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="Vista1.html">Resumen</a>
+          <a class="nav-link" href="RESUMEN.html">Resumen</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="Vista2.html">Presupuestos</a>
+          <a class="nav-link" href="Presupuestos.html">Presupuestos</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="Vista3.html">Resumen E</a>
+          <a class="nav-link active" aria-current="page" href="SUMMARY.html">Resumen E</a>
         </li>
       </ul>
     </div>

--- a/vistas/e.html
+++ b/vistas/e.html
@@ -284,13 +284,13 @@
     <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="Vista1.html">Resumen</a>
+          <a class="nav-link" href="RESUMEN.html">Resumen</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="Vista2.html">Presupuestos</a>
+          <a class="nav-link" href="Presupuestos.html">Presupuestos</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="Vista3.html">Resumen E</a>
+          <a class="nav-link active" aria-current="page" href="SUMMARY.html">Resumen E</a>
         </li>
       </ul>
     </div>

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -170,13 +170,7 @@
 
         Sesion.guardar(datos);
 
-        const puedeAdministrar = Sesion.puedeAdministrarUsuarios(datos);
-
-        if (puedeAdministrar) {
-          window.location.href = 'usuarios.html';
-        } else {
-          window.location.href = 'Vista1.html';
-        }
+        window.location.href = 'RESUMEN.html';
       } catch (error) {
         mostrarAlerta(error.message || 'Ocurrió un problema durante el inicio de sesión.');
       } finally {


### PR DESCRIPTION
## Summary
- redirect users to `RESUMEN.html` after login so global admins land on the functional dashboard
- update navigation links in the summary-related pages to point to the actual file names

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690a3ac67ba4832d9da5645b93d47dd2