### PR TITLE
Populate comité report from auxiliar data

### DIFF
--- a/src/services/comitesService.js
+++ b/src/services/comitesService.js
@@ -1,5 +1,5 @@
+const { ejecutarConsulta } = require('./firebirdService');
 const {
-  obtenerSaldosPorCuentas,
   obtenerAniosDisponibles: obtenerAniosDesdeSaldos,
   obtenerCuentasPorAnio,
   MESES
@@ -8,6 +8,32 @@ const {
 const ES_CUENTA_COMITE = (codigo = '') => {
   const clean = String(codigo || '').trim();
   return /^404/.test(clean) || /^502/.test(clean) || /^504/.test(clean);
+};
+
+const construirNombreTabla = (prefijo, anio) => `${prefijo}${anio.toString().slice(-2).padStart(2, '0')}`;
+
+const EXPRESION_MONTO = `CASE
+      WHEN a.debe_haber IN ('D','1','DEBE')  THEN a.montomov
+      WHEN a.debe_haber IN ('H','2','HABER') THEN -a.montomov
+      ELSE 0
+    END`;
+
+const mapearFila = (row) => {
+  const resultado = {
+    numCta: String(row.NUM_CTA || '').trim(),
+    nombre: String(row.NOMBRE || '').trim(),
+    naturaleza: String(row.NATURALEZA || '').trim()
+  };
+
+  MESES.forEach(({ alias, clave }) => {
+    resultado[clave] = Number(row[alias] ?? 0);
+  });
+
+  resultado.ajuste13 = Number(row.AJUSTE13 ?? 0);
+  resultado.ajuste14 = Number(row.AJUSTE14 ?? 0);
+  resultado.anual = Number(row.ANUAL ?? 0);
+
+  return resultado;
 };
 
 async function obtenerAniosDisponibles(empresaId) {
@@ -36,11 +62,53 @@ async function obtenerComites(empresaId, anio) {
 }
 
 async function obtenerMovimientosPorCuentas(empresaId, anio, cuentas = []) {
+  if (!empresaId) throw new Error('Empresa obligatoria');
+
+  const ejercicio = Number(anio);
+  if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
+    throw new Error('Ejercicio inválido');
+  }
+
   const lista = Array.isArray(cuentas)
-    ? cuentas.map((c) => String(c || '').trim()).filter(Boolean)
+    ? Array.from(new Set(cuentas.map((c) => String(c || '').trim()).filter(Boolean)))
     : [];
-  if (lista.length === 0) return [];
-  return obtenerSaldosPorCuentas(empresaId, anio, lista);
+
+  if (lista.length === 0) {
+    return [];
+  }
+
+  const tablaAuxiliar = construirNombreTabla('AUXILIAR', ejercicio);
+  const tablaCuentas = construirNombreTabla('CUENTAS', ejercicio);
+
+  const columnasMeses = MESES.map(({ periodo, alias }) => `
+      COALESCE(SUM(CASE WHEN a.periodo = ${periodo} THEN ${EXPRESION_MONTO} ELSE 0 END), 0) AS ${alias}
+    `).join(', ');
+
+  const placeholders = lista.map(() => '?').join(',');
+  const parametros = [ejercicio, ...lista];
+
+  const sql = `
+    SELECT
+      c.num_cta AS NUM_CTA,
+      c.nombre AS NOMBRE,
+      c.naturaleza AS NATURALEZA,
+      ${columnasMeses},
+      COALESCE(SUM(CASE WHEN a.periodo = 13 THEN ${EXPRESION_MONTO} ELSE 0 END), 0) AS AJUSTE13,
+      COALESCE(SUM(CASE WHEN a.periodo = 14 THEN ${EXPRESION_MONTO} ELSE 0 END), 0) AS AJUSTE14,
+      COALESCE(SUM(CASE WHEN a.periodo BETWEEN 1 AND 14 THEN ${EXPRESION_MONTO} ELSE 0 END), 0) AS ANUAL
+    FROM ${tablaCuentas} c
+    LEFT JOIN ${tablaAuxiliar} a
+      ON a.num_cta = c.num_cta
+     AND a.ejercicio = ?
+     AND a.periodo BETWEEN 1 AND 14
+    WHERE c.status = 'A'
+      AND c.num_cta IN (${placeholders})
+    GROUP BY c.num_cta, c.nombre, c.naturaleza
+    ORDER BY c.num_cta
+  `;
+
+  const filas = await ejecutarConsulta(empresaId, sql, parametros);
+  return filas.map(mapearFila);
 }
 
 module.exports = {

--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -107,7 +107,13 @@
     .table-comites td:first-child {
       text-align: left;
       font-weight: 600;
-      min-width: 320px;
+      min-width: 180px;
+    }
+
+    .table-comites th:nth-child(2),
+    .table-comites td:nth-child(2) {
+      text-align: left;
+      min-width: 240px;
     }
 
     .table-comites thead th {
@@ -140,10 +146,9 @@
       font-weight: 500;
     }
 
-    .table-comites tbody tr td:first-child span {
-      display: block;
+    .table-comites tbody tr td:nth-child(2) {
       color: var(--color-secondary-white);
-      font-size: 0.78rem;
+      font-size: 0.82rem;
       font-weight: 500;
     }
 
@@ -223,7 +228,7 @@
   <script src="js/sesion.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
  
-  <script> existente
+  <script>
 
       (() => {
         const sesion = (typeof Sesion !== 'undefined' && typeof Sesion.requerirSesion === 'function')
@@ -344,6 +349,15 @@
             return currency.format(value);
           }
 
+          function escapeHtml(value) {
+            return String(value ?? '')
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;')
+              .replace(/'/g, '&#39;');
+          }
+
           function actualizarEncabezado() {
             const anio = Number(state.anio) || new Date().getFullYear();
             const sufijo = String(anio).slice(-2);
@@ -352,7 +366,8 @@
             ).join('');
             els.tableHead.innerHTML = `
         <tr>
-          <th>COMITÉS</th>
+          <th>Cuenta</th>
+          <th>Descripción</th>
           ${cols}
           <th><span>${anio}</span>Total</th>
         </tr>
@@ -365,7 +380,9 @@
             COLUMNS.forEach((col) => {
               valores[col.clave] = Number(registro[col.clave] || 0);
             });
-            valores.total = Number(registro.anual || 0);
+            const ajustes = Number(registro.ajuste13 || 0) + Number(registro.ajuste14 || 0);
+            const totalMeses = COLUMNS.reduce((acum, col) => acum + valores[col.clave], 0);
+            valores.total = totalMeses + ajustes;
             return {
               codigo,
               nombre: registro.nombre || codigo,
@@ -407,7 +424,7 @@
               htmlPartes.push(renderRow(row, 'ingresos'));
             });
             htmlPartes.push(renderTotalRow('Suma de Ingresos Comités', totalIngresos));
-            htmlPartes.push('<tr><td colspan="14" style="background:transparent; border:none;"></td></tr>');
+            htmlPartes.push('<tr><td colspan="15" style="background:transparent; border:none;"></td></tr>');
             gastosRows.forEach((row) => htmlPartes.push(renderRow(row, 'gastos')));
             htmlPartes.push(renderTotalRow('Suma de Gastos Comités', totalGastos));
             htmlPartes.push(renderResultadoRow('Resultado Operativo Comités', resultado));
@@ -420,9 +437,13 @@
             const celdas = COLUMNS.map(col =>
               `<td>${formatoValor(row.valores[col.clave])}</td>`
             ).join('');
+            const codigo = row.codigo ? escapeHtml(row.codigo) : '—';
+            const descripcionTexto = row.nombre ? escapeHtml(row.nombre) : '—';
+            const tituloDescripcion = row.nombre ? ` title="${descripcionTexto}"` : '';
             return `
         <tr data-cuenta="${row.codigo}" data-section="${section}">
-          <td>${row.codigo} <br><span class="text-white-50">${row.nombre}</span></td>
+          <td>${codigo}</td>
+          <td${tituloDescripcion}>${descripcionTexto}</td>
           ${celdas}
           <td>${formatoValor(row.valores.total)}</td>
         </tr>
@@ -433,9 +454,10 @@
             const celdas = COLUMNS.map(col =>
               `<td>${formatoValor(totales[col.clave])}</td>`
             ).join('');
+            const texto = escapeHtml(label);
             return `
         <tr data-kind="total">
-          <td>${label}</td>
+          <td colspan="2" class="text-start">${texto}</td>
           ${celdas}
           <td>${formatoValor(totales.total)}</td>
         </tr>
@@ -446,9 +468,10 @@
             const celdas = COLUMNS.map(col =>
               `<td>${formatoValor(totales[col.clave])}</td>`
             ).join('');
+            const texto = escapeHtml(label);
             return `
         <tr data-kind="resultado">
-          <td>${label}</td>
+          <td colspan="2" class="text-start">${texto}</td>
           ${celdas}
           <td>${formatoValor(totales.total)}</td>
         </tr>
@@ -474,9 +497,10 @@
 
               if (Array.isArray(data.anios) && data.anios.length) {
                 const ordenAsc = data.anios.slice().sort((a, b) => a - b);
-                els.yearSelect.innerHTML = ordenAsc
-                  .map(anio => `<option value="${anio}">${anio}</option>`)
-                  .join('');
+                const opciones = ['<option value="">—</option>'].concat(
+                  ordenAsc.map(anio => `<option value="${anio}">${anio}</option>`)
+                );
+                els.yearSelect.innerHTML = opciones.join('');
                 if (!ordenAsc.includes(state.anio)) {
                   state.anio = ordenAsc[ordenAsc.length - 1]; // último año disponible
                 }
@@ -487,8 +511,11 @@
             } catch (error) {
               console.warn('No fue posible cargar años.', error);
               const actual = new Date().getFullYear();
-              els.yearSelect.innerHTML = `<option value="${actual}">${actual}</option>`;
-              els.yearSelect.value = actual;
+              els.yearSelect.innerHTML = `
+                <option value="">—</option>
+                <option value="${actual}">${actual}</option>
+              `;
+              els.yearSelect.value = String(actual);
               state.anio = actual;
               setStatus(error.message || 'Error al cargar años', 'warning');
             } finally {
@@ -537,7 +564,7 @@
 
             const cuentas = [...state.cuentas.ingresos, ...state.cuentas.gastos];
             if (!cuentas.length) {
-              els.tableBody.innerHTML = '<tr><td colspan="14">No hay cuentas configuradas.</td></tr>';
+              els.tableBody.innerHTML = '<tr><td colspan="15">No hay cuentas configuradas.</td></tr>';
               setStatus('Agrega al menos una cuenta.', 'warning');
               state.cargando = false;
               return;

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -412,10 +412,7 @@
               <div class="col-sm-6 col-lg-3">
                 <label for="selectAnio" class="form-label">Ejercicio</label>
                 <select id="selectAnio" class="form-select">
-                  <option>2022</option>
-                  <option>2021</option>
-                  <option>2020</option>
-                  <option>2019</option>
+                  <option value="">—</option>
                 </select>
               </div>
               <div class="col-sm-6 col-lg-3">

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -632,15 +632,30 @@ async function poblarAniosDesdeSALDOS() {
     if (!sel) return preferred;
     const prev = Number(sel.value);
     sel.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = '—';
+    sel.appendChild(placeholder);
+
     lista.forEach((anio) => {
       const opt = document.createElement('option');
       opt.value = String(anio);
       opt.textContent = String(anio);
       sel.appendChild(opt);
     });
-    const target = lista.includes(prev) ? prev : preferred;
-    sel.value = String(target);
-    return target;
+
+    const tienePrevio = Number.isFinite(prev) && lista.includes(prev);
+    const fallback = Number.isFinite(preferred) ? preferred : lista[lista.length - 1];
+    const target = tienePrevio ? prev : fallback;
+
+    if (Number.isFinite(target)) {
+      sel.value = String(target);
+      return target;
+    }
+
+    sel.value = '';
+    return preferred;
   };
 
   const valorSeleccionado = selects.reduce((acc, sel) => fillSelect(sel, acc ?? prefer), null) ?? prefer;


### PR DESCRIPTION
## Summary
- query Firebird auxiliar tables to compute comité balances per month and expose adjustments in the API response
- sanitize and enrich the comité table to show a dedicated description column while summing adjustments into the totals
- tweak the frontend layout to align the new column and keep empty states consistent with the wider grid

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912542171e0832d8fe6ed38feeb103d)