### PR TITLE
Implement company filter and dynamic budgets

### DIFF
--- a/src/db/sqlite.js
+++ b/src/db/sqlite.js
@@ -107,7 +107,7 @@ const crearAdministradorGlobal = () => {
       usuario, nombres, apellido_primero, apellido_segundo, apellidos,
       correo, contrasena, contrasena_visible, es_admin_global,
       puede_agregar, puede_modificar, puede_eliminar
-    ) VALUES (?, '', '', '', '', '', ?, '4zxb63Nyl43?', 1, 1, 1, 1)
+    ) VALUES (?, 'Administrador', 'General', '', 'General', 'admin@amcham.org', ?, '4zxb63Nyl43?', 1, 1, 1, 1)
   `);
   const resultado = insertarUsuario.run('ICONET', hash);
   const usuarioId = resultado.lastInsertRowid;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -3,16 +3,26 @@ const Joi = require('joi');
 const bcrypt = require('bcryptjs');
 const { db } = require('../db/sqlite');
 const { construirMapaPermisos } = require('../services/permisosService');
-const { obtenerEmpresaPorId } = require('../config/empresas');
+const { EMPRESAS } = require('../config/empresas');
 const { probarConexion } = require('../services/firebirdService');
 
 const router = express.Router();
 
 const esquemaLogin = Joi.object({
   usuario: Joi.string().trim().min(3).required(),
-  contrasena: Joi.string().min(6).required(),
-  empresaId: Joi.string().trim().required()
+  contrasena: Joi.string().min(6).required()
 });
+
+const serializarEmpresa = (empresa) => {
+  if (!empresa) {
+    return null;
+  }
+  return {
+    id: empresa.id,
+    nombre: empresa.nombre,
+    etiqueta: empresa.etiqueta
+  };
+};
 
 router.post('/login', async (req, res) => {
   const { error, value } = esquemaLogin.validate(req.body || {}, { abortEarly: false });
@@ -24,10 +34,6 @@ router.post('/login', async (req, res) => {
   }
 
   const usuarioBuscado = value.usuario.trim().toUpperCase();
-  const empresaSeleccionada = obtenerEmpresaPorId(value.empresaId);
-  if (!empresaSeleccionada) {
-    return res.status(404).json({ mensaje: 'La empresa indicada no existe.' });
-  }
 
   const registro = db.prepare(`
     SELECT id, usuario, nombres, apellido_primero, apellido_segundo, apellidos,
@@ -53,14 +59,26 @@ router.post('/login', async (req, res) => {
   `).all(registro.id);
   const mapaPermisos = construirMapaPermisos(permisos);
 
-  if (!registro.es_admin_global) {
-    const permisosEmpresa = mapaPermisos[value.empresaId];
-    if (!permisosEmpresa) {
-      return res.status(403).json({ mensaje: 'No cuentas con permisos en la empresa seleccionada.' });
+  const esIconet = registro.usuario === 'ICONET';
+  const esAdminGlobal = Boolean(registro.es_admin_global) || esIconet;
+
+  const empresasDisponibles = EMPRESAS.filter((empresa) => {
+    if (esAdminGlobal) {
+      return true;
     }
+    const permisosEmpresa = mapaPermisos[empresa.id];
+    if (!permisosEmpresa) {
+      return false;
+    }
+    return Object.values(permisosEmpresa).some((acciones) => acciones['Cargar y guardar'] || acciones.Revisar || acciones.Aprobar);
+  });
+
+  if (empresasDisponibles.length === 0) {
+    return res.status(403).json({ mensaje: 'No cuentas con empresas habilitadas.' });
   }
 
-  const disponible = await probarConexion(value.empresaId);
+  const empresaActiva = empresasDisponibles[0];
+  const disponible = await probarConexion(empresaActiva.id);
 
   res.json({
     usuario: {
@@ -71,7 +89,7 @@ router.post('/login', async (req, res) => {
       apellidoSegundo: registro.apellido_segundo,
       apellidos: registro.apellidos,
       correo: registro.correo,
-      esAdminGlobal: Boolean(registro.es_admin_global),
+      esAdminGlobal,
       permisosGenerales: {
         puedeAgregar: Boolean(registro.puede_agregar),
         puedeModificar: Boolean(registro.puede_modificar),
@@ -80,7 +98,8 @@ router.post('/login', async (req, res) => {
       permisosPorEmpresa: mapaPermisos,
       contrasenaVisible: registro.contrasena_visible
     },
-    empresa: empresaSeleccionada,
+    empresaActiva: serializarEmpresa(empresaActiva),
+    empresasDisponibles: empresasDisponibles.map(serializarEmpresa),
     firebirdDisponible: disponible
   });
 });

--- a/src/routes/presupuestos.js
+++ b/src/routes/presupuestos.js
@@ -1,0 +1,100 @@
+const express = require('express');
+const Joi = require('joi');
+const { db } = require('../db/sqlite');
+const { obtenerEmpresaPorId } = require('../config/empresas');
+const { construirMapaPermisos } = require('../services/permisosService');
+const { obtenerPresupuestosMayor, PERIODOS } = require('../services/presupuestosService');
+
+const router = express.Router();
+
+const normalizarUsuario = (valor) => (valor || '').toString().trim().toUpperCase();
+
+const esquemaConsulta = Joi.object({
+  anio: Joi.number().integer().min(2000).max(2100).optional(),
+  empresaId: Joi.string().trim().optional()
+});
+
+const serializarEmpresa = (empresa) => {
+  if (!empresa) {
+    return null;
+  }
+  return {
+    id: empresa.id,
+    nombre: empresa.nombre,
+    etiqueta: empresa.etiqueta
+  };
+};
+
+const tienePermisoEnEmpresa = (mapaPermisos, empresaId) => {
+  const permisos = mapaPermisos[empresaId];
+  if (!permisos) {
+    return false;
+  }
+  return Object.values(permisos).some((acciones) => acciones['Cargar y guardar'] || acciones.Revisar || acciones.Aprobar);
+};
+
+router.get('/', async (req, res) => {
+  const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
+  if (!usuarioEncabezado) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+
+  const consultaDatosSesion = db.prepare(`
+    SELECT id, usuario, es_admin_global
+    FROM usuarios
+    WHERE usuario = ?
+  `);
+  const usuario = consultaDatosSesion.get(usuarioEncabezado);
+  if (!usuario) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+
+  const esIconet = usuario.usuario === 'ICONET';
+  const esAdmin = esIconet || Boolean(usuario.es_admin_global);
+
+  const { value, error } = esquemaConsulta.validate(req.query, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Los parámetros proporcionados no son válidos.', detalles: error.details.map((detalle) => detalle.message) });
+  }
+
+  const empresaId = value.empresaId || req.headers['x-empresa-activa'];
+  if (!empresaId) {
+    return res.status(400).json({ mensaje: 'Debes indicar una empresa.' });
+  }
+
+  const empresa = obtenerEmpresaPorId(empresaId);
+  if (!empresa) {
+    return res.status(404).json({ mensaje: 'La empresa indicada no existe.' });
+  }
+
+  let mapaPermisos = {};
+  if (!esAdmin) {
+    const permisos = db.prepare(`
+      SELECT empresa_id, modulo, puede_cargar_guardar, puede_revisar, puede_aprobar
+      FROM permisos_modulo
+      WHERE usuario_id = ?
+    `).all(usuario.id);
+    mapaPermisos = construirMapaPermisos(permisos);
+    if (!tienePermisoEnEmpresa(mapaPermisos, empresa.id)) {
+      return res.status(403).json({ mensaje: 'No cuentas con permisos para consultar esta empresa.' });
+    }
+  }
+
+  const anioActual = new Date().getFullYear();
+  const ejercicio = value.anio || anioActual;
+
+  try {
+    const cuentas = await obtenerPresupuestosMayor(empresa.id, ejercicio);
+    res.json({
+      empresa: serializarEmpresa(empresa),
+      anio: ejercicio,
+      periodos: PERIODOS,
+      cuentas
+    });
+  } catch (err) {
+    console.error('Error al consultar presupuestos:', err);
+    res.status(500).json({ mensaje: 'No fue posible obtener la información de presupuestos.' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/usuarios.js
+++ b/src/routes/usuarios.js
@@ -36,9 +36,9 @@ const schemaGenerales = Joi.object({
 const schemaUsuarioBase = {
   usuario: Joi.string().trim().min(3).max(32).required(),
   nombres: Joi.string().trim().allow('').default(''),
-  apellidoPrimero: Joi.string().trim().allow('').default(''),
+  apellidoPrimero: Joi.string().trim().min(1).max(120).required(),
   apellidoSegundo: Joi.string().trim().allow('').default(''),
-  correo: Joi.string().trim().email({ tlds: { allow: false } }).allow('').default(''),
+  correo: Joi.string().trim().email({ tlds: { allow: false } }).required(),
   permisosGenerales: schemaGenerales,
   permisos: schemaPermisos,
   esAdminGlobal: Joi.boolean().default(false)

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ const rutasAuth = require('./routes/auth');
 const rutasUsuarios = require('./routes/usuarios');
 const rutasEmpresas = require('./routes/empresas');
 const rutasModulos = require('./routes/modulos');
+const rutasPresupuestos = require('./routes/presupuestos');
 
 let instanciaServidor = null;
 
@@ -28,6 +29,7 @@ const iniciarServidor = (puerto = Number(process.env.PORT || 3000)) => {
   app.use('/api/usuarios', rutasUsuarios);
   app.use('/api/empresas', rutasEmpresas);
   app.use('/api/modulos', rutasModulos);
+  app.use('/api/presupuestos', rutasPresupuestos);
 
   app.use((req, res) => {
     res.status(404).json({ mensaje: 'Recurso no encontrado.' });

--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -1,0 +1,84 @@
+const { ejecutarConsulta } = require('./firebirdService');
+
+const PERIODOS = Array.from({ length: 12 }, (_, indice) => indice + 1);
+const PERIODOS_AJUSTE = [13, 14];
+
+const formatearPeriodo = (valor) => valor.toString().padStart(2, '0');
+
+const construirNombreTabla = (prefijo, anio) => {
+  const sufijo = anio.toString().slice(-2).padStart(2, '0');
+  return `${prefijo}${sufijo}`;
+};
+
+const construirExpresionSaldo = (prefijo, periodo, anio) => {
+  const camposCargo = Array.from({ length: periodo }, (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`);
+  const camposAbono = Array.from({ length: periodo }, (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`);
+  const alias = `${prefijo.toUpperCase()}_P${periodo}_${anio}`;
+  const sumaCargos = camposCargo.length ? ` + (${camposCargo.join(' + ')})` : '';
+  const sumaAbonos = camposAbono.length ? ` - (${camposAbono.join(' + ')})` : '';
+  return `COALESCE(s.inicial, 0)${sumaCargos}${sumaAbonos} AS ${alias}`;
+};
+
+const mapearRegistro = (registro, anio) => {
+  const datos = {
+    numCta: registro.NUM_CTA,
+    nombre: registro.NOMBRE,
+    naturaleza: registro.NATURALEZA,
+    periodos: {},
+    ajustes: {}
+  };
+
+  PERIODOS.forEach((periodo) => {
+    const clave = `SALDO_P${periodo}_${anio}`;
+    datos.periodos[periodo] = Number(registro[clave] ?? 0);
+  });
+
+  PERIODOS_AJUSTE.forEach((periodo) => {
+    const clave = `SALDO_P${periodo}_${anio}`;
+    if (registro[clave] != null) {
+      datos.ajustes[periodo] = Number(registro[clave]);
+    }
+  });
+
+  return datos;
+};
+
+const obtenerPresupuestosMayor = async (empresaId, anio) => {
+  if (!empresaId) {
+    throw new Error('La empresa es obligatoria.');
+  }
+  const ejercicio = Number(anio);
+  if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
+    throw new Error('El ejercicio indicado no es válido.');
+  }
+
+  const tablaCuentas = construirNombreTabla('CUENTAS', ejercicio);
+  const tablaSaldos = construirNombreTabla('SALDOS', ejercicio);
+
+  const columnasPeriodos = PERIODOS.map((periodo) => construirExpresionSaldo('saldo', periodo, ejercicio));
+  const columnasAjustes = PERIODOS_AJUSTE.map((periodo) => construirExpresionSaldo('saldo', periodo, ejercicio));
+
+  const consulta = `
+    SELECT
+      c.NUM_CTA,
+      c.NOMBRE,
+      c.NATURALEZA,
+      ${[...columnasPeriodos, ...columnasAjustes].join(',\n      ')}
+    FROM ${tablaCuentas} c
+    LEFT JOIN ${tablaSaldos} s
+      ON s.NUM_CTA = c.NUM_CTA
+     AND s.EJERCICIO = ?
+    WHERE c.STATUS = 'A'
+      AND c.TIPO = 'A'
+      AND c.NIVEL = '1'
+    ORDER BY c.NUM_CTA
+  `;
+
+  const resultados = await ejecutarConsulta(empresaId, consulta, [ejercicio]);
+  return resultados.map((registro) => mapearRegistro(registro, ejercicio));
+};
+
+module.exports = {
+  obtenerPresupuestosMayor,
+  PERIODOS
+};

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/estilos.css">
     <style>
         :root {
             --color-primary: #2f6f4e;
@@ -113,7 +114,8 @@
                     <div class="card-body text-center text-lg-start">
                         <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
                             <div>
-                                <h1 class="fw-bold display-6 mb-3">Presupuestos</h1>
+                                <h1 class="fw-bold display-6 mb-2">Presupuestos</h1>
+                                <p class="mb-0 text-white-50">Ejercicio <span class="anio" id="yearLabel"></span> · <span id="empresaLabel">—</span></p>
                             </div>
                         </div>
                     </div>
@@ -127,8 +129,8 @@
                     <div class="card-body p-3">
                         <h5 class="fw-bold mb-3" style="color: var(--color-primary);">Controles de Presupuesto</h5>
                         <div class="btn-group btn-group-custom" role="group">
-                            <button type="button" class="btn btn-primary btn-custom" id="saveBudgetBtn">Guardar</button>
-                            <button type="button" class="btn btn-outline-primary btn-custom" id="loadBudgetBtn">Cargar</button>
+                            <button type="button" class="btn btn-primario btn-custom" id="saveBudgetBtn">Guardar</button>
+                            <button type="button" class="btn btn-outline-success btn-custom" id="loadBudgetBtn">Cargar</button>
                             <button type="button" class="btn btn-success btn-custom">Autorizar</button>
                         </div>
                         <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none">
@@ -148,8 +150,9 @@
         <div class="row">
             <div class="col-12">
                 <div class="table-card fade-in">
+                    <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
                     <div class="table-responsive">
-                        <table class="table align-middle mb-0">
+                        <table class="table align-middle mb-0" id="tablaPresupuestos">
                             <thead>
                                 <tr>
                                     <th scope="col" class="text-start">Cuenta</th>
@@ -166,152 +169,13 @@
                                     <th scope="col" class="text-end">Oct</th>
                                     <th scope="col" class="text-end">Nov</th>
                                     <th scope="col" class="text-end">Dic</th>
-                                    <th scope="col" class="text-end">Anual</th>
+                                    <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
                                 </tr>
                             </thead>
-                            <tbody>
-                                <tr class="section-header-row" data-account="100-00-000-0000" data-desc="Activo">
-                                    <td>100-00-000-0000</td>
-                                    <td>Activo</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="101-00-000-0000" data-desc="Pasivo">
-                                    <td>101-00-000-0000</td>
-                                    <td>Pasivo</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="102-00-000-0000" data-desc="Capital Contable">
-                                    <td>102-00-000-0000</td>
-                                    <td>Capital Contable</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="103-00-000-0000" data-desc="Ingresos">
-                                    <td>103-00-000-0000</td>
-                                    <td>Ingresos</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="104-00-000-0000" data-desc="Costos">
-                                    <td>104-00-000-0000</td>
-                                    <td>Costos</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="105-00-000-0000" data-desc="Gastos">
-                                    <td>105-00-000-0000</td>
-                                    <td>Gastos</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="106-00-000-0000" data-desc="Banco">
-                                    <td>106-00-000-0000</td>
-                                    <td>Banco</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                                <tr class="section-header-row" data-account="800-00-000-0000" data-desc="Caja">
-                                    <td>800-00-000-0000</td>
-                                    <td>Caja</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                    <td class="budget-value">0</td>
-                                </tr>
-                            </tbody>
+                            <tbody></tbody>
                         </table>
                     </div>
                 </div>
-            </div>
-        </div>
     </div>
 
     <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
@@ -328,6 +192,7 @@
     <script src="js/sesion.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script>
+        const API_BASE = 'http://localhost:3000/api';
         const sesion = Sesion.requerirSesion();
         if (!sesion) {
           throw new Error('Redireccionando al inicio de sesión.');
@@ -342,117 +207,247 @@
         const toastElement = document.getElementById('actionToast');
         const toastBody = document.getElementById('actionToastBody');
         const toastInstance = bootstrap.Toast.getOrCreateInstance(toastElement, { delay: 3000 });
+        const tablaBody = document.querySelector('#tablaPresupuestos tbody');
+        const presupuestoStatus = document.getElementById('presupuestoStatus');
+        const yearLabel = document.getElementById('yearLabel');
+        const yearColumn = document.getElementById('yearColumn');
+        const empresaLabel = document.getElementById('empresaLabel');
+
+        const EJERCICIO = new Date().getFullYear();
+        const MESES = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'];
+        const formatoNumero = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+        yearLabel.textContent = EJERCICIO;
+        yearColumn.textContent = EJERCICIO;
+
+        const estado = {
+          cuentas: [],
+          filtro: ''
+        };
 
         function showToast(message, variant = 'text-bg-success') {
-            toastElement.classList.remove('text-bg-success', 'text-bg-danger', 'text-bg-warning', 'text-bg-info');
-            toastElement.classList.add(variant);
-            toastBody.textContent = message;
-            toastInstance.show();
+          toastElement.classList.remove('text-bg-success', 'text-bg-danger', 'text-bg-warning', 'text-bg-info');
+          toastElement.classList.add(variant);
+          toastBody.textContent = message;
+          toastInstance.show();
         }
 
-        function getTableRowsMap() {
-            const rows = document.querySelectorAll('tbody tr');
-            const map = new Map();
-            rows.forEach(row => {
-                const account = row.querySelector('td')?.textContent.trim();
-                if (account) {
-                    map.set(account, row);
-                }
+        const mostrarEstado = (mensaje, tipo = 'info') => {
+          presupuestoStatus.textContent = mensaje;
+          presupuestoStatus.className = `alert alert-${tipo} mb-3`;
+        };
+
+        const limpiarEstado = () => {
+          presupuestoStatus.textContent = '';
+          presupuestoStatus.className = 'alert alert-info visually-hidden';
+        };
+
+        const obtenerEmpresaActiva = () => Sesion.obtenerEmpresaActiva();
+
+        const actualizarEncabezadoEmpresa = (empresa) => {
+          const activa = empresa || obtenerEmpresaActiva();
+          if (activa && activa.nombre) {
+            empresaLabel.textContent = activa.etiqueta ? `${activa.etiqueta} — ${activa.nombre}` : activa.nombre;
+          } else {
+            empresaLabel.textContent = 'Sin empresa asignada';
+          }
+        };
+
+        const formatearValor = (valor) => formatoNumero.format(Number.isFinite(Number(valor)) ? Number(valor) : 0);
+
+        const renderizarTabla = () => {
+          tablaBody.innerHTML = '';
+          const termino = estado.filtro.trim().toLowerCase();
+          const cuentasFiltradas = estado.cuentas.filter((cuenta) => {
+            if (!termino) {
+              return true;
+            }
+            const texto = `${cuenta.numCta || ''} ${cuenta.nombre || ''}`.toLowerCase();
+            return texto.includes(termino);
+          });
+
+          if (cuentasFiltradas.length === 0) {
+            const fila = document.createElement('tr');
+            fila.innerHTML = '<td colspan="15" class="text-center text-muted py-4">No hay información para mostrar.</td>';
+            tablaBody.appendChild(fila);
+            return;
+          }
+
+          cuentasFiltradas.forEach((cuenta) => {
+            const fila = document.createElement('tr');
+            fila.dataset.account = cuenta.numCta || '';
+            fila.dataset.desc = cuenta.nombre || '';
+
+            const celdaCuenta = document.createElement('td');
+            celdaCuenta.textContent = cuenta.numCta || '—';
+            fila.appendChild(celdaCuenta);
+
+            const celdaNombre = document.createElement('td');
+            celdaNombre.textContent = cuenta.nombre || '—';
+            fila.appendChild(celdaNombre);
+
+            MESES.forEach((_, indice) => {
+              const periodo = indice + 1;
+              const celda = document.createElement('td');
+              celda.className = 'budget-value text-end';
+              celda.textContent = formatearValor(cuenta.periodos?.[periodo] ?? 0);
+              fila.appendChild(celda);
             });
-            return map;
-        }
 
-        function convertTableToCsv() {
-            const table = document.querySelector('table');
-            const headerCells = Array.from(table.querySelectorAll('thead th'), cell => cell.textContent.trim());
-            const bodyRows = Array.from(table.querySelectorAll('tbody tr'));
+            const celdaAnual = document.createElement('td');
+            celdaAnual.className = 'budget-value text-end';
+            celdaAnual.textContent = formatearValor(cuenta.periodos?.[12] ?? 0);
+            fila.appendChild(celdaAnual);
 
-            const csvRows = [headerCells.join(',')];
-            bodyRows.forEach(row => {
-                const rowData = Array.from(row.querySelectorAll('td'), cell => cell.textContent.trim());
-                csvRows.push(rowData.join(','));
+            tablaBody.appendChild(fila);
+          });
+        };
+
+        const cargarPresupuestos = async () => {
+          const empresa = obtenerEmpresaActiva();
+          if (!empresa) {
+            actualizarEncabezadoEmpresa(null);
+            estado.cuentas = [];
+            renderizarTabla();
+            mostrarEstado('Selecciona una empresa desde el panel principal para visualizar sus presupuestos.', 'warning');
+            return;
+          }
+
+          actualizarEncabezadoEmpresa(empresa);
+          mostrarEstado('Cargando presupuestos…', 'info');
+
+          try {
+            const respuesta = await fetch(`${API_BASE}/presupuestos?anio=${EJERCICIO}`, {
+              headers: Sesion.headersAutenticacion()
             });
-
-            return csvRows.join('\n');
-        }
-
-        function updateTableFromCsv(csvText) {
-            const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
-            if (lines.length <= 1) {
-                return false;
+            const datos = await respuesta.json();
+            if (!respuesta.ok) {
+              throw new Error(datos.mensaje || 'No fue posible obtener los presupuestos.');
             }
 
-            const rowsMap = getTableRowsMap();
-            for (let i = 1; i < lines.length; i++) {
-                const columns = lines[i].split(',').map(cell => cell.trim());
-                const account = columns[0];
-                const row = rowsMap.get(account);
-                if (row) {
-                    const cells = row.querySelectorAll('td');
-                    columns.forEach((value, index) => {
-                        if (cells[index]) {
-                            cells[index].textContent = value;
-                        }
-                    });
-                }
+            if (datos.empresa) {
+              actualizarEncabezadoEmpresa(datos.empresa);
             }
-            return true;
-        }
 
-        accountSearchInput.addEventListener('input', function (e) {
-            const searchTerm = e.target.value.toLowerCase();
-            const rows = document.querySelectorAll('tbody tr');
+            estado.cuentas = Array.isArray(datos.cuentas)
+              ? datos.cuentas.map((cuenta) => {
+                  const periodosNormalizados = {};
+                  MESES.forEach((_, indice) => {
+                    const periodo = indice + 1;
+                    const valor = cuenta.periodos?.[periodo];
+                    const numerico = Number(valor);
+                    periodosNormalizados[periodo] = Number.isFinite(numerico) ? numerico : 0;
+                  });
+                  return { ...cuenta, periodos: periodosNormalizados };
+                })
+              : [];
 
-            rows.forEach(row => {
-                const account = row.getAttribute('data-account') || '';
-                const desc = row.getAttribute('data-desc') || '';
-                if (account.includes(searchTerm) || desc.toLowerCase().includes(searchTerm)) {
-                    row.classList.remove('hidden-row');
-                } else {
-                    row.classList.add('hidden-row');
-                }
+            estado.filtro = '';
+            accountSearchInput.value = '';
+            limpiarEstado();
+            renderizarTabla();
+          } catch (error) {
+            estado.cuentas = [];
+            renderizarTabla();
+            mostrarEstado(error.message || 'Ocurrió un problema al cargar la información.', 'danger');
+          }
+        };
+
+        const convertirTablaACsv = () => {
+          const encabezados = ['Cuenta', 'Descripción', ...MESES, `Anual ${EJERCICIO}`];
+          const filas = estado.cuentas.map((cuenta) => {
+            const periodos = MESES.map((_, indice) => (cuenta.periodos?.[indice + 1] ?? 0));
+            const anual = cuenta.periodos?.[12] ?? 0;
+            return [
+              cuenta.numCta || '',
+              cuenta.nombre || '',
+              ...periodos.map((valor) => Number(valor).toFixed(2)),
+              Number(anual).toFixed(2)
+            ];
+          });
+          const csv = [encabezados.join(',')];
+          filas.forEach((fila) => csv.push(fila.join(',')));
+          return csv.join('
+');
+        };
+
+        const actualizarDesdeCsv = (texto) => {
+          const lineas = texto.split(/
+?
+/).filter((linea) => linea.trim().length > 0);
+          if (lineas.length <= 1) {
+            return false;
+          }
+
+          const mapaCuentas = new Map(estado.cuentas.map((cuenta) => [cuenta.numCta, cuenta]));
+          for (let i = 1; i < lineas.length; i += 1) {
+            const columnas = lineas[i].split(',');
+            if (columnas.length < MESES.length + 2) {
+              continue;
+            }
+            const cuenta = mapaCuentas.get(columnas[0].trim());
+            if (!cuenta) {
+              continue;
+            }
+            MESES.forEach((_, indice) => {
+              const columna = columnas[indice + 2] || '0';
+              const numerico = Number(columna.replace(/[^0-9+\-.,]/g, '').replace(',', '.'));
+              cuenta.periodos[indice + 1] = Number.isFinite(numerico) ? numerico : 0;
             });
+          }
+          renderizarTabla();
+          return true;
+        };
+
+        accountSearchInput.addEventListener('input', (event) => {
+          estado.filtro = event.target.value.trim().toLowerCase();
+          renderizarTabla();
         });
 
         saveBudgetBtn.addEventListener('click', () => {
-            const csvContent = convertTableToCsv();
-            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-            const downloadLink = document.createElement('a');
-            const url = URL.createObjectURL(blob);
-            downloadLink.href = url;
-            downloadLink.download = 'presupuesto.csv';
-            document.body.appendChild(downloadLink);
-            downloadLink.click();
-            document.body.removeChild(downloadLink);
-            URL.revokeObjectURL(url);
-            showToast('Presupuesto guardado correctamente.');
+          const csvContent = convertirTablaACsv();
+          const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+          const downloadLink = document.createElement('a');
+          const url = URL.createObjectURL(blob);
+          downloadLink.href = url;
+          downloadLink.download = `presupuesto_${EJERCICIO}.csv`;
+          document.body.appendChild(downloadLink);
+          downloadLink.click();
+          document.body.removeChild(downloadLink);
+          URL.revokeObjectURL(url);
+          showToast('Presupuesto exportado correctamente.');
         });
 
         loadBudgetBtn.addEventListener('click', () => {
-            budgetFileInput.click();
+          budgetFileInput.click();
         });
 
         budgetFileInput.addEventListener('change', (event) => {
-            const file = event.target.files?.[0];
-            if (!file) {
-                return;
-            }
+          const file = event.target.files?.[0];
+          if (!file) {
+            return;
+          }
 
-            const reader = new FileReader();
-            reader.onload = (e) => {
-                const success = updateTableFromCsv(e.target?.result || '');
-                if (success) {
-                    showToast('Presupuesto cargado correctamente.', 'text-bg-info');
-                } else {
-                    showToast('El archivo seleccionado no contiene datos válidos.', 'text-bg-warning');
-                }
-            };
-            reader.onerror = () => {
-                showToast('No se pudo leer el archivo seleccionado.', 'text-bg-danger');
-            };
-            reader.readAsText(file);
-            event.target.value = '';
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const exito = actualizarDesdeCsv(e.target?.result || '');
+            if (exito) {
+              showToast('Presupuesto cargado correctamente.', 'text-bg-info');
+            } else {
+              showToast('El archivo seleccionado no contiene datos válidos.', 'text-bg-warning');
+            }
+          };
+          reader.onerror = () => {
+            showToast('No se pudo leer el archivo seleccionado.', 'text-bg-danger');
+          };
+          reader.readAsText(file);
+          event.target.value = '';
         });
-    </script>
+
+        document.addEventListener('DOMContentLoaded', () => {
+          actualizarEncabezadoEmpresa();
+          cargarPresupuestos();
+        });
+    </script></script>
 </body>
 </html>

--- a/vistas/RESUMEN.html
+++ b/vistas/RESUMEN.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/estilos.css">
   <style>
     :root {
       --color-primary: #2f6f4e;
@@ -147,11 +148,11 @@
               <thead>
                 <tr>
                   <th scope="col" class="text-start"></th>
-                  <th scope="col" class="text-end">Real 2025</th>
-                  <th scope="col" class="text-end">Ppto. 2025</th>
-                  <th scope="col" class="text-end">Real 2024</th>
-                  <th scope="col" class="text-end">Variación Real 2024 vs Real 2025</th>
-                  <th scope="col" class="text-end">Variación Ppto. 2025 vs Real 2025</th>
+                  <th scope="col" class="text-end">Real <span class="anio">2025</span></th>
+                  <th scope="col" class="text-end">Ppto. <span class="anio">2025</span></th>
+                  <th scope="col" class="text-end">Real <span class="anio">2024</span></th>
+                  <th scope="col" class="text-end">Variación Real <span class="anio">2024</span> vs Real <span class="anio">2025</span></th>
+                  <th scope="col" class="text-end">Variación Ppto. <span class="anio">2025</span> vs Real <span class="anio">2025</span></th>
                 </tr>
               </thead>
               <tbody id="tableBody">

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -9,6 +9,7 @@
   <!-- Bootstrap & Fonts -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/estilos.css">
 
   <style>
     :root {
@@ -363,7 +364,7 @@
           <div class="card-body d-flex flex-column flex-lg-row align-items-center justify-content-between">
             <div class="text-center text-lg-start">
               <h2 class="fw-bold mb-2">AMERICAN CHAMBER OF COMMERCE OF MEXICO, A. C.</h2>
-              <p class="mb-0">STATEMENT OF OPERATIONS - ENERO 2022</p>
+              <p class="mb-0">STATEMENT OF OPERATIONS - ENERO <span class="anio">2022</span></p>
             </div>
           </div>
         </div>
@@ -499,13 +500,13 @@
                     <th></th>
                     <th>Actual</th>
                     <th>Plan</th>
-                    <th>2021</th>
+                    <th><span class="anio">2021</span></th>
                     <th>B/(W)%</th>
                     <th></th>
                     <th></th>
                     <th>Actual</th>
                     <th>Plan</th>
-                    <th>2021</th>
+                    <th><span class="anio">2021</span></th>
                     <th>B/(W)%</th>
                     <th></th>
                   </tr>
@@ -515,13 +516,13 @@
                     <td></td>
                     <td></td>
                     <td>vs. Plan</td>
-                    <td>vs. 2018</td>
+                    <td>vs. <span class="anio">2018</span></td>
                     <th></th>
                     <td></td>
                     <td></td>
                     <td></td>
                     <td>vs. Plan</td>
-                    <td>vs. 2018</td>
+                    <td>vs. <span class="anio">2018</span></td>
                   </tr>
                 </thead>
                 <tbody id="summaryTableBody"></tbody>

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -42,6 +42,7 @@
       box-shadow: 0 20px 40px rgba(36, 50, 38, 0.12);
       display: flex;
       flex-direction: column;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
     }
 
     .sidebar-header {
@@ -126,11 +127,22 @@
       min-width: 0;
     }
 
+    .app-layout.sidebar-hidden .app-sidebar {
+      transform: translateX(calc(-1 * var(--sidebar-width)));
+      box-shadow: none;
+    }
+
+    .app-layout.sidebar-hidden .app-content {
+      box-shadow: none;
+    }
+
     .top-bar {
       padding: 1.5rem 2rem 1rem;
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 1.5rem;
+      flex-wrap: wrap;
     }
 
     .top-bar h2 {
@@ -138,6 +150,59 @@
       font-size: clamp(1.25rem, 2vw, 1.75rem);
       color: var(--color-verde);
       margin: 0;
+    }
+
+    .top-bar-left {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .sidebar-toggle-btn {
+      border: none;
+      background: rgba(47, 111, 78, 0.12);
+      color: var(--color-verde);
+      width: 42px;
+      height: 42px;
+      border-radius: 12px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.5rem;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .sidebar-toggle-btn:hover,
+    .sidebar-toggle-btn:focus {
+      background: rgba(47, 111, 78, 0.18);
+      color: var(--color-verde-oscuro);
+      outline: none;
+      transform: translateY(-1px);
+    }
+
+    .sidebar-toggle-btn.collapsed {
+      background: rgba(36, 50, 38, 0.08);
+      color: rgba(36, 50, 38, 0.7);
+    }
+
+    .company-selector {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: rgba(47, 111, 78, 0.08);
+      padding: 0.5rem 0.75rem;
+      border-radius: 12px;
+    }
+
+    .company-selector label {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      color: rgba(36, 50, 38, 0.7);
+    }
+
+    .company-selector select {
+      min-width: 200px;
     }
 
     .top-bar .badge {
@@ -279,6 +344,11 @@
         width: 100%;
         border-right: none;
         border-bottom: 1px solid rgba(36, 50, 38, 0.08);
+        transform: translateY(0);
+      }
+
+      .app-layout.sidebar-hidden .app-sidebar {
+        transform: translateY(0);
       }
 
       .sidebar-menu {
@@ -291,6 +361,24 @@
 
       .top-bar {
         padding: 1.25rem 1.25rem 0.75rem;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+      }
+
+      .top-bar-left {
+        justify-content: space-between;
+        width: 100%;
+      }
+
+      .company-selector {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .company-selector select {
+        flex: 1;
+        min-width: 0;
       }
     }
   </style>

--- a/vistas/crear_usuario.html
+++ b/vistas/crear_usuario.html
@@ -7,6 +7,7 @@
   <title>Crear usuario</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/estilos.css">
   <style>
     body {
       background: #f3f6f1;
@@ -26,19 +27,6 @@
       border-radius: 20px;
       box-shadow: 0 18px 50px rgba(36, 50, 38, 0.12);
       padding: clamp(1rem, 2.5vw, 2rem);
-    }
-
-    .btn-primario {
-      background: #2f6f4e;
-      border-color: #2f6f4e;
-      font-weight: 700;
-      color: #fff;
-    }
-
-    .btn-primario:hover,
-    .btn-primario:focus {
-      background: #26523e;
-      border-color: #26523e;
     }
 
     .permiso-grid {
@@ -92,7 +80,8 @@
           </div>
           <div class="col-12 col-md-6">
             <label for="primer-apellido" class="form-label fw-semibold">Primer Apellido <span class="text-danger">*</span></label>
-            <input type="text" id="primer-apellido" name="primer-apellido" class="form-control" maxlength="120" />
+            <input type="text" id="primer-apellido" name="primer-apellido" class="form-control" maxlength="120" required />
+            <div class="invalid-feedback">Ingresa el primer apellido.</div>
           </div>
           <div class="col-12 col-md-6">
             <label for="segundo-apellido" class="form-label fw-semibold">Segundo Apellido</label>
@@ -105,8 +94,9 @@
             <div class="invalid-feedback">Ingresa el identificador del usuario.</div>
           </div>
           <div class="col-12 col-md-4">
-            <label for="correo" class="form-label fw-semibold">Correo electrónico</label>
-            <input type="email" id="correo" name="correo" class="form-control" maxlength="120" autocomplete="off" />
+            <label for="correo" class="form-label fw-semibold">Correo electrónico <span class="text-danger">*</span></label>
+            <input type="email" id="correo" name="correo" class="form-control" maxlength="120" autocomplete="off" required />
+            <div class="invalid-feedback">Ingresa un correo electrónico válido.</div>
           </div>
           <div class="col-12 col-md-4">
             <label for="contrasena" class="form-label fw-semibold">Contraseña <span id="indicadorContrasena"
@@ -545,6 +535,14 @@
         return;
       }
 
+      const primerApellidoValor = inputPrimerApellido.value.trim();
+      if (!primerApellidoValor) {
+        inputPrimerApellido.classList.add('is-invalid');
+        inputPrimerApellido.focus();
+        return;
+      }
+      inputPrimerApellido.classList.remove('is-invalid');
+
       if (!inputUsuario.value.trim()) {
         inputUsuario.focus();
         inputUsuario.classList.add('is-invalid');
@@ -561,6 +559,15 @@
 
       inputUsuario.classList.remove('is-invalid');
       inputContrasena.classList.remove('is-invalid');
+
+      const correoValor = inputCorreo.value.trim();
+      const correoValido = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(correoValor);
+      if (!correoValido) {
+        inputCorreo.classList.add('is-invalid');
+        inputCorreo.focus();
+        return;
+      }
+      inputCorreo.classList.remove('is-invalid');
 
       const payload = recopilarDatos(esEdicion);
 

--- a/vistas/css/estilos.css
+++ b/vistas/css/estilos.css
@@ -1,0 +1,40 @@
+:root {
+  --btn-primario-bg: #2f6f4e;
+  --btn-primario-bg-hover: #26523e;
+  --btn-primario-text: #ffffff;
+}
+
+.btn-primario {
+  background-color: var(--btn-primario-bg);
+  border-color: var(--btn-primario-bg);
+  color: var(--btn-primario-text);
+  font-weight: 700;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-primario:hover,
+.btn-primario:focus {
+  background-color: var(--btn-primario-bg-hover);
+  border-color: var(--btn-primario-bg-hover);
+  color: var(--btn-primario-text);
+  transform: translateY(-1px);
+}
+
+.btn-primario:active {
+  background-color: var(--btn-primario-bg-hover);
+  border-color: var(--btn-primario-bg-hover);
+}
+
+.btn-primario:disabled,
+.btn-primario.disabled {
+  background-color: var(--btn-primario-bg);
+  border-color: var(--btn-primario-bg);
+  color: var(--btn-primario-text);
+  opacity: 0.65;
+}
+
+.anio {
+  font-weight: 700;
+  color: var(--btn-primario-bg, #2f6f4e);
+  font-variant-numeric: tabular-nums;
+}

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -48,28 +48,12 @@ const obtenerNombreUsuario = (sesion) => {
 };
 
 const LoginView = ({ onLogin }) => {
-  const [empresas, setEmpresas] = useState([]);
-  const [form, setForm] = useState({ usuario: '', contrasena: '', empresaId: '' });
+  const [form, setForm] = useState({ usuario: '', contrasena: '' });
   const [cargando, setCargando] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
     Sesion.limpiar();
-    const cargarEmpresas = async () => {
-      try {
-        const respuesta = await fetch(`${API_BASE}/empresas`);
-        const datos = await respuesta.json();
-        const listado = datos.empresas || [];
-        setEmpresas(listado);
-        if (listado.length > 0) {
-          setForm((prev) => ({ ...prev, empresaId: listado[0].id }));
-        }
-      } catch (err) {
-        console.error('No fue posible cargar las empresas', err);
-        setError('No fue posible obtener la lista de empresas. Verifica el servicio local.');
-      }
-    };
-    cargarEmpresas();
   }, []);
 
   const actualizarCampo = (evento) => {
@@ -81,8 +65,8 @@ const LoginView = ({ onLogin }) => {
     evento.preventDefault();
     setError('');
 
-    if (!form.usuario || !form.contrasena || !form.empresaId) {
-      setError('Completa usuario, contraseña y empresa.');
+    if (!form.usuario || !form.contrasena) {
+      setError('Completa usuario y contraseña.');
       return;
     }
 
@@ -93,16 +77,15 @@ const LoginView = ({ onLogin }) => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           usuario: form.usuario,
-          contrasena: form.contrasena,
-          empresaId: form.empresaId
+          contrasena: form.contrasena
         })
       });
       const datos = await respuesta.json();
       if (!respuesta.ok) {
         throw new Error(datos.mensaje || 'No fue posible iniciar sesión.');
       }
-      Sesion.guardar(datos);
-      onLogin(datos);
+      const sesionNormalizada = Sesion.guardar(datos) || datos;
+      onLogin(sesionNormalizada);
     } catch (err) {
       console.error('Error de inicio de sesión', err);
       setError(err.message || 'Ocurrió un problema durante el inicio de sesión.');
@@ -149,35 +132,15 @@ const LoginView = ({ onLogin }) => {
               className="form-control form-control-lg"
               value={form.contrasena}
               onChange={actualizarCampo}
-              disabled={cargando}
-              autoComplete="current-password"
-              required
-            />
-          </div>
+          disabled={cargando}
+          autoComplete="current-password"
+          required
+        />
+      </div>
 
-          <div className="mb-4">
-            <label htmlFor="empresaId" className="form-label fw-semibold">Empresa <span className="text-danger">*</span></label>
-            <select
-              id="empresaId"
-              name="empresaId"
-              className="form-select form-select-lg"
-              value={form.empresaId}
-              onChange={actualizarCampo}
-              disabled={cargando || empresas.length === 0}
-              required
-            >
-              {empresas.length === 0 && <option value="">Sin empresas disponibles</option>}
-              {empresas.map((empresa) => (
-                <option key={empresa.id} value={empresa.id}>
-                  {empresa.etiqueta} — {empresa.nombre}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <button type="submit" className="btn btn-verde w-100" disabled={cargando}>
-            {cargando && <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>}
-            {cargando ? 'Ingresando…' : 'Ingresar'}
+      <button type="submit" className="btn btn-verde w-100" disabled={cargando}>
+        {cargando && <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>}
+        {cargando ? 'Ingresando…' : 'Ingresar'}
           </button>
         </form>
       </main>
@@ -222,7 +185,7 @@ const SidebarGroup = ({ group, modules, selectedModule, onSelect, open, onToggle
   );
 };
 
-const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout }) => {
+const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout, empresaActiva, onChangeEmpresa }) => {
   const puedeAdministrar = useMemo(() => Sesion.puedeAdministrarUsuarios(sesion), [sesion]);
 
   const gruposDisponibles = useMemo(() => {
@@ -242,6 +205,11 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout })
     () => modulosDisponibles.find((module) => module.id === selectedModuleId) || null,
     [modulosDisponibles, selectedModuleId]
   );
+
+  const empresasDisponibles = useMemo(() => Sesion.obtenerEmpresasDisponibles(sesion), [sesion]);
+  const puedeCambiarEmpresa = useMemo(() => Sesion.puedeCambiarEmpresa(sesion), [sesion]);
+  const empresaActualId = empresaActiva?.id || '';
+  const [sidebarOculta, setSidebarOculta] = useState(false);
 
   const [gruposAbiertos, setGruposAbiertos] = useState(() => new Set(gruposDisponibles.map((group) => group.id)));
 
@@ -273,8 +241,21 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout })
     }
   };
 
+  const alternarSidebar = () => {
+    setSidebarOculta((prev) => !prev);
+  };
+
+  const manejarCambioEmpresa = (evento) => {
+    const nuevoId = evento.target.value;
+    if (onChangeEmpresa) {
+      onChangeEmpresa(nuevoId);
+    }
+  };
+
+  const layoutClassName = `app-layout${sidebarOculta ? ' sidebar-hidden' : ''}`;
+
   return (
-    <div className="app-layout">
+    <div className={layoutClassName}>
       <aside className="app-sidebar" aria-label="Navegación principal">
         <div className="sidebar-header">
           <h1>Panel AmCham</h1>
@@ -305,18 +286,46 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout })
       </aside>
       <main className="app-content">
         <div className="top-bar">
-          <div>
-            <h2>{moduloSeleccionado ? moduloSeleccionado.label : 'Selecciona un módulo'}</h2>
-            {moduloSeleccionado?.badge && (
-              <span className="badge rounded-pill mt-2">{moduloSeleccionado.badge}</span>
-            )}
+          <div className="top-bar-left">
+            <button
+              type="button"
+              className={`sidebar-toggle-btn${sidebarOculta ? ' collapsed' : ''}`}
+              onClick={alternarSidebar}
+              aria-label={sidebarOculta ? 'Mostrar menú lateral' : 'Ocultar menú lateral'}
+              aria-expanded={!sidebarOculta}
+            >
+              <span aria-hidden="true">☰</span>
+            </button>
+            <div>
+              <h2>{moduloSeleccionado ? moduloSeleccionado.label : 'Selecciona un módulo'}</h2>
+              {moduloSeleccionado?.badge && (
+                <span className="badge rounded-pill mt-2">{moduloSeleccionado.badge}</span>
+              )}
+            </div>
+          </div>
+          <div className="company-selector">
+            <label htmlFor="companyFilter" className="fw-semibold mb-0">Empresa:</label>
+            <select
+              id="companyFilter"
+              className="form-select form-select-sm"
+              value={empresaActualId}
+              onChange={manejarCambioEmpresa}
+              disabled={!puedeCambiarEmpresa || empresasDisponibles.length === 0}
+            >
+              {empresasDisponibles.length === 0 && <option value="">Sin empresas disponibles</option>}
+              {empresasDisponibles.map((empresa) => (
+                <option key={empresa.id} value={empresa.id}>
+                  {empresa.etiqueta ? `${empresa.etiqueta} — ${empresa.nombre}` : empresa.nombre}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
         <div className="content-wrapper">
           <div className="content-card">
             {moduloSeleccionado ? (
               <iframe
-                key={moduloSeleccionado.id}
+                key={`${moduloSeleccionado.id}-${empresaActualId || 'sin-empresa'}`}
                 src={moduloSeleccionado.path}
                 title={moduloSeleccionado.label}
                 className="content-iframe"
@@ -335,35 +344,45 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout })
 
 const App = () => {
   const [sesion, setSesion] = useState(() => Sesion.obtener());
+  const [empresaActiva, setEmpresaActiva] = useState(() => Sesion.obtenerEmpresaActiva());
   const [moduloSeleccionado, setModuloSeleccionado] = useState(null);
-
-  const manejarLogin = (datosSesion) => {
-    setSesion(datosSesion);
-    const puedeAdministrar = Sesion.puedeAdministrarUsuarios(datosSesion);
-    const primerGrupo = MODULE_GROUPS.find((grupo) => grupo.items.some((modulo) => !modulo.requiresAdmin || puedeAdministrar));
-    if (primerGrupo) {
-      const primerModulo = primerGrupo.items.find((modulo) => !modulo.requiresAdmin || puedeAdministrar);
-      if (primerModulo) {
-        setModuloSeleccionado(primerModulo.id);
-      }
-    }
-  };
-
-  const manejarLogout = () => {
-    Sesion.limpiar();
-    setSesion(null);
-    setModuloSeleccionado(null);
-  };
 
   const seleccionarModulo = useCallback((moduloId) => {
     setModuloSeleccionado(moduloId);
   }, []);
 
+  const manejarLogin = (datosSesion) => {
+    const sesionNormalizada = datosSesion || Sesion.obtener();
+    setSesion(sesionNormalizada);
+    setEmpresaActiva(Sesion.obtenerEmpresaActiva(sesionNormalizada));
+  };
+
+  const manejarLogout = () => {
+    Sesion.limpiar();
+    setSesion(null);
+    setEmpresaActiva(null);
+    setModuloSeleccionado(null);
+  };
+
+  const manejarCambioEmpresa = useCallback((empresaId) => {
+    const nuevaEmpresa = Sesion.establecerEmpresaActiva(empresaId);
+    setEmpresaActiva(nuevaEmpresa);
+    setSesion(Sesion.obtener());
+  }, []);
+
   useEffect(() => {
-    if (sesion) {
-      manejarLogin(sesion);
+    if (!sesion) {
+      return;
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    const puedeAdministrar = Sesion.puedeAdministrarUsuarios(sesion);
+    const primerGrupo = MODULE_GROUPS.find((grupo) => grupo.items.some((modulo) => !modulo.requiresAdmin || puedeAdministrar));
+    if (primerGrupo) {
+      const primerModulo = primerGrupo.items.find((modulo) => !modulo.requiresAdmin || puedeAdministrar);
+      if (primerModulo) {
+        setModuloSeleccionado((actual) => actual || primerModulo.id);
+      }
+    }
+  }, [sesion]);
 
   if (!sesion) {
     return <LoginView onLogin={manejarLogin} />;
@@ -375,6 +394,8 @@ const App = () => {
       selectedModuleId={moduloSeleccionado}
       onSelectModule={seleccionarModulo}
       onLogout={manejarLogout}
+      empresaActiva={empresaActiva}
+      onChangeEmpresa={manejarCambioEmpresa}
     />
   );
 };

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -2,6 +2,66 @@
   const STORAGE_KEY = 'sesionUsuario';
   const REDIRECCION_POR_DEFECTO = 'login.html';
   const ID_ENLACE_ADMIN = 'navAdministrarUsuarios';
+  const EVENTO_EMPRESA = 'sesion:empresa-cambiada';
+
+  const clonar = (valor) => {
+    try {
+      return JSON.parse(JSON.stringify(valor));
+    } catch (error) {
+      console.warn('No fue posible clonar la sesión, se usará una referencia directa.', error);
+      return valor;
+    }
+  };
+
+  const normalizarEmpresa = (empresa) => {
+    if (!empresa || typeof empresa !== 'object') {
+      return null;
+    }
+    const id = empresa.id != null ? String(empresa.id) : '';
+    if (!id) {
+      return null;
+    }
+    return {
+      id,
+      nombre: empresa.nombre || '',
+      etiqueta: empresa.etiqueta || ''
+    };
+  };
+
+  const prepararSesion = (valor) => {
+    if (!valor || typeof valor !== 'object') {
+      return null;
+    }
+    const sesion = clonar(valor) || {};
+    const empresas = Array.isArray(valor.empresasDisponibles)
+      ? valor.empresasDisponibles.map(normalizarEmpresa).filter(Boolean)
+      : [];
+    const empresaActiva = normalizarEmpresa(valor.empresaActiva) || empresas[0] || null;
+    sesion.empresasDisponibles = empresas;
+    sesion.empresaActiva = empresaActiva;
+    return sesion;
+  };
+
+  const obtenerEmpresasDisponibles = (sesion) => {
+    const datos = sesion || obtener();
+    if (!datos || !Array.isArray(datos.empresasDisponibles)) {
+      return [];
+    }
+    return datos.empresasDisponibles.map(normalizarEmpresa).filter(Boolean);
+  };
+
+  const obtenerEmpresaActiva = (sesion) => {
+    const datos = sesion || obtener();
+    return normalizarEmpresa(datos?.empresaActiva);
+  };
+
+  const notificarCambioEmpresa = (empresa) => {
+    try {
+      window.dispatchEvent(new CustomEvent(EVENTO_EMPRESA, { detail: { empresa } }));
+    } catch (error) {
+      console.warn('No fue posible notificar el cambio de empresa.', error);
+    }
+  };
 
   const normalizarUsuario = (valor) => {
     return (valor || '').toString().trim().toUpperCase();
@@ -10,7 +70,11 @@
   const obtener = () => {
     try {
       const datos = sessionStorage.getItem(STORAGE_KEY);
-      return datos ? JSON.parse(datos) : null;
+      const sesion = datos ? JSON.parse(datos) : null;
+      if (!sesion) {
+        return null;
+      }
+      return prepararSesion(sesion);
     } catch (error) {
       console.warn('No fue posible leer la sesión almacenada.', error);
       return null;
@@ -19,14 +83,23 @@
 
   const guardar = (valor) => {
     if (!valor) {
-      sessionStorage.removeItem(STORAGE_KEY);
-      return;
+      limpiar();
+      return null;
     }
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(valor));
+    const sesionAnterior = obtener();
+    const datos = prepararSesion(valor);
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(datos));
+    const anteriorId = sesionAnterior?.empresaActiva?.id || null;
+    const nuevaId = datos?.empresaActiva?.id || null;
+    if (anteriorId !== nuevaId) {
+      notificarCambioEmpresa(datos?.empresaActiva || null);
+    }
+    return datos;
   };
 
   const limpiar = () => {
     sessionStorage.removeItem(STORAGE_KEY);
+    notificarCambioEmpresa(null);
   };
 
   const puedeAdministrarUsuarios = (sesion) => {
@@ -73,15 +146,38 @@
     }
   };
 
+  const puedeCambiarEmpresa = (sesion) => obtenerEmpresasDisponibles(sesion).length > 1;
+
+  const establecerEmpresaActiva = (empresaId) => {
+    const sesionActual = obtener();
+    if (!sesionActual) {
+      return null;
+    }
+    const empresas = obtenerEmpresasDisponibles(sesionActual);
+    const seleccionada = empresas.find((empresa) => empresa.id === String(empresaId));
+    if (!seleccionada) {
+      return null;
+    }
+    const actualizada = guardar({ ...sesionActual, empresaActiva: seleccionada });
+    return actualizada?.empresaActiva || null;
+  };
+
   const headersAutenticacion = () => {
     const sesion = obtener();
     if (!sesion || !sesion.usuario) {
       return {};
     }
 
-    return {
+    const headers = {
       'X-Usuario-Actual': normalizarUsuario(sesion.usuario.usuario)
     };
+
+    const empresaActiva = obtenerEmpresaActiva(sesion);
+    if (empresaActiva?.id) {
+      headers['X-Empresa-Activa'] = empresaActiva.id;
+    }
+
+    return headers;
   };
 
   window.Sesion = {
@@ -92,6 +188,11 @@
     esAdmin,
     puedeAdministrarUsuarios,
     asegurarEnlaceAdministrarUsuarios,
-    headersAutenticacion
+    headersAutenticacion,
+    obtenerEmpresasDisponibles,
+    obtenerEmpresaActiva,
+    establecerEmpresaActiva,
+    puedeCambiarEmpresa,
+    EVENTO_EMPRESA
   };
 })();

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -87,13 +87,6 @@
         <div class="invalid-feedback">Ingresa tu contraseña.</div>
       </div>
 
-      <div class="mb-4">
-        <label for="empresa" class="form-label fw-semibold">Empresa <span aria-hidden="true">*</span></label>
-        <select id="empresa" name="empresa" class="form-select form-select-lg" required aria-describedby="ayuda-empresa">
-        </select>
-        <div class="invalid-feedback">Selecciona la empresa con la que deseas trabajar.</div>
-      </div>
-
       <button type="submit" class="btn btn-verde w-100" id="botonIngresar">
         <span class="spinner-border spinner-border-sm me-2 visually-hidden" role="status" aria-hidden="true"></span>
         Ingresar
@@ -104,7 +97,6 @@
   <script src="js/sesion.js"></script>
   <script>
     const API_BASE = 'http://localhost:3000/api';
-    const selectEmpresa = document.getElementById('empresa');
     const formulario = document.getElementById('formularioLogin');
     const alerta = document.getElementById('alerta');
     const boton = document.getElementById('botonIngresar');
@@ -121,30 +113,9 @@
       alerta.textContent = '';
     };
 
-    const cargarEmpresas = async () => {
-      try {
-        const respuesta = await fetch(`${API_BASE}/empresas`);
-        const datos = await respuesta.json();
-        selectEmpresa.innerHTML = '<option value="" disabled selected>Selecciona una empresa</option>';
-        (datos.empresas || []).forEach((empresa) => {
-          const opcion = document.createElement('option');
-          opcion.value = empresa.id;
-          opcion.textContent = `${empresa.etiqueta} — ${empresa.nombre}`;
-          selectEmpresa.appendChild(opcion);
-        });
-      } catch (error) {
-        mostrarAlerta('No fue posible obtener la lista de empresas. Verifica el servicio local.');
-      }
-    };
-
     formulario.addEventListener('submit', async (evento) => {
       evento.preventDefault();
       evento.stopPropagation();
-
-      if (!formulario.checkValidity()) {
-        formulario.classList.add('was-validated');
-        return;
-      }
 
       limpiarAlerta();
       boton.disabled = true;
@@ -152,8 +123,7 @@
 
       const cuerpo = {
         usuario: formulario.usuario.value,
-        contrasena: formulario.contrasena.value,
-        empresaId: formulario.empresa.value
+        contrasena: formulario.contrasena.value
       };
 
       try {
@@ -181,7 +151,6 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       Sesion.limpiar();
-      cargarEmpresas();
     });
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -7,6 +7,7 @@
   <title>Administración de usuarios</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/estilos.css">
   <style>
     body {
       background: #f3f6f1;
@@ -26,18 +27,6 @@
       border-radius: 20px;
       box-shadow: 0 18px 50px rgba(36, 50, 38, 0.12);
       padding: clamp(1rem, 2.5vw, 2rem);
-    }
-
-    .btn-primario {
-      background: #2f6f4e;
-      border-color: #2f6f4e;
-      font-weight: 700;
-    }
-
-    .btn-primario:hover,
-    .btn-primario:focus {
-      background: #26523e;
-      border-color: #26523e;
     }
 
     .role-badge {


### PR DESCRIPTION
## Summary
- add a collapsible sidebar and global company selector tied to session permissions
- populate the Presupuestos view from Firebird using the CUENTASXX/SALDOSXX query for the active year and company
- enforce required first surname and email validation, and centralize the .btn-primario styling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_690a8d424440832d9e87c1dcbffc477e