### PR TITLE
Ajusta lectura de presupuestos para considerar naturaleza de cuenta

### DIFF
--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -56,7 +56,8 @@ const construirExpresionSaldoAnual = () => {
 const mapearRegistro = (registro) => {
   const datos = {
     numCta: registro.CUENTA,
-    descripcion: registro.DESCRIPCION
+    descripcion: registro.DESCRIPCION,
+    naturaleza: registro.NATURALEZA || null
   };
 
   MESES.forEach(({ alias, clave }) => {
@@ -87,6 +88,7 @@ const obtenerPresupuestosMayor = async (empresaId, anio) => {
     SELECT
       c.NUM_CTA AS CUENTA,
       c.NOMBRE AS DESCRIPCION,
+      c.NATURALEZA AS NATURALEZA,
       ${[...columnasMensuales, columnaAnual].join(',\n      ')}
     FROM ${tablaCuentas} c
     LEFT JOIN ${tablaSaldos} s

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -346,18 +346,25 @@
               return Number.isFinite(numerico) ? numerico : 0;
             };
 
+            const obtenerNaturaleza = (valor) => (valor || '').toString().trim().toUpperCase();
+            const esAcreedora = (naturaleza) => ['A', 'C'].includes(naturaleza);
+
             estado.cuentas = Array.isArray(datos.cuentas)
               ? datos.cuentas.map((cuenta) => {
+                  const naturaleza = obtenerNaturaleza(cuenta.naturaleza || cuenta.NATURALEZA);
+                  const factor = esAcreedora(naturaleza) ? -1 : 1;
+
                   const normalizada = {
                     numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
-                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || ''
+                    descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || '',
+                    naturaleza
                   };
 
                   MESES.forEach(({ clave }) => {
-                    normalizada[clave] = normalizarNumero(cuenta[clave]);
+                    normalizada[clave] = normalizarNumero(cuenta[clave]) * factor;
                   });
 
-                  normalizada.anual = normalizarNumero(cuenta.anual);
+                  normalizada.anual = normalizarNumero(cuenta.anual) * factor;
                   return normalizada;
                 })
               : [];


### PR DESCRIPTION
## Summary
- incluir la naturaleza de la cuenta en la consulta de presupuestos del servicio
- normalizar los saldos en la vista de presupuestos aplicando el signo según la naturaleza acreedora o deudora

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b8797ef2c832d8e8269dd785cecc0