### PR TITLE
Ajusta cálculo de saldos de presupuestos por naturaleza

### DIFF
--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -37,7 +37,11 @@ const construirExpresionSaldoMensual = (periodo, alias) => {
   const sumaCargos = camposCargo.length ? camposCargo.join(' + ') : '0';
   const sumaAbonos = camposAbono.length ? camposAbono.join(' + ') : '0';
 
-  return `COALESCE(s.inicial, 0) + (${sumaCargos}) - (${sumaAbonos}) AS ${alias}`;
+  return `CASE WHEN c.NATURALEZA = 'H' THEN
+    COALESCE(s.inicial, 0) - (${sumaCargos}) + (${sumaAbonos})
+  ELSE
+    COALESCE(s.inicial, 0) + (${sumaCargos}) - (${sumaAbonos})
+  END AS ${alias}`;
 };
 
 const construirExpresionSaldoAnual = () => {
@@ -50,13 +54,21 @@ const construirExpresionSaldoAnual = () => {
     (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`
   );
 
-  return `COALESCE(s.inicial, 0) + (${camposCargo.join(' + ')}) - (${camposAbono.join(' + ')}) AS ANUAL`;
+  const sumaCargos = camposCargo.length ? camposCargo.join(' + ') : '0';
+  const sumaAbonos = camposAbono.length ? camposAbono.join(' + ') : '0';
+
+  return `CASE WHEN c.NATURALEZA = 'H' THEN
+    COALESCE(s.inicial, 0) - (${sumaCargos}) + (${sumaAbonos})
+  ELSE
+    COALESCE(s.inicial, 0) + (${sumaCargos}) - (${sumaAbonos})
+  END AS ANUAL`;
 };
 
 const mapearRegistro = (registro) => {
   const datos = {
     numCta: registro.CUENTA,
-    descripcion: registro.DESCRIPCION
+    descripcion: registro.DESCRIPCION,
+    naturaleza: (registro.NATURALEZA || '').trim()
   };
 
   MESES.forEach(({ alias, clave }) => {
@@ -87,6 +99,7 @@ const obtenerPresupuestosMayor = async (empresaId, anio) => {
     SELECT
       c.NUM_CTA AS CUENTA,
       c.NOMBRE AS DESCRIPCION,
+      c.NATURALEZA AS NATURALEZA,
       ${[...columnasMensuales, columnaAnual].join(',\n      ')}
     FROM ${tablaCuentas} c
     LEFT JOIN ${tablaSaldos} s

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -350,7 +350,8 @@
               ? datos.cuentas.map((cuenta) => {
                   const normalizada = {
                     numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
-                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || ''
+                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || '',
+                    naturaleza: cuenta.naturaleza || cuenta.NATURALEZA || ''
                   };
 
                   MESES.forEach(({ clave }) => {

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -125,6 +125,8 @@
       display: flex;
       flex-direction: column;
       min-width: 0;
+      width: calc(100% - var(--sidebar-width));
+      transition: width 0.3s ease;
     }
 
     .app-layout.sidebar-hidden .app-sidebar {
@@ -134,6 +136,7 @@
 
     .app-layout.sidebar-hidden .app-content {
       box-shadow: none;
+      width: 100%;
     }
 
     .top-bar {


### PR DESCRIPTION
## Summary
- calcula los saldos mensuales y anuales considerando la naturaleza de cada cuenta
- expone la naturaleza de las cuentas en la respuesta de presupuestos y la conserva en el frontend
- ajusta el panel principal para que ocupe el 100% del ancho cuando se oculta el sidebar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b7a2fb43c832db7bf924c74902884