### PR TITLE
Corrige saldos de presupuestos y expansión del dashboard

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,6 +20,12 @@ const createWindow = () => {
   });
 
   mainWindow.loadFile(resolveAssetPath('vistas', 'app.html'));
+
+  if (!app.isPackaged) {
+    mainWindow.webContents.once('did-finish-load', () => {
+      mainWindow.webContents.openDevTools({ mode: 'detach' });
+    });
+  }
 };
 
 app.whenReady().then(() => {

--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -24,46 +24,59 @@ const construirNombreTabla = (prefijo, anio) => {
   return `${prefijo}${sufijo}`;
 };
 
-const construirExpresionSaldoMensual = (periodo, alias) => {
-  const camposCargo = Array.from(
-    { length: periodo },
-    (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`
-  );
-  const camposAbono = Array.from(
-    { length: periodo },
-    (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`
-  );
+const construirColumnasMovimientos = () => {
+  const columnas = [`COALESCE(s.INICIAL, 0) AS INICIAL`];
 
-  const sumaCargos = camposCargo.length ? camposCargo.join(' + ') : '0';
-  const sumaAbonos = camposAbono.length ? camposAbono.join(' + ') : '0';
+  PERIODOS.forEach((periodo) => {
+    const sufijo = formatearPeriodo(periodo);
+    columnas.push(`COALESCE(s.CARGO${sufijo}, 0) AS CARGO${sufijo}`);
+    columnas.push(`COALESCE(s.ABONO${sufijo}, 0) AS ABONO${sufijo}`);
+  });
 
-  return `COALESCE(s.inicial, 0) + (${sumaCargos}) - (${sumaAbonos}) AS ${alias}`;
+  return columnas;
 };
 
-const construirExpresionSaldoAnual = () => {
-  const camposCargo = Array.from(
-    { length: 12 },
-    (_, indice) => `COALESCE(s.cargo${formatearPeriodo(indice + 1)}, 0)`
-  );
-  const camposAbono = Array.from(
-    { length: 12 },
-    (_, indice) => `COALESCE(s.abono${formatearPeriodo(indice + 1)}, 0)`
-  );
+const normalizarNumero = (valor) => {
+  const numero = Number(valor);
+  return Number.isFinite(numero) ? numero : 0;
+};
 
-  return `COALESCE(s.inicial, 0) + (${camposCargo.join(' + ')}) - (${camposAbono.join(' + ')}) AS ANUAL`;
+const redondearSaldo = (valor) => {
+  const redondeado = Math.round((valor + Number.EPSILON) * 100) / 100;
+  return Object.is(redondeado, -0) ? 0 : redondeado;
+};
+
+const calcularSaldo = (naturaleza, inicial, cargosAcumulados, abonosAcumulados) => {
+  const esAcreedora = naturaleza === 'H';
+  if (esAcreedora) {
+    return inicial - cargosAcumulados + abonosAcumulados;
+  }
+  return inicial + cargosAcumulados - abonosAcumulados;
 };
 
 const mapearRegistro = (registro) => {
+  const naturaleza = (registro.NATURALEZA || '').trim().toUpperCase();
+  const inicial = normalizarNumero(registro.INICIAL);
+
+  let cargosAcumulados = 0;
+  let abonosAcumulados = 0;
+
   const datos = {
     numCta: registro.CUENTA,
-    descripcion: registro.DESCRIPCION
+    descripcion: registro.DESCRIPCION,
+    naturaleza
   };
 
-  MESES.forEach(({ alias, clave }) => {
-    datos[clave] = Number(registro[alias] ?? 0);
+  MESES.forEach(({ periodo, clave }) => {
+    const sufijo = formatearPeriodo(periodo);
+    cargosAcumulados += normalizarNumero(registro[`CARGO${sufijo}`]);
+    abonosAcumulados += normalizarNumero(registro[`ABONO${sufijo}`]);
+    const saldo = calcularSaldo(naturaleza, inicial, cargosAcumulados, abonosAcumulados);
+    datos[clave] = redondearSaldo(saldo);
   });
 
-  datos.anual = Number(registro.ANUAL ?? 0);
+  const saldoAnual = calcularSaldo(naturaleza, inicial, cargosAcumulados, abonosAcumulados);
+  datos.anual = redondearSaldo(saldoAnual);
 
   return datos;
 };
@@ -80,14 +93,14 @@ const obtenerPresupuestosMayor = async (empresaId, anio) => {
   const tablaCuentas = construirNombreTabla('CUENTAS', ejercicio);
   const tablaSaldos = construirNombreTabla('SALDOS', ejercicio);
 
-  const columnasMensuales = MESES.map(({ periodo, alias }) => construirExpresionSaldoMensual(periodo, alias));
-  const columnaAnual = construirExpresionSaldoAnual();
+  const columnasMovimientos = construirColumnasMovimientos();
 
   const consulta = `
     SELECT
       c.NUM_CTA AS CUENTA,
       c.NOMBRE AS DESCRIPCION,
-      ${[...columnasMensuales, columnaAnual].join(',\n      ')}
+      c.NATURALEZA AS NATURALEZA,
+      ${columnasMovimientos.join(',\n      ')}
     FROM ${tablaCuentas} c
     LEFT JOIN ${tablaSaldos} s
       ON s.NUM_CTA = c.NUM_CTA

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -350,7 +350,8 @@
               ? datos.cuentas.map((cuenta) => {
                   const normalizada = {
                     numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
-                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || ''
+                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || '',
+                    naturaleza: cuenta.naturaleza || cuenta.NATURALEZA || ''
                   };
 
                   MESES.forEach(({ clave }) => {

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -33,16 +33,21 @@
       flex: 1;
       display: flex;
       min-height: 0;
+      position: relative;
     }
 
     .app-sidebar {
+      flex: 0 0 var(--sidebar-width);
       width: var(--sidebar-width);
       background: #ffffff;
       border-right: 1px solid rgba(36, 50, 38, 0.08);
       box-shadow: 0 20px 40px rgba(36, 50, 38, 0.12);
       display: flex;
       flex-direction: column;
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      height: 100%;
+      position: relative;
+      z-index: 5;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
     }
 
     .sidebar-header {
@@ -121,19 +126,28 @@
     }
 
     .app-content {
-      flex: 1;
+      flex: 1 1 auto;
       display: flex;
       flex-direction: column;
       min-width: 0;
+      width: 100%;
+      transition: width 0.3s ease;
     }
 
     .app-layout.sidebar-hidden .app-sidebar {
-      transform: translateX(calc(-1 * var(--sidebar-width)));
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      transform: translateX(-110%);
       box-shadow: none;
+      opacity: 0;
+      pointer-events: none;
     }
 
     .app-layout.sidebar-hidden .app-content {
       box-shadow: none;
+      width: 100%;
     }
 
     .top-bar {
@@ -342,13 +356,21 @@
 
       .app-sidebar {
         width: 100%;
+        flex: none;
         border-right: none;
         border-bottom: 1px solid rgba(36, 50, 38, 0.08);
         transform: translateY(0);
+        transition: max-height 0.3s ease, opacity 0.3s ease;
+        max-height: 100vh;
       }
 
       .app-layout.sidebar-hidden .app-sidebar {
-        transform: translateY(0);
+        position: relative;
+        transform: translateY(-12px);
+        max-height: 0;
+        opacity: 0;
+        pointer-events: none;
+        overflow: hidden;
       }
 
       .sidebar-menu {

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -256,7 +256,12 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout, e
 
   return (
     <div className={layoutClassName}>
-      <aside className="app-sidebar" aria-label="Navegación principal">
+      <aside
+        className="app-sidebar"
+        aria-label="Navegación principal"
+        aria-hidden={sidebarOculta}
+        inert={sidebarOculta ? '' : undefined}
+      >
         <div className="sidebar-header">
           <h1>Panel AmCham</h1>
         </div>


### PR DESCRIPTION
## Summary
- recalcula los saldos de presupuestos desde Node para respetar la naturaleza de cada cuenta sin provocar errores de conversión
- ajusta el layout para que el dashboard ocupe todo el ancho al ocultar el sidebar y deshabilita la interacción con el menú
- abre automáticamente las devtools de Electron al ejecutar npm start en desarrollo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b7a2fb43c832db7bf924c74902884