### PR TITLE
Fix comités and summary year selectors

### DIFF
--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -223,7 +223,7 @@
   <script src="js/sesion.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
  
-  <script> existente
+  <script>
 
       (() => {
         const sesion = (typeof Sesion !== 'undefined' && typeof Sesion.requerirSesion === 'function')
@@ -474,9 +474,10 @@
 
               if (Array.isArray(data.anios) && data.anios.length) {
                 const ordenAsc = data.anios.slice().sort((a, b) => a - b);
-                els.yearSelect.innerHTML = ordenAsc
-                  .map(anio => `<option value="${anio}">${anio}</option>`)
-                  .join('');
+                const opciones = ['<option value="">—</option>'].concat(
+                  ordenAsc.map(anio => `<option value="${anio}">${anio}</option>`)
+                );
+                els.yearSelect.innerHTML = opciones.join('');
                 if (!ordenAsc.includes(state.anio)) {
                   state.anio = ordenAsc[ordenAsc.length - 1]; // último año disponible
                 }
@@ -487,8 +488,11 @@
             } catch (error) {
               console.warn('No fue posible cargar años.', error);
               const actual = new Date().getFullYear();
-              els.yearSelect.innerHTML = `<option value="${actual}">${actual}</option>`;
-              els.yearSelect.value = actual;
+              els.yearSelect.innerHTML = `
+                <option value="">—</option>
+                <option value="${actual}">${actual}</option>
+              `;
+              els.yearSelect.value = String(actual);
               state.anio = actual;
               setStatus(error.message || 'Error al cargar años', 'warning');
             } finally {

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -412,10 +412,7 @@
               <div class="col-sm-6 col-lg-3">
                 <label for="selectAnio" class="form-label">Ejercicio</label>
                 <select id="selectAnio" class="form-select">
-                  <option>2022</option>
-                  <option>2021</option>
-                  <option>2020</option>
-                  <option>2019</option>
+                  <option value="">—</option>
                 </select>
               </div>
               <div class="col-sm-6 col-lg-3">

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -632,15 +632,30 @@ async function poblarAniosDesdeSALDOS() {
     if (!sel) return preferred;
     const prev = Number(sel.value);
     sel.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '—';
+    sel.appendChild(placeholder);
+
     lista.forEach((anio) => {
       const opt = document.createElement('option');
       opt.value = String(anio);
       opt.textContent = String(anio);
       sel.appendChild(opt);
     });
-    const target = lista.includes(prev) ? prev : preferred;
-    sel.value = String(target);
-    return target;
+
+    const tienePrevio = Number.isFinite(prev) && lista.includes(prev);
+    const fallback = Number.isFinite(preferred) ? preferred : lista[lista.length - 1];
+    const target = tienePrevio ? prev : fallback;
+
+    if (Number.isFinite(target)) {
+      sel.value = String(target);
+      return target;
+    }
+
+    sel.value = '';
+    return preferred;
   };
 
   const valorSeleccionado = selects.reduce((acc, sel) => fillSelect(sel, acc ?? prefer), null) ?? prefer;


### PR DESCRIPTION
## Summary
- remove stray script text that prevented Comités.html from initializing
- populate the comités year selector dynamically with a placeholder option when listing SALDOS years
- let summary year selectors rely on backend-provided SALDOS years and add a fallback-safe placeholder

## Testing
- not run (frontend-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912542171e0832d8fe6ed38feeb103d)