### PR TITLE
Fix summary SQL casting and enforce read-only summary UI

### DIFF
--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -23,9 +23,9 @@ const tablaCodigosDerivada = (codigos = []) => {
     .filter((c) => c.length > 0);
   if (limpios.length === 0) {
     // Asegura al menos una fila vacía para no romper el SELECT; luego se normaliza a 0
-    return { sql: "SELECT CAST(''__VACIO__'' AS VARCHAR(24)) AS NUM_CTA FROM RDB$DATABASE", params: [] };
+    return { sql: "SELECT CAST('__VACIO__' AS VARCHAR(24)) AS NUM_CTA FROM RDB$DATABASE", params: [] };
   }
-  const selects = limpios.map(() => 'SELECT ? AS NUM_CTA FROM RDB$DATABASE');
+  const selects = limpios.map(() => 'SELECT CAST(? AS VARCHAR(24)) AS NUM_CTA FROM RDB$DATABASE');
   const sql = selects.join(' UNION ALL ');
   return { sql, params: limpios };
 };

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -192,6 +192,7 @@
       text-align: left;
       background-color: #fff !important;
       font-size: 0.7rem;
+      padding-left: calc(16px + (var(--depth, 0) * 18px));
     }
 
     .label-cell strong {
@@ -208,6 +209,14 @@
       background: #e8e8e8;
       color: #000;
       border: 1px solid #999 !important;
+      padding-left: calc(12px + (var(--depth, 0) * 18px));
+    }
+
+    .category-cell::before,
+    .label-cell::before {
+      content: '';
+      display: inline-block;
+      width: calc(var(--depth, 0) * 18px);
     }
 
     .code-cell {
@@ -232,15 +241,16 @@
 
     .amarillo th,
     .amarillo td {
-      background-color: yellow;
+      background-color: #fff2cc;
       font-weight: 700;
+      color: #000;
     }
 
     .verde th,
     .verde td {
-      background-color: #375623;
-      font-weight: 700;
-      color: #ffffff;
+      background-color: #92d050;
+      font-weight: 800;
+      color: #1f2d0c;
     }
 
     .important {
@@ -317,31 +327,29 @@
     /* Estilo secundario con fondo blanco (Primera y tercera fila del tbody) */
     .highlight-secondary th,
     .highlight-secondary td {
-      background-color: var(--color-secondary-white) !important;
-      color: #ffffff !important;
+      background-color: #b8cce4 !important;
+      color: #1f3763 !important;
       font-weight: 700 !important;
       border: 1px solid #999 !important;
     }
 
-    /* Estilo primario azul - solo título en azul, resto en negro y negrita */
     .highlight-primary th,
     .highlight-primary td {
-      background-color: var(--color-neutral-row) !important;
-      color: #000 !important;
+      background-color: #d9d9d9 !important;
+      color: #1f1f1f !important;
       font-weight: 700 !important;
       border: 1px solid #999 !important;
     }
 
     .highlight-primary .category-cell,
     .highlight-primary .label-cell {
-      color: var(--color-primary-blue) !important;
+      color: #1f3763 !important;
     }
 
-    /* Estilo azul brillante - toda la fila en azul brillante */
     .highlight-bright th,
     .highlight-bright td {
-      background-color: var(--color-neutral-row) !important;
-      color: var(--color-bright-blue) !important;
+      background-color: #cfd8f3 !important;
+      color: #0e19fa !important;
       font-weight: 700 !important;
       border: 1px solid #999 !important;
     }
@@ -350,7 +358,7 @@
     .highlight-bright .label-cell,
     .highlight-bright .mono,
     .highlight-bright .code-cell {
-      color: var(--color-bright-blue) !important;
+      color: #0e19fa !important;
     }
   </style>
 </head>
@@ -483,16 +491,6 @@
     <div class="row">
       <div class="col-12">
         <div class="table-card fade-in">
-          <!-- Barra de fórmulas tipo Excel -->
-          <div class="d-flex align-items-center gap-2 p-2 border-bottom" id="formulaToolbar">
-            <span class="text-muted small">Celda</span>
-            <strong id="currentCellId">-</strong>
-            <input id="formulaBar" type="text" class="form-control form-control-sm" placeholder="=SUM(A1:A10)" style="max-width: 360px;" />
-            <button id="applyFormula" type="button" class="btn btn-sm btn-primary">Aplicar</button>
-            <button id="clearFormula" type="button" class="btn btn-sm btn-outline-secondary">Limpiar</button>
-            <button id="saveFormulas" type="button" class="btn btn-sm btn-outline-primary ms-auto">Guardar</button>
-            <button id="loadFormulas" type="button" class="btn btn-sm btn-outline-primary">Cargar</button>
-          </div>
           <div id="summaryStatus" class="alert alert-info mb-3 visually-hidden" role="status"></div>
           <div class="table-responsive">
             <div class="table-wrapper" id="tableWrapper">
@@ -550,931 +548,85 @@
   <script src="js/summary.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    const sesion = Sesion.requerirSesion();
-    if (!sesion) {
-      throw new Error('Redireccionando al inicio de sesión.');
-    }
+    (function () {
+      window.sesion = Sesion.requerirSesion();
+      if (!window.sesion) {
+        throw new Error('Redireccionando al inicio de sesión.');
+      }
 
-    Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
-
-    // Script para selección de celdas y zoom
-    document.addEventListener('DOMContentLoaded', function () {
-      const table = document.getElementById('mainTable');
-      const tableWrapper = document.getElementById('tableWrapper');
-      const zoomInBtn = document.getElementById('zoomIn');
-      const zoomOutBtn = document.getElementById('zoomOut');
-      const zoomResetBtn = document.getElementById('zoomReset');
-      const zoomDisplay = document.getElementById('zoomDisplay');
-      const resumenAnualCard = document.getElementById('resumenAnualCard');
-      const summaryYearSelect = document.getElementById('summaryYearSelect');
-      const saldoValue = document.getElementById('saldoValue');
-      const acumuladoValue = document.getElementById('acumuladoValue');
-      const filtroAnio = document.getElementById('selectAnio');
-
-
-      const API_BASE = 'http://localhost:3000/api';
-      const summaryStatus = document.getElementById('summaryStatus');
-      const summaryTableBody = document.getElementById('summaryTableBody');
-
-      const estadoModulo = {
-        ejercicios: [],
-        tabla: []
-      };
-
-      const formatoMXN = new Intl.NumberFormat('es-MX', {
-        style: 'currency',
-        currency: 'MXN',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      });
-
-      const limpiarEstado = () => {
-        if (!summaryStatus) return;
-        summaryStatus.className = 'alert alert-info mb-3 visually-hidden';
-        summaryStatus.textContent = '';
-      };
-
-      const mostrarEstado = (mensaje, tipo = 'info') => {
-        if (!summaryStatus) return;
-        summaryStatus.textContent = mensaje;
-        summaryStatus.className = `alert alert-${tipo} mb-3`;
-      };
-
-      const formatearMoneda = (valor) => {
-        if (typeof valor !== 'number' || Number.isNaN(valor)) {
-          return '—';
-        }
-        return formatoMXN.format(valor);
-      };
-
-      const formatearPorcentaje = (valor) => {
-        if (typeof valor !== 'number' || Number.isNaN(valor)) {
-          return '—';
-        }
-        return `${valor.toFixed(2)}%`;
-      };
-
-      const actualizarResumen = (anio) => {
-        if (!saldoValue || !acumuladoValue) {
-          return;
-        }
-        const registro = estadoModulo.ejercicios.find((item) => String(item.anio) === String(anio));
-        if (!registro) {
-          saldoValue.textContent = '—';
-          acumuladoValue.textContent = '—';
-          return;
-        }
-        saldoValue.textContent = formatearMoneda(registro.saldo);
-        acumuladoValue.textContent = formatearMoneda(registro.acumulado);
-      };
-
-      const renderizarTabla = () => {
-        if (!summaryTableBody) return;
-        summaryTableBody.innerHTML = '';
-        const filas = estadoModulo.tabla;
-        if (!Array.isArray(filas) || filas.length === 0) {
-          const vacio = document.createElement('tr');
-          vacio.innerHTML = '<td colspan="12" class="text-center text-muted py-4">No hay información disponible para mostrar.</td>';
-          summaryTableBody.appendChild(vacio);
-          return;
+      document.addEventListener('DOMContentLoaded', () => {
+        const nav = document.querySelector('#navbarNav .navbar-nav');
+        if (nav) {
+          Sesion.asegurarEnlaceAdministrarUsuarios(nav);
         }
 
-        filas.forEach((fila) => {
-          const tr = document.createElement('tr');
-          if (fila.tipo === 'categoria') {
-            tr.className = fila.estilo || 'highlight-primary';
-            tr.innerHTML = `
-              <th></th>
-              <td class="mono">${formatearMoneda(fila.mesActual)}</td>
-              <td class="mono">${formatearMoneda(fila.mesPlan)}</td>
-              <td class="mono">${formatearMoneda(fila.mesAnterior)}</td>
-              <td class="mono">${formatearPorcentaje(fila.mesVariacionPlan)}</td>
-              <td class="mono">${formatearPorcentaje(fila.mesVariacionAnterior)}</td>
-              <td class="category-cell">${fila.etiqueta || ''}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoActual)}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoPlan)}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoAnterior)}</td>
-              <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionPlan)}</td>
-              <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionAnterior)}</td>
-            `;
-          } else {
-            tr.innerHTML = `
-              <th class="code-cell">${fila.codigo || ''}</th>
-              <td class="mono">${formatearMoneda(fila.mesActual)}</td>
-              <td class="mono">${formatearMoneda(fila.mesPlan)}</td>
-              <td class="mono">${formatearMoneda(fila.mesAnterior)}</td>
-              <td class="mono">${formatearPorcentaje(fila.mesVariacionPlan)}</td>
-              <td class="mono">${formatearPorcentaje(fila.mesVariacionAnterior)}</td>
-              <td class="label-cell">${fila.descripcion || ''}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoActual)}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoPlan)}</td>
-              <td class="mono">${formatearMoneda(fila.acumuladoAnterior)}</td>
-              <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionPlan)}</td>
-              <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionAnterior)}</td>
-            `;
+        const table = document.getElementById('mainTable');
+        const tableWrapper = document.getElementById('tableWrapper');
+        const zoomInBtn = document.getElementById('zoomIn');
+        const zoomOutBtn = document.getElementById('zoomOut');
+        const zoomResetBtn = document.getElementById('zoomReset');
+        const zoomDisplay = document.getElementById('zoomDisplay');
+
+        let selectedCell = null;
+        let zoomLevel = 1;
+
+        const clampZoom = (value) => Math.min(1.5, Math.max(0.6, value));
+        const renderZoom = () => {
+          if (tableWrapper) {
+            tableWrapper.style.transform = `scale(${zoomLevel})`;
           }
-          summaryTableBody.appendChild(tr);
-        });
-      };
-
-      const poblarSelects = () => {
-        const ejercicios = estadoModulo.ejercicios;
-        if (summaryYearSelect) {
-          summaryYearSelect.innerHTML = '';
-        }
-        if (filtroAnio) {
-          filtroAnio.innerHTML = '';
-        }
-        if (!Array.isArray(ejercicios) || ejercicios.length === 0) {
-          if (summaryYearSelect) {
-            const opcion = document.createElement('option');
-            opcion.value = '';
-            opcion.textContent = 'Sin datos';
-            summaryYearSelect.appendChild(opcion);
-            summaryYearSelect.disabled = true;
-          }
-          if (filtroAnio) {
-            const opcion = document.createElement('option');
-            opcion.value = '';
-            opcion.textContent = 'Sin datos';
-            filtroAnio.appendChild(opcion);
-            filtroAnio.disabled = true;
-          }
-          return;
-        }
-
-        ejercicios
-          .sort((a, b) => Number(b.anio) - Number(a.anio))
-          .forEach((registro, indice) => {
-            const valor = registro.anio;
-            if (summaryYearSelect) {
-              const option = document.createElement('option');
-              option.value = valor;
-              option.textContent = valor;
-              summaryYearSelect.appendChild(option);
-            }
-            if (filtroAnio) {
-              const option = document.createElement('option');
-              option.value = valor;
-              option.textContent = valor;
-              filtroAnio.appendChild(option);
-            }
-            if (indice === 0) {
-              if (summaryYearSelect) {
-                summaryYearSelect.value = valor;
-                summaryYearSelect.disabled = false;
-              }
-              if (filtroAnio) {
-                filtroAnio.value = valor;
-                filtroAnio.disabled = false;
-              }
-              actualizarResumen(valor);
-              setAllYearSpans(valor); // <--- asegura que el header muestre ese año
-            }
-          });
-      };
-
-      // ==== 1) LAYOUT de filas (edítalo a tu gusto) ====
-      const SUMMARY_LAYOUT_V1 = [
-        {
-          id: 'cdmx_income', tipo: 'categoria', estilo: 'highlight-primary', etiqueta: 'CDMX INCOME', hijos: [
-            {
-              id: 'membership', tipo: 'categoria', estilo: 'highlight-secondary', etiqueta: 'Membership', hijos: [
-                { id: 'ctas_cuotas', tipo: 'detalle', codigo: '401000000000000000001', descripcion: 'Cuotas Netas' },
-                { id: 'ctas_nuevos', tipo: 'detalle', codigo: '402000000000000000001', descripcion: 'Ingresos socios nuevos' },
-                { id: 'membership_sub', tipo: 'subtotal', estilo: 'amarillo', etiqueta: 'Subtotal Membership' }
-              ]
-            },
-            {
-              id: 'events', tipo: 'categoria', estilo: 'highlight-secondary', etiqueta: 'EVENTS', hijos: [
-                { id: 'ctas_eventos', tipo: 'detalle', codigo: '407000000000000000001', descripcion: 'Eventos' },
-                { id: 'ctas_patro', tipo: 'detalle', codigo: '408000000000000000001', descripcion: 'Patrocinios' },
-                { id: 'events_sub', tipo: 'subtotal', estilo: 'amarillo', etiqueta: 'Subtotal Events' }
-              ]
-            },
-            { id: 'income_total', tipo: 'total', estilo: 'verde', etiqueta: 'TOTAL INCOME' }
-          ]
-        }
-      ];
-
-      // Helpers para persistir layout si el usuario lo edita
-      const saveLayoutLS = (l) => localStorage.setItem('summary_layout_v1', JSON.stringify(l));
-      const loadLayoutLS = () => { try { return JSON.parse(localStorage.getItem('summary_layout_v1') || 'null'); } catch { return null; } };
-      let CURRENT_LAYOUT = loadLayoutLS() ?? SUMMARY_LAYOUT_V1;
-
-      // ==== 2) TIPOS y utilidades de métrica ====
-      /** Estructura métrica por fila */
-      const zeroMetrics = () => ({
-        // Mes (seleccionado)
-        mesActual: 0, mesPlan: 0, mesAnterior: 0, mesVariacionPlan: 0, mesVariacionAnterior: 0,
-        // YTD (hasta mes seleccionado)
-        acumuladoActual: 0, acumuladoPlan: 0, acumuladoAnterior: 0, acumuladoVariacionPlan: 0, acumuladoVariacionAnterior: 0,
-      });
-
-      /** % seguro cuando b = 0 */
-      const pct = (a, b) => (Math.abs(b || 0) === 0 ? 0 : ((a - b) / Math.abs(b)) * 100);
-
-      /** Suma métrica (para subtotal/total) */
-      const addMetrics = (dst, src) => {
-        Object.keys(dst).forEach(k => dst[k] += (src[k] || 0));
-        return dst;
-      };
-
-      // ==== 3) Índices de datos (por NUM_CTA) ====
-      /** Convierte arreglo de detalle (API) a índice por código */
-      function buildIndex(apiRows) {
-        const idx = {};
-        (apiRows || []).forEach(r => { idx[String(r.codigo).trim()] = r; });
-        return idx;
-      }
-
-      /** Extrae todos los códigos NUM_CTA visibles en el layout */
-      function collectCodes(layout) {
-        const codes = [];
-        const walk = (nodos) => nodos.forEach(n => {
-          if (n.tipo === 'detalle' && n.codigo) codes.push(String(n.codigo).trim());
-          if (Array.isArray(n.hijos)) walk(n.hijos);
-        });
-        walk(layout);
-        return codes;
-      }
-
-      // ==== 4) Cálculo recursivo: detail -> subtotal/total ====
-      /**
-       * node: estructura del layout
-       * idx : índice por NUM_CTA { codigo: { mesActual, mesPlan, mesAnterior, acumuladoActual, ... } }
-       * return: { row, metrics, children[] }
-       */
-      function computeNode(node, idx) {
-        const metrics = zeroMetrics();
-        let children = [];
-
-        if (Array.isArray(node.hijos) && node.hijos.length) {
-          children = node.hijos.map(h => computeNode(h, idx));
-          // Sumar hijos para categoria/subtotal/total
-          children.forEach(ch => addMetrics(metrics, ch.metrics));
-        } else if (node.tipo === 'detalle' && node.codigo) {
-          const r = idx[String(node.codigo).trim()];
-          if (r) {
-            metrics.mesActual = r.mesActual || 0;
-            metrics.mesPlan = r.mesPlan || 0;
-            metrics.mesAnterior = r.mesAnterior || 0;
-
-            metrics.acumuladoActual = r.acumuladoActual || 0;
-            metrics.acumuladoPlan = r.acumuladoPlan || 0;
-            metrics.acumuladoAnterior = r.acumuladoAnterior || 0;
-          }
-        }
-
-        // % variaciones
-        metrics.mesVariacionPlan = pct(metrics.mesActual, metrics.mesPlan);
-        metrics.mesVariacionAnterior = pct(metrics.mesActual, metrics.mesAnterior);
-        metrics.acumuladoVariacionPlan = pct(metrics.acumuladoActual, metrics.acumuladoPlan);
-        metrics.acumuladoVariacionAnterior = pct(metrics.acumuladoActual, metrics.acumuladoAnterior);
-
-        return { row: node, metrics, children };
-      }
-
-      /** Construye el árbol calculado para todo el layout */
-      function computeTree(layout, idx) {
-        return layout.map(n => computeNode(n, idx));
-      }
-
-      // ==== 5) Aplana el árbol para tu renderizarTabla() ====
-      /** Convierte el árbol calculado -> arreglo plano de filas con el shape exacto que tu renderer espera */
-      function flattenForRender(tree) {
-        const out = [];
-        const walk = (node, depth = 0) => {
-          const { row, metrics, children } = node;
-
-          if (row.tipo === 'categoria' || row.tipo === 'subtotal' || row.tipo === 'total') {
-            out.push({
-              tipo: 'categoria',                // tu renderer usa 'categoria' para filas de título
-              estilo: row.estilo || 'highlight-primary',
-              etiqueta: row.etiqueta || row.label || '',
-              // MES
-              mesActual: metrics.mesActual,
-              mesPlan: metrics.mesPlan,
-              mesAnterior: metrics.mesAnterior,
-              mesVariacionPlan: metrics.mesVariacionPlan,
-              mesVariacionAnterior: metrics.mesVariacionAnterior,
-              // YTD
-              acumuladoActual: metrics.acumuladoActual,
-              acumuladoPlan: metrics.acumuladoPlan,
-              acumuladoAnterior: metrics.acumuladoAnterior,
-              acumuladoVariacionPlan: metrics.acumuladoVariacionPlan,
-              acumuladoVariacionAnterior: metrics.acumuladoVariacionAnterior,
-              depth
-            });
-          } else {
-            // detalle (cuenta)
-            out.push({
-              tipo: 'detalle',
-              codigo: row.codigo,
-              descripcion: row.descripcion || '',
-              // MES
-              mesActual: metrics.mesActual,
-              mesPlan: metrics.mesPlan,
-              mesAnterior: metrics.mesAnterior,
-              mesVariacionPlan: metrics.mesVariacionPlan,
-              mesVariacionAnterior: metrics.mesVariacionAnterior,
-              // YTD
-              acumuladoActual: metrics.acumuladoActual,
-              acumuladoPlan: metrics.acumuladoPlan,
-              acumuladoAnterior: metrics.acumuladoAnterior,
-              acumuladoVariacionPlan: metrics.acumuladoVariacionPlan,
-              acumuladoVariacionAnterior: metrics.acumuladoVariacionAnterior,
-              depth
-            });
-          }
-
-          (children || []).forEach(ch => walk(ch, depth + 1));
-        };
-        tree.forEach(n => walk(n, 0));
-        return out;
-      }
-
-      const cargarDatos = async () => {
-        mostrarEstado('Cargando información…');
-        try {
-          const respuesta = await fetch(`${API_BASE}/modulos/summary-resumen-e`, {
-            headers: Sesion.headersAutenticacion()
-          });
-          const datos = await respuesta.json();
-          if (!respuesta.ok) {
-            throw new Error(datos.mensaje || 'No fue posible obtener la información.');
-          }
-          estadoModulo.ejercicios = Array.isArray(datos.ejercicios) ? datos.ejercicios : [];
-          estadoModulo.tabla = Array.isArray(datos.tablas) ? datos.tablas : [];
-          poblarSelects();
-          renderizarTabla();
-          limpiarEstado();
-        } catch (error) {
-          console.error('Error al cargar SUMMARY', error);
-          mostrarEstado(error.message || 'Ocurrió un error al cargar la información.', 'danger');
-          estadoModulo.ejercicios = [];
-          estadoModulo.tabla = [];
-          poblarSelects();
-          renderizarTabla();
-        }
-      };
-
-      if (summaryYearSelect) {
-        summaryYearSelect.addEventListener('change', (event) => {
-          const seleccionado = event.target.value;
-          setAllYearSpans(seleccionado);      // <--- NUEVO
-          actualizarResumen(seleccionado);
-          if (filtroAnio && filtroAnio.value !== seleccionado) {
-            filtroAnio.value = seleccionado;
-          }
-        });
-      }
-      if (filtroAnio) {
-        filtroAnio.addEventListener('change', (event) => {
-          const seleccionado = event.target.value;
-          setAllYearSpans(seleccionado);      // <--- NUEVO
-          actualizarResumen(seleccionado);
-          if (summaryYearSelect && summaryYearSelect.value !== seleccionado) {
-            summaryYearSelect.value = seleccionado;
-          }
-        });
-      }
-
-
-      cargarDatos();
-      let selectedCell = null;
-      // Prevenir selección de texto al hacer doble click
-      table.addEventListener('mousedown', function (e) {
-        if (e.detail > 1) {
-          e.preventDefault();
-        }
-      });
-    });
-  </script>
-
-  <script>
-    // Sistema de identificadores tipo Excel y fórmulas
-    class ExcelTable {
-      constructor(tableId) {
-        this.table = document.getElementById(tableId);
-        this.cellMap = new Map(); // Mapa de ID -> celda
-        this.formulaMap = new Map(); // Mapa de ID -> fórmula
-        this.selectedCell = null;
-        this.init();
-      }
-
-      init() {
-        this.assignCellIds();
-        this.setupCellEditing();
-        this.setupFormulaBar();
-      }
-
-      // Asignar identificadores tipo Excel a cada celda
-      assignCellIds() {
-        const rows = this.table.querySelectorAll('tbody tr');
-
-        rows.forEach((row, rowIndex) => {
-          const cells = row.querySelectorAll('td, th');
-          cells.forEach((cell, colIndex) => {
-            const cellId = this.getCellId(rowIndex, colIndex);
-            cell.setAttribute('data-cell-id', cellId);
-            cell.setAttribute('title', `Celda: ${cellId}`);
-            this.cellMap.set(cellId, cell);
-          });
-        });
-      }
-
-      // Convertir coordenadas numéricas a ID tipo Excel (0,0 -> A1)
-      getCellId(row, col) {
-        let columnName = '';
-        let tempCol = col;
-
-        while (tempCol >= 0) {
-          columnName = String.fromCharCode(65 + (tempCol % 26)) + columnName;
-          tempCol = Math.floor(tempCol / 26) - 1;
-        }
-
-        return columnName + (row + 1);
-      }
-
-      // Convertir ID tipo Excel a coordenadas numéricas (A1 -> {row: 0, col: 0})
-      parseCellId(cellId) {
-        const match = cellId.match(/^([A-Z]+)(\d+)$/);
-        if (!match) return null;
-
-        const colStr = match[1];
-        const rowNum = parseInt(match[2]) - 1;
-
-        let col = 0;
-        for (let i = 0; i < colStr.length; i++) {
-          col = col * 26 + (colStr.charCodeAt(i) - 64);
-        }
-        col -= 1;
-
-        return { row: rowNum, col: col };
-      }
-
-      // Obtener valor de una celda por su ID
-      getCellValue(cellId) {
-        const cell = this.cellMap.get(cellId);
-        if (!cell) return 0;
-
-        const text = cell.textContent.trim().replace(/^ƒ\s*/, '');
-        const cleaned = text.replace(/[$,()]/g, '').replace(/%/g, '');
-        const num = parseFloat(cleaned);
-
-        return isNaN(num) ? 0 : num;
-      }
-
-      // Establecer valor en una celda
-      setCellValue(cellId, value) {
-        const cell = this.cellMap.get(cellId);
-        if (!cell) return;
-
-        if (typeof value === 'number') {
-          cell.textContent = this.formatNumber(value);
-        } else {
-          cell.textContent = value;
-        }
-      }
-
-      // Formatear número con comas y decimales
-      formatNumber(num) {
-        return num.toLocaleString('en-US', {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2
-        });
-      }
-
-      // Parsear rango de celdas (A1:A10)
-      parseRange(range) {
-        const [start, end] = range.split(':');
-        const startCoords = this.parseCellId(start);
-        const endCoords = this.parseCellId(end);
-
-        if (!startCoords || !endCoords) return [];
-
-        const cells = [];
-        for (let row = startCoords.row; row <= endCoords.row; row++) {
-          for (let col = startCoords.col; col <= endCoords.col; col++) {
-            cells.push(this.getCellId(row, col));
-          }
-        }
-        return cells;
-      }
-
-      // Funciones de Excel
-      excelFunctions = {
-        SUM: (range) => {
-          const cells = this.parseRange(range);
-          return cells.reduce((sum, cellId) => sum + this.getCellValue(cellId), 0);
-        },
-        AVG: (range) => {
-          const cells = this.parseRange(range);
-          const sum = cells.reduce((sum, cellId) => sum + this.getCellValue(cellId), 0);
-          return cells.length > 0 ? sum / cells.length : 0;
-        },
-        MAX: (range) => {
-          const cells = this.parseRange(range);
-          return Math.max(...cells.map(cellId => this.getCellValue(cellId)));
-        },
-        MIN: (range) => {
-          const cells = this.parseRange(range);
-          return Math.min(...cells.map(cellId => this.getCellValue(cellId)));
-        },
-        COUNT: (range) => {
-          const cells = this.parseRange(range);
-          return cells.filter(cellId => this.getCellValue(cellId) !== 0).length;
-        }
-      };
-
-      // Establecer fórmula en una celda
-      setFormula(cellId, formula) {
-        this.formulaMap.set(cellId, formula);
-        const cell = this.cellMap.get(cellId);
-        if (cell) {
-          cell.setAttribute('data-formula', formula);
-          cell.classList.add('formula-cell');
-        }
-        this.calculateFormula(cellId);
-      }
-
-      // Calcular fórmula
-      calculateFormula(cellId) {
-        const formula = this.formulaMap.get(cellId);
-        if (!formula) return;
-
-        try {
-          let expression = formula;
-
-          // Procesar funciones de Excel
-          Object.keys(this.excelFunctions).forEach(funcName => {
-            const regex = new RegExp(`${funcName}\\(([A-Z0-9:]+)\\)`, 'gi');
-            expression = expression.replace(regex, (match, range) => {
-              return this.excelFunctions[funcName.toUpperCase()](range);
-            });
-          });
-
-          // Reemplazar referencias de celdas simples por sus valores
-          expression = expression.replace(/([A-Z]+\d+)(?!:)/g, (match) => {
-            return this.getCellValue(match);
-          });
-
-          // Evaluar expresión
-          const result = eval(expression);
-          this.setCellValue(cellId, result);
-        } catch (error) {
-          console.error(`Error en fórmula ${cellId}: ${formula}`, error);
-          const cell = this.cellMap.get(cellId);
-          if (cell) cell.textContent = '#ERROR';
-        }
-      }
-
-      // Recalcular todas las fórmulas
-      recalculateAll() {
-        this.formulaMap.forEach((formula, cellId) => {
-          this.calculateFormula(cellId);
-        });
-      }
-
-      // Configurar barra de fórmulas
-      setupFormulaBar() {
-        const formulaBar = document.getElementById('formulaBar');
-        const currentCellId = document.getElementById('currentCellId');
-        const applyFormula = document.getElementById('applyFormula');
-        const clearFormula = document.getElementById('clearFormula');
-
-        // Actualizar barra al seleccionar celda
-        this.table.addEventListener('click', (e) => {
-          const cell = e.target.closest('td');
-          if (!cell) return;
-
-          if (this.selectedCell) {
-            this.selectedCell.classList.remove('selected');
-          }
-
-          this.selectedCell = cell;
-          cell.classList.add('selected');
-
-          const cellId = cell.getAttribute('data-cell-id');
-          const formula = cell.getAttribute('data-formula');
-
-          currentCellId.textContent = cellId;
-          formulaBar.value = formula ? '=' + formula : cell.textContent.trim().replace(/^ƒ\s*/, '');
-        });
-
-        // Aplicar fórmula desde la barra
-        applyFormula.addEventListener('click', () => {
-          if (!this.selectedCell) return;
-
-          const cellId = this.selectedCell.getAttribute('data-cell-id');
-          const value = formulaBar.value.trim();
-
-          if (value.startsWith('=')) {
-            const formula = value.substring(1);
-            this.setFormula(cellId, formula);
-          } else {
-            this.formulaMap.delete(cellId);
-            this.selectedCell.removeAttribute('data-formula');
-            this.selectedCell.classList.remove('formula-cell');
-            this.selectedCell.textContent = value;
-          }
-
-          this.recalculateAll();
-        });
-
-        // Enter en la barra de fórmulas
-        formulaBar.addEventListener('keydown', (e) => {
-          if (e.key === 'Enter') {
-            applyFormula.click();
-          }
-        });
-
-        // Limpiar fórmula
-        clearFormula.addEventListener('click', () => {
-          if (!this.selectedCell) return;
-
-          const cellId = this.selectedCell.getAttribute('data-cell-id');
-          this.formulaMap.delete(cellId);
-          this.selectedCell.removeAttribute('data-formula');
-          this.selectedCell.classList.remove('formula-cell');
-          this.selectedCell.textContent = '0.00';
-          formulaBar.value = '0.00';
-
-          this.recalculateAll();
-        });
-      }
-
-      // Configurar edición de celdas
-      setupCellEditing() {
-        this.table.addEventListener('dblclick', (e) => {
-          const cell = e.target.closest('td');
-          if (!cell) return;
-
-          const cellId = cell.getAttribute('data-cell-id');
-          const formula = cell.getAttribute('data-formula') || '';
-
-          const input = document.createElement('input');
-          input.type = 'text';
-          input.value = formula ? '=' + formula : cell.textContent.trim().replace(/^ƒ\s*/, '');
-          input.style.width = '100%';
-          input.style.border = '2px solid #2f6f4e';
-          input.style.padding = '4px';
-
-          cell.innerHTML = '';
-          cell.appendChild(input);
-          input.focus();
-          input.select();
-
-          const saveValue = () => {
-            const value = input.value.trim();
-
-            if (value.startsWith('=')) {
-              const formula = value.substring(1);
-              this.setFormula(cellId, formula);
-            } else {
-              this.formulaMap.delete(cellId);
-              cell.removeAttribute('data-formula');
-              cell.classList.remove('formula-cell');
-              cell.textContent = value;
-            }
-
-            this.recalculateAll();
-          };
-
-          input.addEventListener('blur', saveValue);
-          input.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') {
-              saveValue();
-            } else if (e.key === 'Escape') {
-              const originalValue = this.getCellValue(cellId);
-              cell.textContent = this.formatNumber(originalValue);
-            }
-          });
-        });
-      }
-
-      // Guardar fórmulas
-      saveFormulas() {
-        const formulasData = {};
-        this.formulaMap.forEach((formula, cellId) => {
-          formulasData[cellId] = formula;
-        });
-
-        const json = JSON.stringify(formulasData, null, 2);
-        const blob = new Blob([json], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'formulas_vista3.json';
-        a.click();
-        URL.revokeObjectURL(url);
-      }
-
-      // Cargar fórmulas
-      loadFormulas(jsonData) {
-        try {
-          const formulasData = JSON.parse(jsonData);
-          Object.entries(formulasData).forEach(([cellId, formula]) => {
-            this.setFormula(cellId, formula);
-          });
-          this.recalculateAll();
-        } catch (error) {
-          console.error('Error al cargar fórmulas:', error);
-          alert('Error al cargar el archivo de fórmulas');
-        }
-      }
-    }
-
-    // Script para selección de celdas y zoom
-    document.addEventListener('DOMContentLoaded', function () {
-      const table = document.getElementById('mainTable');
-      const tableWrapper = document.getElementById('tableWrapper');
-      const zoomInBtn = document.getElementById('zoomIn');
-      const zoomOutBtn = document.getElementById('zoomOut');
-      const zoomResetBtn = document.getElementById('zoomReset');
-      const zoomDisplay = document.getElementById('zoomDisplay');
-      const resumenAnualCard = document.getElementById('resumenAnualCard');
-      const summaryYearSelect = document.getElementById('summaryYearSelect');
-      const saldoValue = document.getElementById('saldoValue');
-      const acumuladoValue = document.getElementById('acumuladoValue');
-      const filtroAnio = document.getElementById('selectAnio');
-
-      // --- utilidades de año/mes ---
-      const setAllYearSpans = (anio) => {
-        document.querySelectorAll('.anio').forEach(sp => sp.textContent = anio);
-      };
-
-      // mapa “mes visible” -> periodo (1..13)
-      const MES_A_PERIODO = {
-        'enero': 1, 'febrero': 2, 'marzo': 3, 'abril': 4, 'mayo': 5, 'junio': 6,
-        'julio': 7, 'agosto': 8, 'septiembre': 9, 'octubre': 10, 'noviembre': 11, 'diciembre': 12,
-        'ajuste': 13
-      };
-
-
-      // Inicializar sistema Excel
-      const excelTable = new ExcelTable('mainTable');
-
-      // Hacer disponible globalmente para debugging
-      window.excelTable = excelTable;
-
-      // Botones de guardar/cargar fórmulas
-      document.getElementById('saveFormulas').addEventListener('click', () => {
-        excelTable.saveFormulas();
-      });
-
-      document.getElementById('loadFormulas').addEventListener('click', () => {
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = '.json';
-        input.onchange = (e) => {
-          const file = e.target.files[0];
-          if (file) {
-            const reader = new FileReader();
-            reader.onload = (event) => {
-              excelTable.loadFormulas(event.target.result);
-            };
-            reader.readAsText(file);
+          if (zoomDisplay) {
+            zoomDisplay.textContent = `${Math.round(zoomLevel * 100)}%`;
           }
         };
-        input.click();
-      });
 
-      let currentZoom = 1;
-      const zoomStep = 0.1;
-      const minZoom = 0.5;
-      const maxZoom = 2;
-
-      // Función para actualizar el zoom
-      function updateZoom(newZoom) {
-        currentZoom = Math.max(minZoom, Math.min(maxZoom, newZoom));
-        tableWrapper.style.transform = `scale(${currentZoom})`;
-        zoomDisplay.textContent = `${Math.round(currentZoom * 100)}%`;
-      }
-
-      // Eventos de zoom
-      zoomInBtn.addEventListener('click', () => {
-        updateZoom(currentZoom + zoomStep);
-      });
-
-      zoomOutBtn.addEventListener('click', () => {
-        updateZoom(currentZoom - zoomStep);
-      });
-
-      zoomResetBtn.addEventListener('click', () => {
-        updateZoom(1);
-      });
-
-      // Zoom con rueda del mouse (Ctrl + Scroll)
-      tableWrapper.addEventListener('wheel', (e) => {
-        if (e.ctrlKey) {
-          e.preventDefault();
-          const delta = e.deltaY > 0 ? -zoomStep : zoomStep;
-          updateZoom(currentZoom + delta);
-        }
-      });
-
-      // Deseleccionar al hacer click fuera de la tabla
-      document.addEventListener('click', function (e) {
-        if (!table.contains(e.target) && !document.getElementById('formulaBar').contains(e.target)) {
-          if (excelTable.selectedCell) {
-            excelTable.selectedCell.classList.remove('selected');
-            excelTable.selectedCell = null;
-            document.getElementById('currentCellId').textContent = '-';
-            document.getElementById('formulaBar').value = '';
-          }
-        }
-      });
-
-      // Prevenir selección de texto al hacer doble click
-      table.addEventListener('mousedown', function (e) {
-        if (e.detail > 1) {
-          e.preventDefault();
-        }
-      });
-
-      // Atajos de teclado
-      document.addEventListener('keydown', (e) => {
-        // Ctrl/Cmd + S para guardar fórmulas
-        if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-          e.preventDefault();
-          excelTable.saveFormulas();
-        }
-
-        // Ctrl/Cmd + Z para recalcular todo
-        if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
-          e.preventDefault();
-          excelTable.recalculateAll();
-        }
-
-        // Delete para limpiar celda seleccionada
-        if (e.key === 'Delete' && excelTable.selectedCell && !document.activeElement.matches('input')) {
-          e.preventDefault();
-          const cellId = excelTable.selectedCell.getAttribute('data-cell-id');
-          excelTable.formulaMap.delete(cellId);
-          excelTable.selectedCell.removeAttribute('data-formula');
-          excelTable.selectedCell.classList.remove('formula-cell');
-          excelTable.selectedCell.textContent = '0.00';
-          document.getElementById('formulaBar').value = '0.00';
-          excelTable.recalculateAll();
-        }
-
-        // F2 para editar celda seleccionada
-        if (e.key === 'F2' && excelTable.selectedCell) {
-          e.preventDefault();
-          const event = new MouseEvent('dblclick', {
-            bubbles: true,
-            cancelable: true,
-            view: window
+        if (zoomInBtn) {
+          zoomInBtn.addEventListener('click', () => {
+            zoomLevel = clampZoom(zoomLevel + 0.1);
+            renderZoom();
           });
-          excelTable.selectedCell.dispatchEvent(event);
         }
 
-        // Navegación con flechas
-        if (excelTable.selectedCell && !document.activeElement.matches('input')) {
-          const cellId = excelTable.selectedCell.getAttribute('data-cell-id');
-          const coords = excelTable.parseCellId(cellId);
-          let newCoords = null;
+        if (zoomOutBtn) {
+          zoomOutBtn.addEventListener('click', () => {
+            zoomLevel = clampZoom(zoomLevel - 0.1);
+            renderZoom();
+          });
+        }
 
-          if (e.key === 'ArrowUp' && coords.row > 0) {
-            newCoords = { row: coords.row - 1, col: coords.col };
-          } else if (e.key === 'ArrowDown') {
-            newCoords = { row: coords.row + 1, col: coords.col };
-          } else if (e.key === 'ArrowLeft' && coords.col > 0) {
-            newCoords = { row: coords.row, col: coords.col - 1 };
-          } else if (e.key === 'ArrowRight') {
-            newCoords = { row: coords.row, col: coords.col + 1 };
-          }
+        if (zoomResetBtn) {
+          zoomResetBtn.addEventListener('click', () => {
+            zoomLevel = 1;
+            renderZoom();
+          });
+        }
 
-          if (newCoords) {
-            e.preventDefault();
-            const newCellId = excelTable.getCellId(newCoords.row, newCoords.col);
-            const newCell = excelTable.cellMap.get(newCellId);
-            if (newCell) {
-              newCell.click();
-              newCell.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        if (table) {
+          table.addEventListener('click', (event) => {
+            const cell = event.target.closest('td, th');
+            if (!cell) return;
+            if (selectedCell) {
+              selectedCell.classList.remove('selected');
             }
-          }
+            selectedCell = cell;
+            selectedCell.classList.add('selected');
+          });
         }
-      });
 
-      // Mostrar mensaje de bienvenida en consola
-      console.log('%c📊 Sistema de Fórmulas Excel Activado', 'color: #2f6f4e; font-size: 16px; font-weight: bold;');
-      console.log('%cAtallos de teclado:', 'color: #b87333; font-weight: bold;');
-      console.log('  Ctrl+S: Guardar fórmulas');
-      console.log('  Ctrl+Z: Recalcular todo');
-      console.log('  Delete: Limpiar celda');
-      console.log('  F2: Editar celda');
-      console.log('  Flechas: Navegar entre celdas');
-      console.log('%cFunciones disponibles:', 'color: #b87333; font-weight: bold;');
-      console.log('  SUM(A1:A10), AVG(B1:B5), MAX(C1:C10), MIN(D1:D5), COUNT(E1:E10)');
-      console.log('%cEjemplos de uso:', 'color: #b87333; font-weight: bold;');
-      console.log('  excelTable.setFormula("F10", "SUM(B10:E10)")');
-      console.log('  excelTable.setFormula("G10", "AVG(C1:C20)")');
-      console.log('  excelTable.getCellValue("A5")');
-    });
+        document.addEventListener('click', (event) => {
+          if (!table || !selectedCell) return;
+          if (!table.contains(event.target)) {
+            selectedCell.classList.remove('selected');
+            selectedCell = null;
+          }
+        });
+
+        renderZoom();
+      });
+    })();
   </script>
+
+
 </body>
 
 </html>

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -196,6 +196,7 @@ function flattenForRender(tree) {
         tipo: 'categoria',
         estilo: row.estilo || estiloPorTipo(row.tipo),
         etiqueta: row.etiqueta || row.label || '',
+        tipoFila: row.tipo,
         // Métricas
         mesActual: metrics.mesActual,
         mesPlan: metrics.mesPlan,
@@ -214,6 +215,7 @@ function flattenForRender(tree) {
         tipo: 'detalle',
         codigo: row.codigo,
         descripcion: row.descripcion || '',
+        tipoFila: row.tipo,
         // Métricas
         mesActual: metrics.mesActual,
         mesPlan: metrics.mesPlan,
@@ -422,7 +424,9 @@ function renderizarTabla() {
     const tr = document.createElement('tr');
 
     if (fila.tipo === 'categoria') {
-      tr.className = fila.estilo || THEME.categoria;
+      const clases = [fila.estilo || THEME.categoria];
+      if (fila.tipoFila) clases.push(`fila-${fila.tipoFila}`);
+      tr.className = clases.join(' ');
       tr.innerHTML = `
         <th></th>
         <td class="mono">${formatearMoneda(fila.mesActual)}</td>
@@ -438,6 +442,9 @@ function renderizarTabla() {
         <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionAnterior)}</td>
       `;
     } else {
+      const clases = [];
+      if (fila.tipoFila && fila.tipoFila !== 'detalle') clases.push(`fila-${fila.tipoFila}`);
+      if (clases.length) tr.className = clases.join(' ');
       tr.innerHTML = `
         <th class="code-cell">${fila.codigo || ''}</th>
         <td class="mono">${formatearMoneda(fila.mesActual)}</td>


### PR DESCRIPTION
## Summary
- cast derived account list parameters to VARCHAR to prevent Firebird type errors when loading summary data
- restyle the summary table to match the accounting hierarchy colors and indentation while removing the formula toolbar
- simplify the inline summary page script so the UI stays read-only except for zoom and basic highlighting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690be61381d4832d8f5efe6c2a763341