### PR TITLE
Populate budgets table from Aspel COI data

### DIFF
--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -1,7 +1,21 @@
 const { ejecutarConsulta } = require('./firebirdService');
 
 const PERIODOS = Array.from({ length: 12 }, (_, indice) => indice + 1);
-const PERIODOS_AJUSTE = [13, 14];
+
+const MESES = [
+  { periodo: 1, alias: 'ENE', clave: 'ene' },
+  { periodo: 2, alias: 'FEB', clave: 'feb' },
+  { periodo: 3, alias: 'MAR', clave: 'mar' },
+  { periodo: 4, alias: 'ABR', clave: 'abr' },
+  { periodo: 5, alias: 'MAY', clave: 'may' },
+  { periodo: 6, alias: 'JUN', clave: 'jun' },
+  { periodo: 7, alias: 'JUL', clave: 'jul' },
+  { periodo: 8, alias: 'AGO', clave: 'ago' },
+  { periodo: 9, alias: 'SEP', clave: 'sep' },
+  { periodo: 10, alias: 'OCT', clave: 'oct' },
+  { periodo: 11, alias: 'NOV', clave: 'nov' },
+  { periodo: 12, alias: 'DIC', clave: 'dic' }
+];
 
 const formatearPeriodo = (valor) => valor.toString().padStart(2, '0');
 
@@ -10,35 +24,46 @@ const construirNombreTabla = (prefijo, anio) => {
   return `${prefijo}${sufijo}`;
 };
 
-const construirExpresionSaldo = (prefijo, periodo, anio) => {
-  const camposCargo = Array.from({ length: periodo }, (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`);
-  const camposAbono = Array.from({ length: periodo }, (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`);
-  const alias = `${prefijo.toUpperCase()}_P${periodo}_${anio}`;
-  const sumaCargos = camposCargo.length ? ` + (${camposCargo.join(' + ')})` : '';
-  const sumaAbonos = camposAbono.length ? ` - (${camposAbono.join(' + ')})` : '';
-  return `COALESCE(s.inicial, 0)${sumaCargos}${sumaAbonos} AS ${alias}`;
+const construirExpresionSaldoMensual = (periodo, alias) => {
+  const camposCargo = Array.from(
+    { length: periodo },
+    (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`
+  );
+  const camposAbono = Array.from(
+    { length: periodo },
+    (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`
+  );
+
+  const sumaCargos = camposCargo.length ? camposCargo.join(' + ') : '0';
+  const sumaAbonos = camposAbono.length ? camposAbono.join(' + ') : '0';
+
+  return `COALESCE(s.inicial, 0) + (${sumaCargos}) - (${sumaAbonos}) AS ${alias}`;
 };
 
-const mapearRegistro = (registro, anio) => {
+const construirExpresionSaldoAnual = () => {
+  const camposCargo = Array.from(
+    { length: 12 },
+    (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`
+  );
+  const camposAbono = Array.from(
+    { length: 12 },
+    (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`
+  );
+
+  return `COALESCE(s.inicial, 0) + (${camposCargo.join(' + ')}) - (${camposAbono.join(' + ')}) AS ANUAL`;
+};
+
+const mapearRegistro = (registro) => {
   const datos = {
-    numCta: registro.NUM_CTA,
-    nombre: registro.NOMBRE,
-    naturaleza: registro.NATURALEZA,
-    periodos: {},
-    ajustes: {}
+    numCta: registro.CUENTA,
+    descripcion: registro.DESCRIPCION
   };
 
-  PERIODOS.forEach((periodo) => {
-    const clave = `SALDO_P${periodo}_${anio}`;
-    datos.periodos[periodo] = Number(registro[clave] ?? 0);
+  MESES.forEach(({ alias, clave }) => {
+    datos[clave] = Number(registro[alias] ?? 0);
   });
 
-  PERIODOS_AJUSTE.forEach((periodo) => {
-    const clave = `SALDO_P${periodo}_${anio}`;
-    if (registro[clave] != null) {
-      datos.ajustes[periodo] = Number(registro[clave]);
-    }
-  });
+  datos.anual = Number(registro.ANUAL ?? 0);
 
   return datos;
 };
@@ -55,15 +80,14 @@ const obtenerPresupuestosMayor = async (empresaId, anio) => {
   const tablaCuentas = construirNombreTabla('CUENTAS', ejercicio);
   const tablaSaldos = construirNombreTabla('SALDOS', ejercicio);
 
-  const columnasPeriodos = PERIODOS.map((periodo) => construirExpresionSaldo('saldo', periodo, ejercicio));
-  const columnasAjustes = PERIODOS_AJUSTE.map((periodo) => construirExpresionSaldo('saldo', periodo, ejercicio));
+  const columnasMensuales = MESES.map(({ periodo, alias }) => construirExpresionSaldoMensual(periodo, alias));
+  const columnaAnual = construirExpresionSaldoAnual();
 
   const consulta = `
     SELECT
-      c.NUM_CTA,
-      c.NOMBRE,
-      c.NATURALEZA,
-      ${[...columnasPeriodos, ...columnasAjustes].join(',\n      ')}
+      c.NUM_CTA AS CUENTA,
+      c.NOMBRE AS DESCRIPCION,
+      ${[...columnasMensuales, columnaAnual].join(',\n      ')}
     FROM ${tablaCuentas} c
     LEFT JOIN ${tablaSaldos} s
       ON s.NUM_CTA = c.NUM_CTA
@@ -75,7 +99,7 @@ const obtenerPresupuestosMayor = async (empresaId, anio) => {
   `;
 
   const resultados = await ejecutarConsulta(empresaId, consulta, [ejercicio]);
-  return resultados.map((registro) => mapearRegistro(registro, ejercicio));
+  return resultados.map((registro) => mapearRegistro(registro));
 };
 
 module.exports = {

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -214,7 +214,20 @@
         const empresaLabel = document.getElementById('empresaLabel');
 
         const EJERCICIO = new Date().getFullYear();
-        const MESES = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'];
+        const MESES = [
+          { etiqueta: 'Ene', clave: 'ene' },
+          { etiqueta: 'Feb', clave: 'feb' },
+          { etiqueta: 'Mar', clave: 'mar' },
+          { etiqueta: 'Abr', clave: 'abr' },
+          { etiqueta: 'May', clave: 'may' },
+          { etiqueta: 'Jun', clave: 'jun' },
+          { etiqueta: 'Jul', clave: 'jul' },
+          { etiqueta: 'Ago', clave: 'ago' },
+          { etiqueta: 'Sep', clave: 'sep' },
+          { etiqueta: 'Oct', clave: 'oct' },
+          { etiqueta: 'Nov', clave: 'nov' },
+          { etiqueta: 'Dic', clave: 'dic' }
+        ];
         const formatoNumero = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
         yearLabel.textContent = EJERCICIO;
@@ -262,7 +275,7 @@
             if (!termino) {
               return true;
             }
-            const texto = `${cuenta.numCta || ''} ${cuenta.nombre || ''}`.toLowerCase();
+            const texto = `${cuenta.numCta || ''} ${cuenta.descripcion || ''}`.toLowerCase();
             return texto.includes(termino);
           });
 
@@ -276,27 +289,26 @@
           cuentasFiltradas.forEach((cuenta) => {
             const fila = document.createElement('tr');
             fila.dataset.account = cuenta.numCta || '';
-            fila.dataset.desc = cuenta.nombre || '';
+            fila.dataset.desc = cuenta.descripcion || '';
 
             const celdaCuenta = document.createElement('td');
             celdaCuenta.textContent = cuenta.numCta || '—';
             fila.appendChild(celdaCuenta);
 
             const celdaNombre = document.createElement('td');
-            celdaNombre.textContent = cuenta.nombre || '—';
+            celdaNombre.textContent = cuenta.descripcion || '—';
             fila.appendChild(celdaNombre);
 
-            MESES.forEach((_, indice) => {
-              const periodo = indice + 1;
+            MESES.forEach(({ clave }) => {
               const celda = document.createElement('td');
               celda.className = 'budget-value text-end';
-              celda.textContent = formatearValor(cuenta.periodos?.[periodo] ?? 0);
+              celda.textContent = formatearValor(cuenta[clave]);
               fila.appendChild(celda);
             });
 
             const celdaAnual = document.createElement('td');
             celdaAnual.className = 'budget-value text-end';
-            celdaAnual.textContent = formatearValor(cuenta.periodos?.[12] ?? 0);
+            celdaAnual.textContent = formatearValor(cuenta.anual);
             fila.appendChild(celdaAnual);
 
             tablaBody.appendChild(fila);
@@ -329,16 +341,24 @@
               actualizarEncabezadoEmpresa(datos.empresa);
             }
 
+            const normalizarNumero = (valor) => {
+              const numerico = Number(valor);
+              return Number.isFinite(numerico) ? numerico : 0;
+            };
+
             estado.cuentas = Array.isArray(datos.cuentas)
               ? datos.cuentas.map((cuenta) => {
-                  const periodosNormalizados = {};
-                  MESES.forEach((_, indice) => {
-                    const periodo = indice + 1;
-                    const valor = cuenta.periodos?.[periodo];
-                    const numerico = Number(valor);
-                    periodosNormalizados[periodo] = Number.isFinite(numerico) ? numerico : 0;
+                  const normalizada = {
+                    numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
+                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || ''
+                  };
+
+                  MESES.forEach(({ clave }) => {
+                    normalizada[clave] = normalizarNumero(cuenta[clave]);
                   });
-                  return { ...cuenta, periodos: periodosNormalizados };
+
+                  normalizada.anual = normalizarNumero(cuenta.anual);
+                  return normalizada;
                 })
               : [];
 
@@ -354,27 +374,24 @@
         };
 
         const convertirTablaACsv = () => {
-          const encabezados = ['Cuenta', 'Descripción', ...MESES, `Anual ${EJERCICIO}`];
+          const encabezados = ['Cuenta', 'Descripción', ...MESES.map((mes) => mes.etiqueta), `Anual ${EJERCICIO}`];
           const filas = estado.cuentas.map((cuenta) => {
-            const periodos = MESES.map((_, indice) => (cuenta.periodos?.[indice + 1] ?? 0));
-            const anual = cuenta.periodos?.[12] ?? 0;
+            const periodos = MESES.map(({ clave }) => cuenta[clave] ?? 0);
+            const anual = cuenta.anual ?? 0;
             return [
               cuenta.numCta || '',
-              cuenta.nombre || '',
+              cuenta.descripcion || '',
               ...periodos.map((valor) => Number(valor).toFixed(2)),
               Number(anual).toFixed(2)
             ];
           });
           const csv = [encabezados.join(',')];
           filas.forEach((fila) => csv.push(fila.join(',')));
-          return csv.join('
-');
+          return csv.join('\n');
         };
 
         const actualizarDesdeCsv = (texto) => {
-          const lineas = texto.split(/
-?
-/).filter((linea) => linea.trim().length > 0);
+          const lineas = texto.split(/\r?\n/).filter((linea) => linea.trim().length > 0);
           if (lineas.length <= 1) {
             return false;
           }
@@ -389,11 +406,12 @@
             if (!cuenta) {
               continue;
             }
-            MESES.forEach((_, indice) => {
+            MESES.forEach((mes, indice) => {
               const columna = columnas[indice + 2] || '0';
               const numerico = Number(columna.replace(/[^0-9+\-.,]/g, '').replace(',', '.'));
-              cuenta.periodos[indice + 1] = Number.isFinite(numerico) ? numerico : 0;
+              cuenta[mes.clave] = Number.isFinite(numerico) ? numerico : 0;
             });
+            cuenta.anual = MESES.reduce((acumulado, mes) => acumulado + (cuenta[mes.clave] ?? 0), 0);
           }
           renderizarTabla();
           return true;


### PR DESCRIPTION
## Summary
- build Firebird query for Aspel COI balances with dynamic table names and month columns
- expose month totals and annual total to the front-end and render them with currency formatting in presupuestos.html
- add CSV import/export helpers for the new month fields and annual total

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b6f5fe8fc832d9852d4007e6ede52