### PR TITLE
Integrate budget plan data into summary endpoint

### DIFF
--- a/src/routes/modulos.js
+++ b/src/routes/modulos.js
@@ -1,8 +1,51 @@
 const express = require('express');
 const { listarModulos, obtenerDatosModulo } = require('../services/modulosService');
 const { obtenerResumen, listarAniosSALDOS } = require('../services/summaryService');
+const { obtenerPresupuestosMayor } = require('../services/presupuestosService');
 
 const router = express.Router();
+
+const CLAVES_PLAN = {
+  1: 'ene',
+  2: 'feb',
+  3: 'mar',
+  4: 'abr',
+  5: 'may',
+  6: 'jun',
+  7: 'jul',
+  8: 'ago',
+  9: 'sep',
+  10: 'oct',
+  11: 'nov',
+  12: 'dic',
+  13: 'anual'
+};
+
+const normalizarTexto = (valor) => (valor == null ? '' : String(valor).trim());
+const normalizarCodigo = (valor) => normalizarTexto(valor);
+const normalizarNaturaleza = (valor) => normalizarTexto(valor).toUpperCase();
+const numeroSeguro = (valor) => {
+  const numero = Number(valor);
+  return Number.isFinite(numero) ? numero : 0;
+};
+
+const clavePlanPorPeriodo = (periodo) => {
+  const p = Math.max(1, Math.min(13, Number(periodo) || 1));
+  return CLAVES_PLAN[p] || 'anual';
+};
+
+const obtenerYtdPlan = (registro, periodo) => {
+  const clave = clavePlanPorPeriodo(periodo);
+  if (clave === 'anual') return numeroSeguro(registro.anual);
+  return numeroSeguro(registro[clave]);
+};
+
+const obtenerMesPlan = (registro, periodo) => {
+  const ytdActual = obtenerYtdPlan(registro, periodo);
+  if (periodo <= 1) return ytdActual;
+  const ytdPrevio = obtenerYtdPlan(registro, periodo - 1);
+  return ytdActual - ytdPrevio;
+};
 
 router.get('/', (req, res) => {
   res.json({ modulos: listarModulos() });
@@ -57,8 +100,51 @@ router.post('/summary-resumen-e', async (req, res) => {
       anioComparativo,
       usarAjusteEnYTD: Boolean(usarAjusteEnYTD)
     });
+    const presupuestos = await obtenerPresupuestosMayor(empresaId, ejercicio);
+    const mapaPlan = new Map(
+      (presupuestos || []).map((registro) => [normalizarCodigo(registro.numCta), registro])
+    );
 
-    res.json(resultado);
+    const detalle = (resultado.detalle || []).map((fila) => {
+      const codigo = normalizarCodigo(fila.codigo);
+      const plan = mapaPlan.get(codigo);
+      const descripcionPlan = plan ? normalizarTexto(plan.descripcion) : '';
+      const naturalezaPlan = plan ? normalizarNaturaleza(plan.naturaleza) : '';
+      const descripcion = normalizarTexto(fila.descripcion) || descripcionPlan;
+      const naturaleza = normalizarNaturaleza(fila.naturaleza || naturalezaPlan);
+      let acumuladoPlan = numeroSeguro(fila.acumuladoPlan);
+      let mesPlan = numeroSeguro(fila.mesPlan);
+      if (plan) {
+        acumuladoPlan = obtenerYtdPlan(plan, periodoNum);
+        mesPlan = obtenerMesPlan(plan, periodoNum);
+      }
+
+      const acumuladoActual = numeroSeguro(fila.acumuladoActual);
+      const acumuladoAnterior = numeroSeguro(fila.acumuladoAnterior);
+      const mesActual = numeroSeguro(fila.mesActual);
+      const mesAnterior = numeroSeguro(fila.mesAnterior);
+
+      return {
+        ...fila,
+        codigo,
+        descripcion,
+        naturaleza,
+        mesActual,
+        mesPlan,
+        mesAnterior,
+        acumuladoActual,
+        acumuladoPlan,
+        acumuladoAnterior,
+        ytdActual: numeroSeguro(fila.ytdActual != null ? fila.ytdActual : acumuladoActual),
+        ytdPlan: acumuladoPlan,
+        ytdAnterior: numeroSeguro(fila.ytdAnterior != null ? fila.ytdAnterior : acumuladoAnterior)
+      };
+    });
+
+    res.json({
+      ...resultado,
+      detalle
+    });
   } catch (error) {
     console.error('Error en summary-resumen-e:', error);
     res.status(500).json({ mensaje: 'No fue posible obtener el resumen solicitado.' });

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -66,6 +66,7 @@ const construirSelectResumen = ({ anio, periodo, usarAjusteEnYTD, codigos }) => 
     SELECT
       t.NUM_CTA AS CODIGO,
       c.NOMBRE AS DESCRIPCION,
+      c.NATURALEZA,
       ${exprMes} AS MES,
       ${exprYtd} AS YTD
     FROM (${sqlCodigos}) t
@@ -86,9 +87,12 @@ const mapearResultados = (filas = []) => {
   filas.forEach((r) => {
     const codigo = String(r.CODIGO || '').trim();
     if (!codigo) return;
+    const descripcion = (r.DESCRIPCION || '').toString();
+    const naturaleza = (r.NATURALEZA || '').toString();
     mapa.set(codigo, {
       codigo,
-      descripcion: (r.DESCRIPCION || '').toString(),
+      descripcion,
+      naturaleza,
       mes: Number(r.MES ?? 0) || 0,
       ytd: Number(r.YTD ?? 0) || 0
     });
@@ -117,33 +121,62 @@ async function obtenerResumen({ empresaId, anio, periodo, codigos = [], anioComp
   const mapaComp = mapearResultados(filasComp);
 
   // Armar detalle por código
+  const normalizarTexto = (valor) => (valor == null ? '' : String(valor).trim());
+  const normalizarNaturaleza = (valor) => {
+    const txt = normalizarTexto(valor).toUpperCase();
+    if (txt === 'A' || txt === 'D' || txt === 'C') return txt;
+    return txt;
+  };
   const detalle = listaCodigos.map((codigo) => {
     // Para cada código devolvemos los saldos del ejercicio actual y del comparativo.
     // Esto alimenta cada "celda" de la tabla en el front, que después puede aplicar
     // lógica adicional (sumas, porcentajes, etc.) sobre estos importes base.
     const a = mapaActual.get(codigo) || { codigo, descripcion: '', mes: 0, ytd: 0 };
     const b = mapaComp.get(codigo) || { codigo, descripcion: '', mes: 0, ytd: 0 };
+    const descripcion = normalizarTexto(a.descripcion || b.descripcion || '');
+    const naturaleza = normalizarNaturaleza(a.naturaleza || b.naturaleza || '');
+    const mesActual = Number(a.mes || 0);
+    const mesAnterior = Number(b.mes || 0);
+    const acumuladoActual = Number(a.ytd || 0);
+    const acumuladoAnterior = Number(b.ytd || 0);
     return {
       codigo,
-      descripcion: a.descripcion || b.descripcion || '',
-      mesActual: a.mes || 0,
+      descripcion,
+      naturaleza,
+      mesActual,
       mesPlan: 0,
-      mesAnterior: b.mes || 0,
-      acumuladoActual: a.ytd || 0,
+      mesAnterior,
+      acumuladoActual,
       acumuladoPlan: 0,
-      acumuladoAnterior: b.ytd || 0
+      acumuladoAnterior,
+      ytdActual: acumuladoActual,
+      ytdPlan: 0,
+      ytdAnterior: acumuladoAnterior
     };
   });
 
   // El widget de tarjetas muestra el acumulado del ejercicio actual; aquí lo calculamos
   // sumando el YTD de todos los códigos para el año base.
   const totalAcumulado = detalle.reduce((acc, it) => acc + (Number(it.acumuladoActual) || 0), 0);
+  const totalAcumuladoAnterior = detalle.reduce((acc, it) => acc + (Number(it.acumuladoAnterior) || 0), 0);
 
   const ejercicios = [
     { anio: ejercicio, saldo: totalAcumulado, acumulado: totalAcumulado }
   ];
+  if (Number.isFinite(totalAcumuladoAnterior)) {
+    ejercicios.push({ anio: comp, saldo: totalAcumuladoAnterior, acumulado: totalAcumuladoAnterior });
+  }
 
-  return { detalle, ejercicios };
+  const ejerciciosDisponibles = await listarAniosSALDOS(empresaId);
+
+  return {
+    anio: ejercicio,
+    periodo: periodoNum,
+    anioComparativo: comp,
+    detalle,
+    ejercicios,
+    ejerciciosDisponibles
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- enrich the summary service with naturaleza, YTD aliases, and available exercises metadata
- merge actual balances with budget plans in the summary-resumen-e endpoint, normalizing values before responding

## Testing
- npm test # Missing script: "test"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912162458b0832db1840dbf5a83a565)