### PR TITLE
Add admin column visibility toggles

### DIFF
--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -110,11 +110,25 @@
       min-width: 75px;
     }
 
-    .table-comites th:first-child,
-    .table-comites td:first-child {
+    .table-comites .account-column-header {
+      text-align: left;
+      min-width: 160px;
+      white-space: nowrap;
+    }
+
+    .table-comites .account-column {
       text-align: left;
       font-weight: 600;
-      min-width: 320px;
+      min-width: 160px;
+      font-family: 'Courier New', monospace;
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .table-comites .account-description {
+      text-align: left;
+      font-weight: 600;
+      min-width: 240px;
+      color: var(--color-text);
     }
 
     .table-comites thead th {
@@ -141,17 +155,15 @@
       font-weight: 800;
     }
 
-    .table-comites tbody tr[data-section="ingresos"] td:first-child,
-    .table-comites tbody tr[data-section="gastos"] td:first-child {
+    .table-comites tbody tr[data-section="ingresos"] .account-description,
+    .table-comites tbody tr[data-section="gastos"] .account-description {
       color: var(--color-text);
       font-weight: 500;
     }
 
-    .table-comites tbody tr td:first-child span {
-      display: block;
-      color: var(--color-secondary-white);
-      font-size: 0.78rem;
-      font-weight: 500;
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
 
     #comitesStatus {
@@ -211,6 +223,9 @@
           <div id="comitesCuentaSuggestions" class="position-absolute bg-white border rounded shadow-sm d-none"
             style="z-index: 1000; max-height: 200px; overflow-y: auto; width: calc(100% - 80px);"></div>
         </div>
+        <div class="flex-shrink-0 d-flex align-items-end">
+          <button id="comitesToggleAccounts" type="button" class="btn btn-outline-secondary d-none">Ocultar cuentas</button>
+        </div>
       </div>
 
       <div class="table-responsive">
@@ -239,6 +254,7 @@
 
         const API_BASE = 'http://localhost:3000/api';
         const STORAGE_KEY = 'comites_cuentas_v2';
+        const COLUMN_VISIBILITY_KEY = 'comites_ocultar_cuentas';
         const DEFAULT_LIST = {
           ingresos: [
             '404005000000000000002', '404017000000000000002', '404001000000000000002',
@@ -261,6 +277,7 @@
           { clave: 'sep', etiqueta: 'SEP' }, { clave: 'oct', etiqueta: 'OCT' },
           { clave: 'nov', etiqueta: 'NOV' }, { clave: 'dic', etiqueta: 'DIC' }
         ];
+        const TOTAL_COLUMNS = COLUMNS.length + 3;
         const currency = new Intl.NumberFormat('es-MX', {
           style: 'currency',
           currency: 'MXN',
@@ -276,7 +293,8 @@
             tableBody: document.querySelector('#comitesTable tbody'),
             status: document.getElementById('comitesStatus'),
             contextMenu: document.getElementById('comitesContextMenu'),
-            suggestions: document.getElementById('comitesCuentaSuggestions')
+            suggestions: document.getElementById('comitesCuentaSuggestions'),
+            toggleAccounts: document.getElementById('comitesToggleAccounts')
           };
 
           const state = {
@@ -288,6 +306,38 @@
             cuentasDisponibles: [],
             cargando: false,
             needsReload: false
+          };
+
+          const actualizarBotonColumnas = (ocultar) => {
+            if (!els.toggleAccounts) return;
+            els.toggleAccounts.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
+            els.toggleAccounts.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
+          };
+
+          const aplicarVisibilidadCuentas = (ocultar) => {
+            document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
+            actualizarBotonColumnas(Boolean(ocultar));
+          };
+
+          const inicializarToggleColumnas = () => {
+            const esAdminGlobal = typeof Sesion !== 'undefined'
+              && typeof Sesion.esAdminGlobal === 'function'
+              && Sesion.esAdminGlobal(sesion);
+
+            if (!esAdminGlobal || !els.toggleAccounts) {
+              aplicarVisibilidadCuentas(false);
+              return;
+            }
+
+            els.toggleAccounts.classList.remove('d-none');
+            const preferencia = localStorage.getItem(COLUMN_VISIBILITY_KEY) === '1';
+            aplicarVisibilidadCuentas(preferencia);
+
+            els.toggleAccounts.addEventListener('click', () => {
+              const ocultar = !document.body.classList.contains('ocultar-cuentas');
+              aplicarVisibilidadCuentas(ocultar);
+              localStorage.setItem(COLUMN_VISIBILITY_KEY, ocultar ? '1' : '0');
+            });
           };
 
           function cargarLista() {
@@ -358,6 +408,7 @@
             ).join('');
             els.tableHead.innerHTML = `
         <tr>
+          <th class="account-column-header">Cuenta</th>
           <th>COMITÉS</th>
           ${cols}
           <th><span>${anio}</span>Total</th>
@@ -413,7 +464,7 @@
               htmlPartes.push(renderRow(row, 'ingresos'));
             });
             htmlPartes.push(renderTotalRow('Suma de Ingresos Comités', totalIngresos));
-            htmlPartes.push('<tr><td colspan="14" style="background:transparent; border:none;"></td></tr>');
+            htmlPartes.push(`<tr><td colspan="${TOTAL_COLUMNS}" style="background:transparent; border:none;"></td></tr>`);
             gastosRows.forEach((row) => htmlPartes.push(renderRow(row, 'gastos')));
             htmlPartes.push(renderTotalRow('Suma de Gastos Comités', totalGastos));
             htmlPartes.push(renderResultadoRow('Resultado Operativo Comités', resultado));
@@ -426,9 +477,12 @@
             const celdas = COLUMNS.map(col =>
               `<td>${formatoValor(row.valores[col.clave])}</td>`
             ).join('');
+            const descripcion = row.nombre || row.codigo;
+            const codigo = row.codigo || '—';
             return `
         <tr data-cuenta="${row.codigo}" data-section="${section}">
-          <td>${row.codigo} <br><span class="text-white-50">${row.nombre}</span></td>
+          <td class="account-column">${codigo}</td>
+          <td class="account-description">${descripcion}</td>
           ${celdas}
           <td>${formatoValor(row.valores.total)}</td>
         </tr>
@@ -441,7 +495,7 @@
             ).join('');
             return `
         <tr data-kind="total">
-          <td>${label}</td>
+          <td colspan="2">${label}</td>
           ${celdas}
           <td>${formatoValor(totales.total)}</td>
         </tr>
@@ -454,7 +508,7 @@
             ).join('');
             return `
         <tr data-kind="resultado">
-          <td>${label}</td>
+          <td colspan="2">${label}</td>
           ${celdas}
           <td>${formatoValor(totales.total)}</td>
         </tr>
@@ -547,7 +601,7 @@
 
             const cuentas = [...state.cuentas.ingresos, ...state.cuentas.gastos];
             if (!cuentas.length) {
-              els.tableBody.innerHTML = '<tr><td colspan="14">No hay cuentas configuradas.</td></tr>';
+              els.tableBody.innerHTML = `<tr><td colspan="${TOTAL_COLUMNS}">No hay cuentas configuradas.</td></tr>`;
               setStatus('Agrega al menos una cuenta.', 'warning');
               state.cargando = false;
               return;
@@ -718,6 +772,8 @@
             if (state.cuentaSeleccionada) eliminarCuenta(state.cuentaSeleccionada);
             ocultarContextMenu();
           });
+
+          inicializarToggleColumnas();
 
           async function inicializarPanel() {
             await poblarAnios();

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -137,6 +137,23 @@
     .hidden-row {
       display: none;
     }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
   </style>
 </head>
 
@@ -163,10 +180,11 @@
         <div class="card table-card fade-in">
           <div class="card-body p-3">
             <h5 class="fw-bold mb-3" style="color: var(--color-primary);">Controles de Presupuesto</h5>
-            <div class="btn-group btn-group-custom" role="group">
+            <div class="btn-group btn-group-custom flex-wrap" role="group">
               <button type="button" class="btn btn-primario btn-custom" id="saveBudgetBtn">Guardar</button>
               <button type="button" class="btn btn-outline-success btn-custom" id="loadBudgetBtn">Cargar</button>
               <button type="button" class="btn btn-success btn-custom">Autorizar</button>
+              <button type="button" class="btn btn-outline-secondary btn-custom d-none" id="toggleAccountColumnBtn">Ocultar cuentas</button>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none">
           </div>
@@ -190,7 +208,7 @@
             <table class="table align-middle mb-0" id="tablaPresupuestos">
               <thead>
                 <tr>
-                  <th scope="col" class="text-start">Cuenta</th>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
                   <th scope="col" class="text-start">Descripción</th>
                   <th scope="col" class="text-end">Ene</th>
                   <th scope="col" class="text-end">Feb</th>
@@ -251,6 +269,9 @@
         const yearLabel = document.getElementById('yearLabel');
         const yearColumn = document.getElementById('yearColumn');
         const empresaLabel = document.getElementById('empresaLabel');
+        const toggleAccountColumnBtn = document.getElementById('toggleAccountColumnBtn');
+
+        const ACCOUNT_COLUMN_STORAGE_KEY = 'presupuestos_ocultar_cuentas';
 
         const EJERCICIO = new Date().getFullYear();
         const MESES = [
@@ -276,6 +297,39 @@
           cuentas: [],
           filtro: ''
         };
+
+        const actualizarEtiquetaBotonCuentas = (ocultar) => {
+          if (!toggleAccountColumnBtn) return;
+          toggleAccountColumnBtn.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
+          toggleAccountColumnBtn.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
+        };
+
+        const aplicarVisibilidadCuentas = (ocultar) => {
+          document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
+          actualizarEtiquetaBotonCuentas(Boolean(ocultar));
+        };
+
+        const inicializarControlCuentas = () => {
+          const esAdminGlobal = typeof Sesion !== 'undefined'
+            && typeof Sesion.esAdminGlobal === 'function'
+            && Sesion.esAdminGlobal(sesion);
+          if (!esAdminGlobal || !toggleAccountColumnBtn) {
+            aplicarVisibilidadCuentas(false);
+            return;
+          }
+
+          toggleAccountColumnBtn.classList.remove('d-none');
+          const preferencia = localStorage.getItem(ACCOUNT_COLUMN_STORAGE_KEY) === '1';
+          aplicarVisibilidadCuentas(preferencia);
+
+          toggleAccountColumnBtn.addEventListener('click', () => {
+            const ocultar = !document.body.classList.contains('ocultar-cuentas');
+            aplicarVisibilidadCuentas(ocultar);
+            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, ocultar ? '1' : '0');
+          });
+        };
+
+        inicializarControlCuentas();
 
         function showToast(message, variant = 'text-bg-success') {
           toastElement.classList.remove('text-bg-success', 'text-bg-danger', 'text-bg-warning', 'text-bg-info');
@@ -332,6 +386,7 @@
 
             const celdaCuenta = document.createElement('td');
             celdaCuenta.textContent = cuenta.numCta || '—';
+            celdaCuenta.className = 'account-column';
             fila.appendChild(celdaCuenta);
 
             const celdaNombre = document.createElement('td');
@@ -512,7 +567,6 @@
           actualizarEncabezadoEmpresa();
           cargarPresupuestos();
         });
-      </script>
       </script>
 </body>
 

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -234,6 +234,26 @@
       font-weight: 400;
     }
 
+    .account-column-header {
+      text-align: left;
+      width: 90px;
+      white-space: nowrap;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: .65rem;
+      color: #333;
+      background-color: #f2f2f2 !important;
+      font-weight: 400;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
     .mono {
       font-variant-numeric: tabular-nums;
       font-feature-settings: "tnum";
@@ -494,6 +514,13 @@
         </svg>
         Restablecer
       </button>
+      <button class="zoom-btn d-none" id="toggleAccountColumnBtn">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+          <line x1="9" y1="3" x2="9" y2="21"></line>
+        </svg>
+        <span class="toggle-account-label">Ocultar cuentas</span>
+      </button>
     </div>
 
     <!-- Tabla réplica -->
@@ -506,7 +533,7 @@
               <table class="table align-middle mb-0" id="mainTable">
                 <thead>
                   <tr>
-                    <th></th>
+                    <th class="account-column-header"></th>
                     <th></th>
                     <th></th>
                     <th></th>
@@ -516,7 +543,7 @@
                     <td colspan="1" class="ytd-head">Y&nbsp;T&nbsp;D</td>
                   </tr>
                   <tr class="subhdr">
-                    <th></th>
+                    <th class="account-column-header"></th>
                     <th>Actual</th>
                     <th>Plan</th>
                     <th><span class="anio">2021</span></th>
@@ -530,7 +557,7 @@
                     <th></th>
                   </tr>
                   <tr class="subhdr">
-                    <th></th>
+                    <th class="account-column-header"></th>
                     <td></td>
                     <td></td>
                     <td></td>
@@ -587,6 +614,8 @@
         const zoomOutBtn = document.getElementById('zoomOut');
         const zoomResetBtn = document.getElementById('zoomReset');
         const zoomDisplay = document.getElementById('zoomDisplay');
+        const toggleAccountColumnBtn = document.getElementById('toggleAccountColumnBtn');
+        const ACCOUNT_COLUMN_STORAGE_KEY = 'summary_ocultar_cuentas';
 
         let selectedCell = null;
         let zoomLevel = 1;
@@ -622,6 +651,41 @@
           });
         }
 
+        const actualizarBotonColumnas = (ocultar) => {
+          if (!toggleAccountColumnBtn) return;
+          const etiqueta = toggleAccountColumnBtn.querySelector('.toggle-account-label');
+          if (etiqueta) {
+            etiqueta.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
+          }
+          toggleAccountColumnBtn.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
+        };
+
+        const aplicarVisibilidadCuentas = (ocultar) => {
+          document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
+          actualizarBotonColumnas(Boolean(ocultar));
+        };
+
+        const inicializarToggleColumnas = () => {
+          const esAdminGlobal = typeof Sesion !== 'undefined'
+            && typeof Sesion.esAdminGlobal === 'function'
+            && Sesion.esAdminGlobal(window.sesion);
+
+          if (!esAdminGlobal || !toggleAccountColumnBtn) {
+            aplicarVisibilidadCuentas(false);
+            return;
+          }
+
+          toggleAccountColumnBtn.classList.remove('d-none');
+          const preferencia = localStorage.getItem(ACCOUNT_COLUMN_STORAGE_KEY) === '1';
+          aplicarVisibilidadCuentas(preferencia);
+
+          toggleAccountColumnBtn.addEventListener('click', () => {
+            const ocultar = !document.body.classList.contains('ocultar-cuentas');
+            aplicarVisibilidadCuentas(ocultar);
+            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, ocultar ? '1' : '0');
+          });
+        };
+
         if (table) {
           table.addEventListener('click', (event) => {
             const cell = event.target.closest('td, th');
@@ -642,6 +706,7 @@
           }
         });
 
+        inicializarToggleColumnas();
         renderZoom();
       });
     })();

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -112,6 +112,11 @@
     return Boolean(generales.puedeAgregar && generales.puedeModificar && generales.puedeEliminar);
   };
 
+  const esAdminGlobal = (sesion) => {
+    const evaluada = sesion || obtener();
+    return Boolean(evaluada?.usuario?.esAdminGlobal);
+  };
+
   const esAdmin = (sesion) => puedeAdministrarUsuarios(sesion);
 
   const requerirSesion = ({ requireAdmin = false, redirectTo = REDIRECCION_POR_DEFECTO } = {}) => {
@@ -186,6 +191,7 @@
     limpiar,
     requerirSesion,
     esAdmin,
+    esAdminGlobal,
     puedeAdministrarUsuarios,
     asegurarEnlaceAdministrarUsuarios,
     headersAutenticacion,

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -908,7 +908,7 @@ function renderizarTabla() {
       if (fila.tipoFila) clases.push(`fila-${fila.tipoFila}`);
       tr.className = clases.join(' ');
       tr.innerHTML = `
-        <th id="cell-r${r}-c1" data-row-index="${r}" data-col-index="1" data-column-key="codigo" data-role="code"></th>
+        <th id="cell-r${r}-c1" data-row-index="${r}" data-col-index="1" data-column-key="codigo" data-role="code" class="account-column code-cell"></th>
         <td id="cell-r${r}-c2" data-row-index="${r}" data-col-index="2" data-column-key="mesActual" class="mono">${formatearMoneda(fila.mesActual)}</td>
         <td id="cell-r${r}-c3" data-row-index="${r}" data-col-index="3" data-column-key="mesPlan" class="mono">${formatearMoneda(fila.mesPlan)}</td>
         <td id="cell-r${r}-c4" data-row-index="${r}" data-col-index="4" data-column-key="mesAnterior" class="mono">${formatearMoneda(fila.mesAnterior)}</td>
@@ -926,7 +926,7 @@ function renderizarTabla() {
       if (fila.tipoFila && fila.tipoFila !== 'detalle') clases.push(`fila-${fila.tipoFila}`);
       if (clases.length) tr.className = clases.join(' ');
       tr.innerHTML = `
-        <th id="cell-r${r}-c1" data-row-index="${r}" data-col-index="1" data-column-key="codigo" data-role="code" class="code-cell" data-codigo="${fila.codigo || ''}">${fila.codigo || ''}</th>
+        <th id="cell-r${r}-c1" data-row-index="${r}" data-col-index="1" data-column-key="codigo" data-role="code" class="account-column code-cell" data-codigo="${fila.codigo || ''}">${fila.codigo || ''}</th>
         <td id="cell-r${r}-c2" data-row-index="${r}" data-col-index="2" data-column-key="mesActual" class="mono">${formatearMoneda(fila.mesActual)}</td>
         <td id="cell-r${r}-c3" data-row-index="${r}" data-col-index="3" data-column-key="mesPlan" class="mono">${formatearMoneda(fila.mesPlan)}</td>
         <td id="cell-r${r}-c4" data-row-index="${r}" data-col-index="4" data-column-key="mesAnterior" class="mono">${formatearMoneda(fila.mesAnterior)}</td>


### PR DESCRIPTION
## Summary
- add an esAdminGlobal helper to reuse the admin-global flag
- provide global admins with buttons to hide/show account columns in Presupuestos, Comités, and Summary views
- remember the chosen visibility per module and adjust the Comités layout to split account and description columns

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b2edc34c832db9656c286d273aef)