### PR TITLE
Consolidate Summary_E01 engine and layout logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "",
   "scripts": {
     "start": "electron .",
+    "test": "node --test",
     "pack": "electron-builder --dir",
     "dist": "electron-builder --win portable",
     "postinstall": "electron-builder install-app-deps"

--- a/tests/summary-engine-core.test.js
+++ b/tests/summary-engine-core.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildSummaryRows,
+  collectCodes,
+  safeDiv,
+  variationPercent
+} = require('../vistas/js/summary-engine-core.js');
+
+const SAMPLE_LAYOUT = [
+  { id: 'ING', tipo: 'categoria', titulo: 'INGRESOS', componentes: ['ING_A', 'ING_B'] },
+  { id: 'ING_A', tipo: 'cuenta', codigo: '401', titulo: 'Ingreso A', padre: 'ING' },
+  { id: 'ING_B', tipo: 'cuenta', codigo: '402', titulo: 'Ingreso B', padre: 'ING' },
+  { id: 'ING_SUB', tipo: 'subtotal', titulo: 'Total Ingresos', padre: 'ING', componentes: ['ING_A', 'ING_B'] },
+  { id: 'GAS', tipo: 'categoria', titulo: 'GASTOS', componentes: ['GAS_A'] },
+  { id: 'GAS_A', tipo: 'cuenta', codigo: '501', titulo: 'Gasto A', padre: 'GAS' },
+  { id: 'GAS_SUB', tipo: 'subtotal', titulo: 'Total Gastos', padre: 'GAS', componentes: ['GAS_A'] },
+  { id: 'RESULT', tipo: 'categoria', titulo: 'RESULTADO', componentes: ['UTI'] },
+  { id: 'UTI', tipo: 'total', titulo: 'Utilidad', padre: 'RESULT', componentes: ['ING_SUB', 'GAS_SUB'] },
+  { id: 'KPIS', tipo: 'categoria', titulo: 'INDICADORES', componentes: [] },
+  {
+    id: 'KPI_YTD_PLAN',
+    tipo: 'kpi',
+    titulo: '% YTD vs Plan',
+    padre: 'KPIS',
+    formula: 'UTI.acumuladoActual / UTI.acumuladoPlan',
+    columnaYtd: 'acumuladoVariacionPlan',
+    factor: 100
+  },
+  {
+    id: 'KPI_MES_ANT',
+    tipo: 'kpi',
+    titulo: '% Mes vs Año Anterior',
+    padre: 'KPIS',
+    formulaMes: 'UTI.mesActual / UTI.mesAnterior',
+    columnaMes: 'mesVariacionAnterior',
+    factor: 100
+  }
+];
+
+const DETALLE_BASE = [
+  {
+    codigo: '401',
+    descripcion: 'Ingreso A',
+    mesActual: 100,
+    mesPlan: 90,
+    mesAnterior: 80,
+    acumuladoActual: 300,
+    acumuladoPlan: 270,
+    acumuladoAnterior: 240
+  },
+  {
+    codigo: '402',
+    descripcion: 'Ingreso B',
+    mesActual: 50,
+    mesPlan: 40,
+    mesAnterior: 55,
+    acumuladoActual: 120,
+    acumuladoPlan: 100,
+    acumuladoAnterior: 110
+  },
+  {
+    codigo: '501',
+    descripcion: 'Gasto A',
+    mesActual: -30,
+    mesPlan: -25,
+    mesAnterior: -20,
+    acumuladoActual: -90,
+    acumuladoPlan: -80,
+    acumuladoAnterior: -60
+  }
+];
+
+test('collectCodes devuelve códigos únicos', () => {
+  const codigos = collectCodes(SAMPLE_LAYOUT);
+  assert.deepEqual(codigos.sort(), ['401', '402', '501']);
+});
+
+test('suma jerárquica y KPIs', () => {
+  const filas = buildSummaryRows(SAMPLE_LAYOUT, DETALLE_BASE);
+  const mapa = new Map(filas.map((fila) => [fila.rowId, fila]));
+
+  assert.strictEqual(mapa.get('ING_SUB').mesActual, 150);
+  assert.strictEqual(mapa.get('GAS_SUB').mesActual, -30);
+  assert.strictEqual(mapa.get('UTI').mesActual, 120);
+  assert.strictEqual(mapa.get('UTI').acumuladoActual, 330);
+
+  const kpiYtd = mapa.get('KPI_YTD_PLAN');
+  assert.ok(Math.abs(kpiYtd.acumuladoVariacionPlan - 113.793103) < 1e-3);
+
+  const kpiMesAnt = mapa.get('KPI_MES_ANT');
+  assert.ok(Math.abs(kpiMesAnt.mesVariacionAnterior - 104.347826) < 1e-3);
+
+  assert.strictEqual(mapa.get('ING').depth, 0);
+  assert.strictEqual(mapa.get('ING_A').depth, 1);
+});
+
+test('variaciones seguras y divisiones', () => {
+  assert.strictEqual(safeDiv(10, 0), 0);
+  assert.strictEqual(variationPercent(100, 0), 0);
+  assert.ok(Math.abs(variationPercent(150, 130) - 15.384615) < 1e-6);
+});
+
+test('manejo de cuentas faltantes', () => {
+  const detalle = DETALLE_BASE.filter((item) => item.codigo !== '402');
+  const filas = buildSummaryRows(SAMPLE_LAYOUT, detalle);
+  const mapa = new Map(filas.map((fila) => [fila.rowId, fila]));
+  assert.strictEqual(mapa.get('ING_B').mesActual, 0);
+  assert.strictEqual(mapa.get('ING_SUB').mesActual, 100);
+});

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -418,8 +418,16 @@
                   <option>2019</option>
                 </select>
               </div>
+              <div class="col-sm-6 col-lg-3">
+                <div class="form-check mt-4">
+                  <input class="form-check-input" type="checkbox" id="chkAjuste">
+                  <label class="form-check-label" for="chkAjuste">
+                    Incluir ajuste en YTD
+                  </label>
+                </div>
+              </div>
               <!-- Botón Aplicar eliminado: cambios se aplican en tiempo real -->
-              <div class="col-sm-12 col-lg-3">
+              <div class="col-sm-6 col-lg-3">
                 <button id="btnReset" type="button"
                   class="btn btn-outline-secondary w-100 fw-semibold">Restablecer</button>
               </div>
@@ -553,6 +561,8 @@
   </div>
 
   <script src="js/sesion.js"></script>
+  <script src="js/summary-engine-core.js"></script>
+  <script src="js/summary-layout.js"></script>
   <script src="js/summary.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>

--- a/vistas/js/summary-engine-core.js
+++ b/vistas/js/summary-engine-core.js
@@ -1,0 +1,321 @@
+(function (global, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    global.SummaryEngineCore = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const ZERO_METRICS = {
+    mesActual: 0,
+    mesPlan: 0,
+    mesAnterior: 0,
+    mesVariacionPlan: 0,
+    mesVariacionAnterior: 0,
+    acumuladoActual: 0,
+    acumuladoPlan: 0,
+    acumuladoAnterior: 0,
+    acumuladoVariacionPlan: 0,
+    acumuladoVariacionAnterior: 0,
+    ytdActual: 0,
+    ytdPlan: 0,
+    ytdAnterior: 0
+  };
+
+  const toNumber = (valor) => {
+    const numero = Number(valor);
+    return Number.isFinite(numero) ? numero : 0;
+  };
+
+  function zeroMetrics() {
+    return { ...ZERO_METRICS };
+  }
+
+  function ensureAlias(metrics) {
+    metrics.ytdActual = toNumber(metrics.ytdActual != null ? metrics.ytdActual : metrics.acumuladoActual);
+    metrics.ytdPlan = toNumber(metrics.ytdPlan != null ? metrics.ytdPlan : metrics.acumuladoPlan);
+    metrics.ytdAnterior = toNumber(metrics.ytdAnterior != null ? metrics.ytdAnterior : metrics.acumuladoAnterior);
+    return metrics;
+  }
+
+  function sumMetrics(destino, fuente) {
+    destino.mesActual += toNumber(fuente.mesActual);
+    destino.mesPlan += toNumber(fuente.mesPlan);
+    destino.mesAnterior += toNumber(fuente.mesAnterior);
+    destino.acumuladoActual += toNumber(fuente.acumuladoActual);
+    destino.acumuladoPlan += toNumber(fuente.acumuladoPlan);
+    destino.acumuladoAnterior += toNumber(fuente.acumuladoAnterior);
+    destino.ytdActual += toNumber(fuente.ytdActual != null ? fuente.ytdActual : fuente.acumuladoActual);
+    destino.ytdPlan += toNumber(fuente.ytdPlan != null ? fuente.ytdPlan : fuente.acumuladoPlan);
+    destino.ytdAnterior += toNumber(fuente.ytdAnterior != null ? fuente.ytdAnterior : fuente.acumuladoAnterior);
+    return destino;
+  }
+
+  function safeDiv(numerador, denominador) {
+    const num = Number(numerador || 0);
+    const den = Number(denominador || 0);
+    if (!Number.isFinite(den) || Math.abs(den) === 0) return 0;
+    return num / den;
+  }
+
+  function variationPercent(actual, base) {
+    const a = Number(actual || 0);
+    const b = Number(base || 0);
+    if (Math.abs(b) === 0) return 0;
+    return safeDiv(a - b, Math.abs(b)) * 100;
+  }
+
+  function collectCodes(layout) {
+    if (!Array.isArray(layout)) return [];
+    const codigos = [];
+    layout.forEach((item) => {
+      if (item && String(item.tipo || '').toLowerCase() === 'cuenta' && item.codigo) {
+        const codigo = String(item.codigo).trim();
+        if (codigo) codigos.push(codigo);
+      }
+    });
+    return codigos;
+  }
+
+  const TOKEN_REGEX = /[A-Za-z_][\w]*\.[A-Za-z_][\w]*|\d+\.\d+|\d+|[()+\-*/]/g;
+  const PREC = { '+': 1, '-': 1, '*': 2, '/': 2 };
+
+  function evaluateFormula(expresion, rowsOut) {
+    if (!expresion || typeof expresion !== 'string') return 0;
+    const tokens = expresion.match(TOKEN_REGEX) || [];
+    const output = [];
+    const operadores = [];
+
+    const flushOperadores = (op) => {
+      while (operadores.length > 0) {
+        const top = operadores[operadores.length - 1];
+        if (top === '(') break;
+        if (PREC[top] >= PREC[op]) {
+          output.push(operadores.pop());
+        } else {
+          break;
+        }
+      }
+    };
+
+    tokens.forEach((token) => {
+      if (token === '(') {
+        operadores.push(token);
+      } else if (token === ')') {
+        while (operadores.length > 0 && operadores[operadores.length - 1] !== '(') {
+          output.push(operadores.pop());
+        }
+        operadores.pop();
+      } else if (PREC[token]) {
+        flushOperadores(token);
+        operadores.push(token);
+      } else {
+        output.push(token);
+      }
+    });
+
+    while (operadores.length > 0) {
+      output.push(operadores.pop());
+    }
+
+    const pila = [];
+    output.forEach((token) => {
+      if (PREC[token]) {
+        const b = pila.pop();
+        const a = pila.pop();
+        if (token === '+') pila.push(a + b);
+        else if (token === '-') pila.push(a - b);
+        else if (token === '*') pila.push(a * b);
+        else if (token === '/') pila.push(safeDiv(a, b));
+      } else if (/^[A-Za-z_][\w]*\.[A-Za-z_][\w]*$/.test(token)) {
+        const [id, campo] = token.split('.');
+        const fila = rowsOut && rowsOut[id] ? rowsOut[id] : {};
+        pila.push(toNumber(fila[campo]));
+      } else {
+        pila.push(toNumber(token));
+      }
+    });
+
+    return toNumber(pila.pop());
+  }
+
+  function extraerIds(expresion, set) {
+    if (!expresion || typeof expresion !== 'string') return;
+    const coincidencias = expresion.match(/[A-Za-z_][\w]*\.[A-Za-z_][\w]*/g) || [];
+    coincidencias.forEach((item) => {
+      const [id] = item.split('.');
+      if (id) set.add(id);
+    });
+  }
+
+  function buildSummaryRows(layout, detalle, opciones = {}) {
+    const layoutArray = Array.isArray(layout) ? layout : [];
+    const indicePorCodigo = new Map();
+    (Array.isArray(detalle) ? detalle : []).forEach((registro) => {
+      const codigo = registro && registro.codigo != null ? String(registro.codigo).trim() : '';
+      if (codigo) indicePorCodigo.set(codigo, registro);
+    });
+
+    const nodosPorId = new Map();
+    layoutArray.forEach((item) => {
+      if (item && item.id) nodosPorId.set(item.id, { ...item });
+    });
+
+    const hijosPorPadre = new Map();
+    layoutArray.forEach((item) => {
+      if (!item || !item.id) return;
+      const padre = item.padre || null;
+      if (!hijosPorPadre.has(padre)) hijosPorPadre.set(padre, []);
+      hijosPorPadre.get(padre).push(item.id);
+    });
+
+    const cache = new Map();
+
+    const obtenerComponentes = (nodo, tipo) => {
+      if (Object.prototype.hasOwnProperty.call(nodo, 'componentes')) {
+        return Array.isArray(nodo.componentes) ? nodo.componentes : [];
+      }
+      const hijos = hijosPorPadre.get(nodo.id) || [];
+      if (tipo === 'categoria') return hijos;
+      return hijos.filter((idHijo) => {
+        const info = nodosPorId.get(idHijo);
+        if (!info) return false;
+        const t = String(info.tipo || '').toLowerCase();
+        return t !== 'kpi';
+      });
+    };
+
+    const construirContextoFormulas = () => {
+      const contexto = {};
+      cache.forEach((valor, id) => {
+        contexto[id] = ensureAlias({ ...valor.metrics });
+      });
+      return contexto;
+    };
+
+    const calcularNodo = (id) => {
+      if (cache.has(id)) return cache.get(id);
+      const nodo = nodosPorId.get(id);
+      if (!nodo) {
+        const vacio = { metrics: ensureAlias(zeroMetrics()), meta: { tipoFila: 'categoria', etiqueta: id } };
+        cache.set(id, vacio);
+        return vacio;
+      }
+
+      const tipo = String(nodo.tipo || '').toLowerCase();
+      const metrics = ensureAlias(zeroMetrics());
+      const meta = {
+        tipoFila: tipo,
+        etiqueta: nodo.titulo || nodo.etiqueta || ''
+      };
+
+      if (tipo === 'cuenta') {
+        const codigo = nodo.codigo ? String(nodo.codigo).trim() : '';
+        const registro = codigo ? indicePorCodigo.get(codigo) : null;
+        metrics.mesActual = toNumber(registro?.mesActual);
+        metrics.mesPlan = toNumber(registro?.mesPlan);
+        metrics.mesAnterior = toNumber(registro?.mesAnterior);
+        metrics.acumuladoActual = toNumber(registro?.acumuladoActual ?? registro?.ytdActual);
+        metrics.acumuladoPlan = toNumber(registro?.acumuladoPlan ?? registro?.ytdPlan);
+        metrics.acumuladoAnterior = toNumber(registro?.acumuladoAnterior ?? registro?.ytdAnterior);
+        ensureAlias(metrics);
+        meta.tipoFila = 'detalle';
+        meta.codigo = codigo;
+        const descripcion = registro?.descripcion || nodo.titulo || '';
+        meta.descripcion = descripcion;
+        if (!meta.etiqueta) meta.etiqueta = descripcion;
+        meta.naturaleza = registro?.naturaleza || '';
+      } else if (tipo === 'kpi') {
+        const dependencias = new Set();
+        extraerIds(nodo.formula, dependencias);
+        extraerIds(nodo.formulaMes, dependencias);
+        dependencias.forEach((dep) => calcularNodo(dep));
+        const contexto = construirContextoFormulas();
+        const factor = nodo.factor != null ? Number(nodo.factor) : 1;
+        if (nodo.formula) {
+          const columna = nodo.columnaYtd || nodo.columna || 'acumuladoActual';
+          metrics[columna] = factor * evaluateFormula(nodo.formula, contexto);
+        }
+        if (nodo.formulaMes) {
+          const columnaMes = nodo.columnaMes || 'mesActual';
+          metrics[columnaMes] = factor * evaluateFormula(nodo.formulaMes, contexto);
+        }
+        ensureAlias(metrics);
+        meta.tipoFila = 'kpi';
+      } else {
+        const componentes = obtenerComponentes(nodo, tipo);
+        componentes.forEach((idHijo) => {
+          if (idHijo === nodo.id) return;
+          const infoHijo = calcularNodo(idHijo);
+          sumMetrics(metrics, infoHijo.metrics);
+        });
+        ensureAlias(metrics);
+        if (tipo !== 'categoria') meta.tipoFila = tipo;
+        if (!meta.etiqueta) meta.etiqueta = nodo.titulo || nodo.id;
+      }
+
+      const resultado = { metrics, meta };
+      cache.set(id, resultado);
+      return resultado;
+    };
+
+    const salida = [];
+    const estiloPorTipo = typeof opciones.estiloPorTipo === 'function' ? opciones.estiloPorTipo : () => undefined;
+
+    const recorrer = (padre, depth) => {
+      const hijos = hijosPorPadre.get(padre) || [];
+      hijos.forEach((idHijo) => {
+        const nodo = nodosPorId.get(idHijo);
+        if (!nodo) return;
+        const info = calcularNodo(idHijo);
+        const metrics = ensureAlias({ ...zeroMetrics(), ...info.metrics });
+        const tipoFila = info.meta.tipoFila || String(nodo.tipo || '').toLowerCase();
+        const esKpi = tipoFila === 'kpi';
+        const fila = {
+          rowId: idHijo,
+          tipoFila,
+          tipo: tipoFila === 'detalle' ? 'detalle' : 'categoria',
+          estilo: nodo.estilo || estiloPorTipo(tipoFila),
+          codigo: info.meta.codigo || '',
+          descripcion: info.meta.descripcion || '',
+          etiqueta: info.meta.etiqueta || info.meta.descripcion || '',
+          naturaleza: info.meta.naturaleza || '',
+          depth,
+          ...metrics
+        };
+
+        if (!esKpi) {
+          fila.mesVariacionPlan = variationPercent(fila.mesActual, fila.mesPlan);
+          fila.mesVariacionAnterior = variationPercent(fila.mesActual, fila.mesAnterior);
+          fila.acumuladoVariacionPlan = variationPercent(fila.acumuladoActual, fila.acumuladoPlan);
+          fila.acumuladoVariacionAnterior = variationPercent(fila.acumuladoActual, fila.acumuladoAnterior);
+        } else {
+          fila.mesVariacionPlan = toNumber(fila.mesVariacionPlan);
+          fila.mesVariacionAnterior = toNumber(fila.mesVariacionAnterior);
+          fila.acumuladoVariacionPlan = toNumber(fila.acumuladoVariacionPlan);
+          fila.acumuladoVariacionAnterior = toNumber(fila.acumuladoVariacionAnterior);
+        }
+
+        salida.push(fila);
+
+        const tipoNodo = String(nodo.tipo || '').toLowerCase();
+        if (tipoNodo === 'categoria') {
+          recorrer(idHijo, depth + 1);
+        }
+      });
+    };
+
+    recorrer(null, 0);
+    return salida;
+  }
+
+  return {
+    zeroMetrics,
+    safeDiv,
+    variationPercent,
+    evaluateFormula,
+    collectCodes,
+    buildSummaryRows
+  };
+});

--- a/vistas/js/summary-layout.js
+++ b/vistas/js/summary-layout.js
@@ -1,34 +1,103 @@
-export const LAYOUT = [
-  // ===== INGRESOS =====
-  { id: 'ING', tipo: 'categoria', titulo: 'INGRESOS' },
+(function (global) {
+  const ingresosDetalle = [
+    { id: 'ING_401000000000000000001', tipo: 'cuenta', codigo: '401000000000000000001', titulo: 'Cuotas Netas', padre: 'ING' },
+    { id: 'ING_402000000000000000001', tipo: 'cuenta', codigo: '402000000000000000001', titulo: 'Ingresos Socios Nuevos', padre: 'ING' },
+    { id: 'ING_412000000000000000001', tipo: 'cuenta', codigo: '412000000000000000001', titulo: 'Reingresos', padre: 'ING' },
+    { id: 'ING_407000000000000000001', tipo: 'cuenta', codigo: '407000000000000000001', titulo: 'Eventos', padre: 'ING' },
+    { id: 'ING_408000000000000000001', tipo: 'cuenta', codigo: '408000000000000000001', titulo: 'Patrocinios', padre: 'ING' },
+    { id: 'ING_417000000000000000001', tipo: 'cuenta', codigo: '417000000000000000001', titulo: 'Otros Ingresos Operativos', padre: 'ING' },
+    { id: 'ING_403000000000000000001', tipo: 'cuenta', codigo: '403000000000000000001', titulo: 'Servicios', padre: 'ING' },
+    { id: 'ING_409000000000000000001', tipo: 'cuenta', codigo: '409000000000000000001', titulo: 'Productos Comerciales', padre: 'ING' },
+    { id: 'ING_406000000000000000001', tipo: 'cuenta', codigo: '406000000000000000001', titulo: 'Ingresos Diversos', padre: 'ING' },
+    { id: 'ING_705000000000000000001', tipo: 'cuenta', codigo: '705000000000000000001', titulo: 'Recuperaciones', padre: 'ING' },
+    { id: 'ING_701000000000000000001', tipo: 'cuenta', codigo: '701000000000000000001', titulo: 'Ingresos Financieros', padre: 'ING' },
+    { id: 'ING_702000000000000000001', tipo: 'cuenta', codigo: '702000000000000000001', titulo: 'Ingresos Por Cambios', padre: 'ING' },
+    { id: 'ING_704000000000000000001', tipo: 'cuenta', codigo: '704000000000000000001', titulo: 'Otros Productos', padre: 'ING' },
+    { id: 'ING_901000000000000000001', tipo: 'cuenta', codigo: '901000000000000000001', titulo: 'Otros Ingresos No Operativos', padre: 'ING' },
+    { id: 'ING_413000000000000000001', tipo: 'cuenta', codigo: '413000000000000000001', titulo: 'Reembolsos', padre: 'ING' },
+    { id: 'ING_414000000000000000001', tipo: 'cuenta', codigo: '414000000000000000001', titulo: 'Recuperación de Costos', padre: 'ING' },
+    { id: 'ING_416000000000000000001', tipo: 'cuenta', codigo: '416000000000000000001', titulo: 'Ingresos Especiales', padre: 'ING' },
+    { id: 'ING_418000000000000000001', tipo: 'cuenta', codigo: '418000000000000000001', titulo: 'Otros Ingresos', padre: 'ING' }
+  ];
 
-  // Detalle (pon aquí tus códigos reales)
-  { id: 'ING_MEM', tipo: 'cuenta', codigo: '400-000-000-00', titulo: 'Membresías', padre: 'ING' },
-  { id: 'ING_OTR', tipo: 'cuenta', codigo: '402-000-000-00', titulo: 'Otros ingresos', padre: 'ING' },
+  const gastosDetalle = [
+    { id: 'GAS_450001000000000000002', tipo: 'cuenta', codigo: '450001000000000000002', titulo: 'Costos Directos 1', padre: 'GAS' },
+    { id: 'GAS_450002000000000000002', tipo: 'cuenta', codigo: '450002000000000000002', titulo: 'Costos Directos 2', padre: 'GAS' },
+    { id: 'GAS_601000000000000000001', tipo: 'cuenta', codigo: '601000000000000000001', titulo: 'Costos Administrativos', padre: 'GAS' },
+    { id: 'GAS_801001000000000000002', tipo: 'cuenta', codigo: '801001000000000000002', titulo: 'Gasto Operativo 1', padre: 'GAS' },
+    { id: 'GAS_801002000000000000002', tipo: 'cuenta', codigo: '801002000000000000002', titulo: 'Gasto Operativo 2', padre: 'GAS' },
+    { id: 'GAS_801003000000000000002', tipo: 'cuenta', codigo: '801003000000000000002', titulo: 'Gasto Operativo 3', padre: 'GAS' },
+    { id: 'GAS_801004000000000000002', tipo: 'cuenta', codigo: '801004000000000000002', titulo: 'Gasto Operativo 4', padre: 'GAS' },
+    { id: 'GAS_801005000000000000002', tipo: 'cuenta', codigo: '801005000000000000002', titulo: 'Gasto Operativo 5', padre: 'GAS' },
+    { id: 'GAS_801006000000000000002', tipo: 'cuenta', codigo: '801006000000000000002', titulo: 'Gasto Operativo 6', padre: 'GAS' },
+    { id: 'GAS_801007000000000000002', tipo: 'cuenta', codigo: '801007000000000000002', titulo: 'Gasto Operativo 7', padre: 'GAS' },
+    { id: 'GAS_801008000000000000002', tipo: 'cuenta', codigo: '801008000000000000002', titulo: 'Gasto Operativo 8', padre: 'GAS' },
+    { id: 'GAS_801009000000000000002', tipo: 'cuenta', codigo: '801009000000000000002', titulo: 'Gasto Operativo 9', padre: 'GAS' },
+    { id: 'GAS_801010000000000000002', tipo: 'cuenta', codigo: '801010000000000000002', titulo: 'Gasto Operativo 10', padre: 'GAS' },
+    { id: 'GAS_801011000000000000002', tipo: 'cuenta', codigo: '801011000000000000002', titulo: 'Gasto Operativo 11', padre: 'GAS' },
+    { id: 'GAS_801012000000000000002', tipo: 'cuenta', codigo: '801012000000000000002', titulo: 'Gasto Operativo 12', padre: 'GAS' },
+    { id: 'GAS_801013000000000000002', tipo: 'cuenta', codigo: '801013000000000000002', titulo: 'Gasto Operativo 13', padre: 'GAS' },
+    { id: 'GAS_513000000000000000001', tipo: 'cuenta', codigo: '513000000000000000001', titulo: 'Gastos Financieros 1', padre: 'GAS' },
+    { id: 'GAS_517000000000000000001', tipo: 'cuenta', codigo: '517000000000000000001', titulo: 'Gastos Financieros 2', padre: 'GAS' },
+    { id: 'GAS_516000000000000000001', tipo: 'cuenta', codigo: '516000000000000000001', titulo: 'Gastos Financieros 3', padre: 'GAS' },
+    { id: 'GAS_519000000000000000001', tipo: 'cuenta', codigo: '519000000000000000001', titulo: 'Gastos Financieros 4', padre: 'GAS' },
+    { id: 'GAS_515000000000000000001', tipo: 'cuenta', codigo: '515000000000000000001', titulo: 'Gastos Financieros 5', padre: 'GAS' },
+    { id: 'GAS_518000000000000000001', tipo: 'cuenta', codigo: '518000000000000000001', titulo: 'Gastos Financieros 6', padre: 'GAS' },
+    { id: 'GAS_514000000000000000001', tipo: 'cuenta', codigo: '514000000000000000001', titulo: 'Gastos Financieros 7', padre: 'GAS' },
+    { id: 'GAS_950001002000000000003', tipo: 'cuenta', codigo: '950001002000000000003', titulo: 'Otros Gastos 1', padre: 'GAS' },
+    { id: 'GAS_950002002000000000003', tipo: 'cuenta', codigo: '950002002000000000003', titulo: 'Otros Gastos 2', padre: 'GAS' }
+  ];
 
-  // Subtotal ingresos
-  { id: 'ING_SUB', tipo: 'subtotal', hijos: ['ING_MEM','ING_OTR'], titulo: 'Total ingresos', padre: 'ING' },
+  const layout = [
+    { id: 'ING', tipo: 'categoria', titulo: 'INGRESOS', componentes: ingresosDetalle.map((item) => item.id) },
+    ...ingresosDetalle,
+    { id: 'ING_SUB', tipo: 'subtotal', titulo: 'TOTAL INGRESOS', padre: 'ING', componentes: ingresosDetalle.map((item) => item.id) },
 
-  // ===== GASTOS =====
-  { id: 'GAS', tipo: 'categoria', titulo: 'GASTOS' },
+    { id: 'GAS', tipo: 'categoria', titulo: 'COSTOS Y GASTOS', componentes: gastosDetalle.map((item) => item.id) },
+    ...gastosDetalle,
+    { id: 'GAS_SUB', tipo: 'subtotal', titulo: 'TOTAL COSTOS Y GASTOS', padre: 'GAS', componentes: gastosDetalle.map((item) => item.id) },
 
-  // Detalle (ejemplos; ajusta a tus códigos)
-  { id: 'GAS_GEN',  tipo: 'cuenta', codigo: '500-000-000-00', titulo: 'Gastos generales', padre: 'GAS' },
-  { id: 'GAS_NOM',  tipo: 'cuenta', codigo: '510-000-000-00', titulo: 'Nómina', padre: 'GAS' },
-  { id: 'GAS_EV',   tipo: 'cuenta', codigo: '520-000-000-00', titulo: 'Eventos', padre: 'GAS' },
+    { id: 'RESULTADOS', tipo: 'categoria', titulo: 'RESULTADO OPERATIVO', componentes: ['UTI'] },
+    { id: 'UTI', tipo: 'total', titulo: 'UTILIDAD NETA', padre: 'RESULTADOS', componentes: ['ING_SUB', 'GAS_SUB'] },
 
-  // Subtotal gastos
-  { id: 'GAS_SUB', tipo: 'subtotal', hijos: ['GAS_GEN','GAS_NOM','GAS_EV'], titulo: 'Total gastos', padre: 'GAS' },
+    { id: 'KPIS', tipo: 'categoria', titulo: 'INDICADORES CLAVE', componentes: [] },
+    {
+      id: 'KPI_YTD_vs_PLAN',
+      tipo: 'kpi',
+      titulo: '% YTD vs Plan',
+      padre: 'KPIS',
+      formula: 'UTI.acumuladoActual / UTI.acumuladoPlan',
+      columnaYtd: 'acumuladoVariacionPlan',
+      factor: 100
+    },
+    {
+      id: 'KPI_YTD_vs_ANT',
+      tipo: 'kpi',
+      titulo: '% YTD vs Año Anterior',
+      padre: 'KPIS',
+      formula: 'UTI.acumuladoActual / UTI.acumuladoAnterior',
+      columnaYtd: 'acumuladoVariacionAnterior',
+      factor: 100
+    },
+    {
+      id: 'KPI_MES_vs_PLAN',
+      tipo: 'kpi',
+      titulo: '% Mes vs Plan',
+      padre: 'KPIS',
+      formulaMes: 'UTI.mesActual / UTI.mesPlan',
+      columnaMes: 'mesVariacionPlan',
+      factor: 100
+    },
+    {
+      id: 'KPI_MES_vs_ANT',
+      tipo: 'kpi',
+      titulo: '% Mes vs Año Anterior',
+      padre: 'KPIS',
+      formulaMes: 'UTI.mesActual / UTI.mesAnterior',
+      columnaMes: 'mesVariacionAnterior',
+      factor: 100
+    }
+  ];
 
-  // ===== RESULTADOS =====
-  { id: 'UTI', tipo: 'total', hijos: ['ING_SUB','GAS_SUB'], titulo: 'UTILIDAD (Ingresos - Gastos)' },
-
-  // ===== KPIs =====
-  // % vs Plan (YTD y MES)
-  { id: 'KPI_YTD_vs_PLAN', tipo: 'kpi', titulo: '% YTD vs Plan',  formula: 'UTI.ytdActual / UTI.ytdPlan' },
-  { id: 'KPI_MES_vs_PLAN', tipo: 'kpi', titulo: '% MES vs Plan',  formula: 'UTI.mesActual / UTI.mesPlan' },
-
-  // % vs Año anterior (YTD y MES)
-  { id: 'KPI_YTD_vs_ANT',  tipo: 'kpi', titulo: '% YTD vs Año Ant', formula: 'UTI.ytdActual / UTI.ytdAnterior' },
-  { id: 'KPI_MES_vs_ANT',  tipo: 'kpi', titulo: '% MES vs Año Ant', formula: 'UTI.mesActual / UTI.mesAnterior' },
-];
+  global.SUMMARY_E01_LAYOUT = layout;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -112,31 +112,43 @@ const estiloPorTipo = (tipo) => (
 // === LAYOUT (jerarquía y colores) ===
 // ===================================
 // Puedes extenderlo o cargarlo desde BD/JSON; si el usuario lo edita, se persiste en LS.
-const SUMMARY_LAYOUT_V1 = [
-  {
-    id: 'cdmx_income', tipo: 'categoria', estilo: THEME.categoria, etiqueta: 'CDMX INCOME', hijos: [
-      {
-        id: 'membership', tipo: 'categoria', estilo: THEME.subcategoria, etiqueta: 'Membership', hijos: [
-          { id: 'ctas_cuotas', tipo: 'detalle', codigo: '401000000000000000001', descripcion: 'Cuotas Netas' },
-          { id: 'ctas_nuevos', tipo: 'detalle', codigo: '402000000000000000001', descripcion: 'Ingresos socios nuevos' },
-          { id: 'membership_sub', tipo: 'subtotal', estilo: THEME.subtotal, etiqueta: 'Subtotal Membership' }
-        ]
-      },
-      {
-        id: 'events', tipo: 'categoria', estilo: THEME.subcategoria, etiqueta: 'EVENTS', hijos: [
-          { id: 'ctas_eventos', tipo: 'detalle', codigo: '407000000000000000001', descripcion: 'Eventos' },
-          { id: 'ctas_patro', tipo: 'detalle', codigo: '408000000000000000001', descripcion: 'Patrocinios' },
-          { id: 'events_sub', tipo: 'subtotal', estilo: THEME.subtotal, etiqueta: 'Subtotal Events' }
-        ]
-      },
-      { id: 'income_total', tipo: 'total', estilo: THEME.total, etiqueta: 'TOTAL INCOME' }
-    ]
+const SummaryCore = (typeof window !== 'undefined' && window.SummaryEngineCore)
+  ? window.SummaryEngineCore
+  : {
+      collectCodes: () => [],
+      buildSummaryRows: () => [],
+      safeDiv: (n, d) => {
+        const num = Number(n || 0);
+        const den = Number(d || 0);
+        return Math.abs(den) === 0 ? 0 : num / den;
+      }
+    };
+
+const collectCodes = typeof SummaryCore.collectCodes === 'function'
+  ? (layout) => SummaryCore.collectCodes(layout)
+  : () => [];
+
+const DEFAULT_LAYOUT = (typeof window !== 'undefined' && window.SUMMARY_E01_LAYOUT)
+  ? window.SUMMARY_E01_LAYOUT
+  : [];
+
+const cloneLayout = (layout) => {
+  try {
+    return JSON.parse(JSON.stringify(layout));
+  } catch (e) {
+    console.warn('No fue posible clonar layout, usando arreglo original.', e);
+    return Array.isArray(layout) ? layout.slice() : [];
   }
-];
+};
 
 const saveLayoutLS = (l) => localStorage.setItem('summary_layout_v1', JSON.stringify(l));
 const loadLayoutLS = () => { try { return JSON.parse(localStorage.getItem('summary_layout_v1') || 'null'); } catch { return null; } };
-let CURRENT_LAYOUT = loadLayoutLS() ?? SUMMARY_LAYOUT_V1;
+
+let CURRENT_LAYOUT = loadLayoutLS();
+if (!Array.isArray(CURRENT_LAYOUT) || CURRENT_LAYOUT.length === 0) {
+  CURRENT_LAYOUT = cloneLayout(DEFAULT_LAYOUT);
+}
+
 
 // Mostrar un toast verde de exito (Bootstrap) al actualizar
 function mostrarToastExito(mensaje = 'Actualizado correctamente') {
@@ -154,18 +166,6 @@ function mostrarToastExito(mensaje = 'Actualizado correctamente') {
     setTimeout(() => { toastEl.classList.remove('show'); }, 1500);
   }
 }
-
-// ======================================
-// === Motor de cálculo tipo “Excel”  ===
-// ======================================
-const zeroMetrics = () => ({
-  // Mes (seleccionado)
-  mesActual: 0, mesPlan: 0, mesAnterior: 0, mesVariacionPlan: 0, mesVariacionAnterior: 0,
-  // YTD (hasta mes seleccionado)
-  acumuladoActual: 0, acumuladoPlan: 0, acumuladoAnterior: 0, acumuladoVariacionPlan: 0, acumuladoVariacionAnterior: 0
-});
-const pct = (a, b) => (Math.abs(b || 0) === 0 ? 0 : ((a - b) / Math.abs(b)) * 100);
-const addMetrics = (dst, src) => { Object.keys(dst).forEach(k => dst[k] += (src[k] || 0)); return dst; };
 
 // =========================================================
 // === SISTEMA DE FORMULAS (fila / celda / columna)     ===
@@ -335,109 +335,6 @@ const applyFormulaEngine = (rows) => {
   return cloned;
 };
 
-// Índices de datos por NUM_CTA
-function buildIndex(apiRows) {
-  const idx = {};
-  (apiRows || []).forEach(r => { idx[String(r.codigo).trim()] = r; });
-  return idx;
-}
-
-// Recolecta códigos NUM_CTA del layout visible
-function collectCodes(layout) {
-  const codes = [];
-  const walk = (nodos) => nodos.forEach(n => {
-    if (n.tipo === 'detalle' && n.codigo) codes.push(String(n.codigo).trim());
-    if (Array.isArray(n.hijos)) walk(n.hijos);
-  });
-  walk(layout);
-  return codes;
-}
-
-// Cálculo recursivo: detalle -> subtotal/categoría/total
-function computeNode(node, idx) {
-  const metrics = zeroMetrics();
-  let children = [];
-
-  if (Array.isArray(node.hijos) && node.hijos.length) {
-    children = node.hijos.map(h => computeNode(h, idx));
-    // Agregación: suma de hijos
-    children.forEach(ch => addMetrics(metrics, ch.metrics));
-  } else if (node.tipo === 'detalle' && node.codigo) {
-    const r = idx[String(node.codigo).trim()];
-    if (r) {
-      metrics.mesActual = r.mesActual || 0;
-      metrics.mesPlan = r.mesPlan || 0;
-      metrics.mesAnterior = r.mesAnterior || 0;
-
-      metrics.acumuladoActual = r.acumuladoActual || 0;
-      metrics.acumuladoPlan = r.acumuladoPlan || 0;
-      metrics.acumuladoAnterior = r.acumuladoAnterior || 0;
-    }
-  }
-
-  // Variaciones %
-  metrics.mesVariacionPlan = pct(metrics.mesActual, metrics.mesPlan);
-  metrics.mesVariacionAnterior = pct(metrics.mesActual, metrics.mesAnterior);
-  metrics.acumuladoVariacionPlan = pct(metrics.acumuladoActual, metrics.acumuladoPlan);
-  metrics.acumuladoVariacionAnterior = pct(metrics.acumuladoActual, metrics.acumuladoAnterior);
-
-  return { row: node, metrics, children };
-}
-function computeTree(layout, idx) { return layout.map(n => computeNode(n, idx)); }
-
-// Aplana árbol -> arreglo que entiende el renderer
-function flattenForRender(tree) {
-  const out = [];
-  const walk = (node, depth = 0) => {
-    const { row, metrics, children } = node;
-
-    if (row.tipo === 'categoria' || row.tipo === 'subtotal' || row.tipo === 'total') {
-      out.push({
-        tipo: 'categoria',
-        rowId: row.id || row.codigo || row.descripcion || '',
-        estilo: row.estilo || estiloPorTipo(row.tipo),
-        etiqueta: row.etiqueta || row.label || '',
-        tipoFila: row.tipo,
-        // Métricas
-        mesActual: metrics.mesActual,
-        mesPlan: metrics.mesPlan,
-        mesAnterior: metrics.mesAnterior,
-        mesVariacionPlan: metrics.mesVariacionPlan,
-        mesVariacionAnterior: metrics.mesVariacionAnterior,
-        acumuladoActual: metrics.acumuladoActual,
-        acumuladoPlan: metrics.acumuladoPlan,
-        acumuladoAnterior: metrics.acumuladoAnterior,
-        acumuladoVariacionPlan: metrics.acumuladoVariacionPlan,
-        acumuladoVariacionAnterior: metrics.acumuladoVariacionAnterior,
-        depth
-      });
-    } else {
-      out.push({
-        tipo: 'detalle',
-        rowId: row.id || row.codigo || row.descripcion || '',
-        codigo: row.codigo,
-        descripcion: row.descripcion || '',
-        tipoFila: row.tipo,
-        // Métricas
-        mesActual: metrics.mesActual,
-        mesPlan: metrics.mesPlan,
-        mesAnterior: metrics.mesAnterior,
-        mesVariacionPlan: metrics.mesVariacionPlan,
-        mesVariacionAnterior: metrics.mesVariacionAnterior,
-        acumuladoActual: metrics.acumuladoActual,
-        acumuladoPlan: metrics.acumuladoPlan,
-        acumuladoAnterior: metrics.acumuladoAnterior,
-        acumuladoVariacionPlan: metrics.acumuladoVariacionPlan,
-        acumuladoVariacionAnterior: metrics.acumuladoVariacionAnterior,
-        depth
-      });
-    }
-    (children || []).forEach(ch => walk(ch, depth + 1));
-  };
-  tree.forEach(n => walk(n, 0));
-  return out;
-}
-
 // ========================================
 // === ADAPTADORES (SALDOSxx / ACUMxx)  ===
 // ========================================
@@ -578,14 +475,15 @@ const CALC_STRATEGY = {
 // - Devuelve un objeto con:
 //   { detalle: [...], ejercicios: [...] }
 //   donde 'detalle' son filas por codigo y 'ejercicios' alimenta la tarjeta superior.
-async function fetchSummary({ anio, periodo, empresaId }) {
+async function fetchSummary({ anio, periodo, empresaId, incluirAjusteEnYTD }) {
   const codigos = collectCodes(CURRENT_LAYOUT);
+  const usarAjuste = Boolean(incluirAjusteEnYTD);
 
   // set contexto
   CTX.anio = anio;
   CTX.periodo = periodo;
   CTX.anioComparativo = anio - 1;
-  CTX.incluirAjusteEnYTD = false;      // cámbialo si quieres expositor en UI
+  CTX.incluirAjusteEnYTD = usarAjuste;
   CTX.fuente = 'SALDOSxx';             // o 'ACUMxx' según la fuente
 
   if (CALC_STRATEGY.modo === 'server') {
@@ -593,13 +491,21 @@ async function fetchSummary({ anio, periodo, empresaId }) {
     const resp = await fetch(`${API_BASE}/modulos/summary-resumen-e`, {
       method: 'POST',
       headers: { ...Sesion.headersAutenticacion(), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ anio, periodo, empresaId, codigos })
+      body: JSON.stringify({
+        anio,
+        periodo,
+        empresaId,
+        codigos,
+        anioComparativo: CTX.anioComparativo,
+        usarAjusteEnYTD: usarAjuste
+      })
     });
     const data = await resp.json();
     if (!resp.ok) throw new Error(data.mensaje || 'No fue posible obtener la información.');
     return {
       detalle: Array.isArray(data.detalle) ? data.detalle : [],
-      ejercicios: Array.isArray(data.ejercicios) ? data.ejercicios : []
+      ejercicios: Array.isArray(data.ejercicios) ? data.ejercicios : [],
+      ejerciciosDisponibles: Array.isArray(data.ejerciciosDisponibles) ? data.ejerciciosDisponibles : []
     };
   }
 
@@ -607,7 +513,14 @@ async function fetchSummary({ anio, periodo, empresaId }) {
   const resp = await fetch(`${API_BASE}/modulos/summary-crudo`, {
     method: 'POST',
     headers: { ...Sesion.headersAutenticacion(), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ anio, periodo, empresaId, codigos, fuente: CALC_STRATEGY.fuente() })
+    body: JSON.stringify({
+      anio,
+      periodo,
+      empresaId,
+      codigos,
+      fuente: CALC_STRATEGY.fuente(),
+      usarAjusteEnYTD: usarAjuste
+    })
   });
   const raw = await resp.json();
   if (!resp.ok) throw new Error(raw.mensaje || 'No fue posible obtener la información.');
@@ -626,90 +539,64 @@ async function fetchSummary({ anio, periodo, empresaId }) {
     return OPERACIONES.detalleDesdeACUM(r, CTX);
   });
 
-  return { detalle, ejercicios: raw.ejercicios || [] };
-}
-
-// ======================================================
-// === RENDER DE TABLA (respeta estilos y jerarquía) ===
-// ======================================================
-function renderizarTabla() {
-  const body = document.getElementById('summaryTableBody');
-  if (!body) return;
-
-  body.innerHTML = '';
-  const filas = estadoModulo.tabla;
-
-  if (!Array.isArray(filas) || filas.length === 0) {
-    const vacio = document.createElement('tr');
-    vacio.innerHTML = '<td colspan="12" class="text-center text-muted py-4">No hay información disponible para mostrar.</td>';
-    body.appendChild(vacio);
-    return;
-  }
-
-  filas.forEach((fila) => {
-    const tr = document.createElement('tr');
-
-    if (fila.tipo === 'categoria') {
-      const clases = [fila.estilo || THEME.categoria];
-      if (fila.tipoFila) clases.push(`fila-${fila.tipoFila}`);
-      tr.className = clases.join(' ');
-      tr.innerHTML = `
-        <th></th>
-        <td class="mono">${formatearMoneda(fila.mesActual)}</td>
-        <td class="mono">${formatearMoneda(fila.mesPlan)}</td>
-        <td class="mono">${formatearMoneda(fila.mesAnterior)}</td>
-        <td class="mono">${formatearPorcentaje(fila.mesVariacionPlan)}</td>
-        <td class="mono">${formatearPorcentaje(fila.mesVariacionAnterior)}</td>
-        <td class="category-cell" data-depth="${fila.depth||0}" style="--depth:${fila.depth||0}">${fila.etiqueta || ''}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoActual)}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoPlan)}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoAnterior)}</td>
-        <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionPlan)}</td>
-        <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionAnterior)}</td>
-      `;
-    } else {
-      const clases = [];
-      if (fila.tipoFila && fila.tipoFila !== 'detalle') clases.push(`fila-${fila.tipoFila}`);
-      if (clases.length) tr.className = clases.join(' ');
-      tr.innerHTML = `
-        <th class="code-cell">${fila.codigo || ''}</th>
-        <td class="mono">${formatearMoneda(fila.mesActual)}</td>
-        <td class="mono">${formatearMoneda(fila.mesPlan)}</td>
-        <td class="mono">${formatearMoneda(fila.mesAnterior)}</td>
-        <td class="mono">${formatearPorcentaje(fila.mesVariacionPlan)}</td>
-        <td class="mono">${formatearPorcentaje(fila.mesVariacionAnterior)}</td>
-        <td class="label-cell" data-depth="${fila.depth||0}" style="--depth:${fila.depth||0}">${fila.descripcion || ''}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoActual)}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoPlan)}</td>
-        <td class="mono">${formatearMoneda(fila.acumuladoAnterior)}</td>
-        <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionPlan)}</td>
-        <td class="mono">${formatearPorcentaje(fila.acumuladoVariacionAnterior)}</td>
-      `;
-    }
-    body.appendChild(tr);
-  });
+  return {
+    detalle,
+    ejercicios: raw.ejercicios || [],
+    ejerciciosDisponibles: raw.ejerciciosDisponibles || []
+  };
 }
 
 // ==============================================================
 // === ACCIONES (agregar/quitar cuentas conservando estilos)  ===
 // ==============================================================
 function addDetail(parentId, codigo, descripcion = '') {
-  const deep = (xs) => xs.map(x => {
-    if (x.id === parentId) {
-      const hijos = Array.isArray(x.hijos) ? x.hijos.slice() : [];
-      hijos.push({ id: `det_${codigo}`, tipo: 'detalle', codigo: String(codigo), descripcion });
-      return { ...x, hijos };
+  if (!parentId || !codigo) return;
+  const codigoTxt = String(codigo).trim();
+  const nuevoId = `cuenta_${codigoTxt}`;
+  const nuevaFila = {
+    id: nuevoId,
+    tipo: 'cuenta',
+    codigo: codigoTxt,
+    titulo: descripcion || codigoTxt,
+    padre: parentId
+  };
+
+  const actualizado = (Array.isArray(CURRENT_LAYOUT) ? CURRENT_LAYOUT.slice() : []);
+  actualizado.push(nuevaFila);
+
+  CURRENT_LAYOUT = actualizado.map((item) => {
+    if (!Array.isArray(item.componentes)) return item;
+    if (item.id === parentId || item.padre === parentId) {
+      if (!item.componentes.includes(nuevoId)) {
+        return { ...item, componentes: [...item.componentes, nuevoId] };
+      }
     }
-    return { ...x, hijos: x.hijos ? deep(x.hijos) : x.hijos };
+    return item;
   });
-  CURRENT_LAYOUT = deep(CURRENT_LAYOUT);
+
   saveLayoutLS(CURRENT_LAYOUT);
 }
 
 function removeByCode(codigo) {
-  const deep = (xs) => xs.map(x => ({ ...x, hijos: x.hijos ? deep(x.hijos) : x.hijos }))
-    .filter(x => !(x.tipo === 'detalle' && String(x.codigo).trim() === String(codigo).trim()));
-  CURRENT_LAYOUT = deep(CURRENT_LAYOUT);
+  if (!codigo) return;
+  const codigoTxt = String(codigo).trim();
+  let idEliminado = null;
+
+  CURRENT_LAYOUT = (Array.isArray(CURRENT_LAYOUT) ? CURRENT_LAYOUT : []).filter((item) => {
+    if (item.tipo === 'cuenta' && String(item.codigo || '').trim() === codigoTxt) {
+      idEliminado = item.id;
+      return false;
+    }
+    return true;
+  }).map((item) => {
+    if (!Array.isArray(item.componentes) || !idEliminado) return item;
+    const filtrado = item.componentes.filter((comp) => comp !== idEliminado);
+    if (filtrado.length !== item.componentes.length) {
+      return { ...item, componentes: filtrado };
+    }
+    return item;
+  });
+
   saveLayoutLS(CURRENT_LAYOUT);
 }
 
@@ -722,25 +609,31 @@ async function aplicarSeleccionUI() {
   const anio = Number(filtroAnio?.value || new Date().getFullYear());
   const mesNombre = String((filtroMes?.value || 'enero')).toLowerCase();
   const periodo = MES_A_PERIODO[mesNombre] || 1;
+  const incluirAjuste = Boolean(document.getElementById('chkAjuste')?.checked);
 
   setAllYearSpans(anio);
   mostrarEstado('Calculando…');
 
   try {
-    const { detalle, ejercicios } = await fetchSummary({
+    const { detalle, ejercicios, ejerciciosDisponibles } = await fetchSummary({
       anio,
       periodo,
-      empresaId: (typeof sesion !== 'undefined' ? sesion?.empresaId : undefined)
+      empresaId: (typeof sesion !== 'undefined' ? sesion?.empresaId : undefined),
+      incluirAjusteEnYTD: incluirAjuste
     });
 
-    // index por codigo para el motor
-    const idx = buildIndex(detalle);
-    // cálculo jerárquico
-    const tree = computeTree(CURRENT_LAYOUT, idx);
+    const layoutParaMotor = Array.isArray(CURRENT_LAYOUT) ? CURRENT_LAYOUT : [];
+    const tablaCalculada = SummaryCore.buildSummaryRows(
+      layoutParaMotor,
+      detalle,
+      { estiloPorTipo }
+    );
 
-    const tablaCalculada = flattenForRender(tree);
     estadoModulo.tabla = applyFormulaEngine(tablaCalculada);
     estadoModulo.ejercicios = ejercicios;
+    if (Array.isArray(ejerciciosDisponibles) && ejerciciosDisponibles.length) {
+      estadoModulo.ejerciciosDisponibles = ejerciciosDisponibles;
+    }
 
     actualizarResumen(anio);
     renderizarTabla();
@@ -810,6 +703,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Botón Restablecer: establece año/mes en curso y aplica
   const btnReset = document.getElementById('btnReset');
+  const chkAjuste = document.getElementById('chkAjuste');
   if (btnReset) {
     btnReset.addEventListener('click', () => {
       const ahora = new Date();
@@ -828,6 +722,15 @@ document.addEventListener('DOMContentLoaded', () => {
       if (selMes) selMes.value = mesNombre.charAt(0).toUpperCase() + mesNombre.slice(1);
       setAllMonthSpans(mesNombre);
 
+      if (chkAjuste) chkAjuste.checked = false;
+
+      aplicarSeleccionUI();
+    });
+  }
+
+  if (chkAjuste) {
+    chkAjuste.checked = false;
+    chkAjuste.addEventListener('change', () => {
       aplicarSeleccionUI();
     });
   }
@@ -930,146 +833,39 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   // inicializar <span.mes> con el valor actual del combo
   const filtroMesInit = document.getElementById('selectMes');
-  const m = String(filtroMesInit?.value || 'enero').toLowerCase();
+  const ahora = new Date();
+  const mesActualNombre = ['enero','febrero','marzo','abril','mayo','junio','julio','agosto','septiembre','octubre','noviembre','diciembre'][ahora.getMonth()];
+  if (filtroMesInit) filtroMesInit.value = mesActualNombre.charAt(0).toUpperCase() + mesActualNombre.slice(1);
+  const m = String(filtroMesInit?.value || mesActualNombre || 'enero').toLowerCase();
   setAllMonthSpans(m);
 })();
 });
 
-// Busca una cuenta en el payload del backend por código exacto
-function indexByCodigo(detalle) {
-  const map = new Map();
-  for (const r of detalle) map.set(String(r.codigo).trim(), r);
-  return map;
-}
-
-function zeroRow() {
-  return {
-    mesActual:0, ytdActual:0,
-    mesPlan:0,   ytdPlan:0,
-    mesAnterior:0, ytdAnterior:0
-  };
-}
-
-function addRows(a, b) {
-  return {
-    mesActual:   (a.mesActual||0)   + (b.mesActual||0),
-    ytdActual:   (a.ytdActual||0)   + (b.ytdActual||0),
-    mesPlan:     (a.mesPlan||0)     + (b.mesPlan||0),
-    ytdPlan:     (a.ytdPlan||0)     + (b.ytdPlan||0),
-    mesAnterior: (a.mesAnterior||0) + (b.mesAnterior||0),
-    ytdAnterior: (a.ytdAnterior||0) + (b.ytdAnterior||0),
-  };
-}
-
-function safeDiv(n, d) {
-  const N = Number(n||0), D = Number(d||0);
-  return D === 0 ? 0 : N / D;
-}
-
-// Eval simple de fórmulas tipo "UTI.ytdActual / UTI.ytdPlan"
-// rowsOut es un diccionario { idRow -> rowValues }
-function evalFormula(expr, rowsOut) {
-  // Solo soportamos "A.B / C.D" o "A.B - C.D" etc. con + - * /
-  // Sencillo parser:
-  const tokens = expr.split(/\s+/);
-  const stack = [];
-
-  function valueOf(token) {
-    // token como "UTI.ytdActual" o número
-    if (/^[A-Za-z_][\w]*\.[A-Za-z_][\w]*$/.test(token)) {
-      const [id, field] = token.split('.');
-      const row = rowsOut[id] || zeroRow();
-      return Number(row[field] || 0);
-    }
-    if (!isNaN(Number(token))) return Number(token);
-    return token; // operador
-  }
-
-  for (const t of tokens) {
-    stack.push(valueOf(t));
-    while (stack.length >= 3 && typeof stack[stack.length-2] === 'string') {
-      const b = stack.pop();
-      const op = stack.pop();
-      const a = stack.pop();
-      if (op === '+') stack.push(Number(a)+Number(b));
-      else if (op === '-') stack.push(Number(a)-Number(b));
-      else if (op === '*') stack.push(Number(a)*Number(b));
-      else if (op === '/') stack.push(safeDiv(a,b));
-      else { // operador desconocido, reponer
-        stack.push(a, op, b);
-        break;
-      }
-    }
-  }
-  return Number(stack[0] || 0);
-}
-
 // Construye todas las filas del layout a partir del payload del backend
 export function materializarLayout(LAYOUT, payload) {
-  // payload.detalle: [{ codigo, mesActual, ytdActual, mesPlan, ytdPlan, mesAnterior, ytdAnterior, ... }, ...]
-  const byCode = indexByCodigo(payload.detalle);
-  const rowsOut = {}; // id -> valores calculados
+  const layout = Array.isArray(LAYOUT) ? LAYOUT : [];
+  const detalle = Array.isArray(payload?.detalle) ? payload.detalle : [];
+  const filas = SummaryCore.buildSummaryRows(layout, detalle, { estiloPorTipo });
 
-  // 1) Primero resuelve las filas de cuenta
-  for (const item of LAYOUT) {
-    if (item.tipo === 'cuenta') {
-      const r = byCode.get(String(item.codigo).trim()) || {};
-      rowsOut[item.id] = {
-        titulo: item.titulo || item.codigo,
-        ...zeroRow(),
-        mesActual:   Number(r.mesActual||0),
-        ytdActual:   Number(r.ytdActual||0),
-        mesPlan:     Number(r.mesPlan||0),
-        ytdPlan:     Number(r.ytdPlan||0),
-        mesAnterior: Number(r.mesAnterior||0),
-        ytdAnterior: Number(r.ytdAnterior||0),
-      };
-    }
-  }
-
-  // 2) Luego subtotales/totales (pueden depender de varias cuentas)
-  const tiposSuma = new Set(['subtotal','total']);
-  for (const item of LAYOUT) {
-    if (tiposSuma.has(item.tipo)) {
-      const hijos = item.hijos || [];
-      let acc = zeroRow();
-      for (const hid of hijos) {
-        const hv = rowsOut[hid] || zeroRow();
-        acc = addRows(acc, hv);
-      }
-      rowsOut[item.id] = { titulo: item.titulo || item.id, ...acc };
-    }
-  }
-
-  // 3) Por último KPIs (fórmulas)
-  for (const item of LAYOUT) {
-    if (item.tipo === 'kpi') {
-      const v = {
-        ...zeroRow(),
-        // Por convención mostramos el KPI en YTD y MES en estos dos campos:
-        ytdActual: evalFormula(item.formula.replaceAll(/\b([A-Za-z_]\w*)\./g, '$1.'), rowsOut),
-      };
-      // Si quieres también KPI de MES con otra fórmula, agrega formulaMes: '...'
-      if (item.formulaMes) v.mesActual = evalFormula(item.formulaMes, rowsOut);
-      rowsOut[item.id] = { titulo: item.titulo || item.id, ...v };
-    }
-  }
-
-  // 4) Devuelve arreglado en el mismo orden del LAYOUT (para pintar)
-  const salida = [];
-  for (const item of LAYOUT) {
-    if (item.tipo === 'categoria') {
-      salida.push({ id: item.id, tipo: 'categoria', titulo: item.titulo });
-    } else {
-      const v = rowsOut[item.id] || zeroRow();
-      salida.push({
-        id: item.id,
-        tipo: item.tipo,
-        titulo: (rowsOut[item.id] && rowsOut[item.id].titulo) || item.titulo || item.id,
-        ...v
-      });
-    }
-  }
-  return salida;
+  return filas.map((fila) => ({
+    id: fila.rowId,
+    tipo: fila.tipoFila,
+    titulo: fila.etiqueta || fila.descripcion || fila.rowId,
+    codigo: fila.codigo,
+    descripcion: fila.descripcion || '',
+    mesActual: Number(fila.mesActual || 0),
+    mesPlan: Number(fila.mesPlan || 0),
+    mesAnterior: Number(fila.mesAnterior || 0),
+    mesVariacionPlan: Number(fila.mesVariacionPlan || 0),
+    mesVariacionAnterior: Number(fila.mesVariacionAnterior || 0),
+    ytdActual: Number(fila.acumuladoActual ?? fila.ytdActual ?? 0),
+    ytdPlan: Number(fila.acumuladoPlan ?? fila.ytdPlan ?? 0),
+    ytdAnterior: Number(fila.acumuladoAnterior ?? fila.ytdAnterior ?? 0),
+    acumuladoActual: Number(fila.acumuladoActual || fila.ytdActual || 0),
+    acumuladoPlan: Number(fila.acumuladoPlan || fila.ytdPlan || 0),
+    acumuladoAnterior: Number(fila.acumuladoAnterior || fila.ytdAnterior || 0),
+    acumuladoVariacionPlan: Number(fila.acumuladoVariacionPlan || 0),
+    acumuladoVariacionAnterior: Number(fila.acumuladoVariacionAnterior || 0)
+  }));
 }
 


### PR DESCRIPTION
## Summary
- add a shared summary engine core module to compute metrics, safe divisions, and KPI formulas for Summary_E01
- refresh SUMMARY front-end to use the new engine, updated layout structure, and expose the YTD adjustment toggle with reset behavior
- register Summary_E01 layout codes and add automated tests that cover hierarchical sums, KPI calculations, and safe variation handling

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121b8e8214832da0e8fca285094754)