### PR TITLE
Forzar ocultar cuentas para usuarios no globales

### DIFF
--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -325,7 +325,15 @@
               && Sesion.esAdminGlobal(sesion);
 
             if (!esAdminGlobal || !els.toggleAccounts) {
-              aplicarVisibilidadCuentas(false);
+              aplicarVisibilidadCuentas(true);
+              if (els.toggleAccounts) {
+                els.toggleAccounts.classList.add('d-none');
+                els.toggleAccounts.setAttribute('aria-pressed', 'true');
+                els.toggleAccounts.setAttribute('disabled', 'true');
+                els.toggleAccounts.setAttribute('aria-disabled', 'true');
+                els.toggleAccounts.setAttribute('tabindex', '-1');
+              }
+              localStorage.setItem(COLUMN_VISIBILITY_KEY, '1');
               return;
             }
 

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -314,7 +314,15 @@
             && typeof Sesion.esAdminGlobal === 'function'
             && Sesion.esAdminGlobal(sesion);
           if (!esAdminGlobal || !toggleAccountColumnBtn) {
-            aplicarVisibilidadCuentas(false);
+            aplicarVisibilidadCuentas(true);
+            if (toggleAccountColumnBtn) {
+              toggleAccountColumnBtn.classList.add('d-none');
+              toggleAccountColumnBtn.setAttribute('aria-pressed', 'true');
+              toggleAccountColumnBtn.setAttribute('disabled', 'true');
+              toggleAccountColumnBtn.setAttribute('aria-disabled', 'true');
+              toggleAccountColumnBtn.setAttribute('tabindex', '-1');
+            }
+            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, '1');
             return;
           }
 

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -671,7 +671,15 @@
             && Sesion.esAdminGlobal(window.sesion);
 
           if (!esAdminGlobal || !toggleAccountColumnBtn) {
-            aplicarVisibilidadCuentas(false);
+            aplicarVisibilidadCuentas(true);
+            if (toggleAccountColumnBtn) {
+              toggleAccountColumnBtn.classList.add('d-none');
+              toggleAccountColumnBtn.setAttribute('aria-pressed', 'true');
+              toggleAccountColumnBtn.setAttribute('disabled', 'true');
+              toggleAccountColumnBtn.setAttribute('aria-disabled', 'true');
+              toggleAccountColumnBtn.setAttribute('tabindex', '-1');
+            }
+            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, '1');
             return;
           }
 


### PR DESCRIPTION
## Summary
- oculta las columnas de cuentas por defecto para sesiones sin privilegios de administrador global
- deshabilita los controles de alternancia y mantiene la preferencia persistida cuando el usuario no puede ver cuentas

## Testing
- No se ejecutaron pruebas (cambios en frontend)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913cf5ce4e0832db53dfd69680ced70)