### PR TITLE
Add workflow controls, notifications, and unified budget views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^5.1.0",
         "helmet": "^8.1.0",
         "joi": "^18.0.1",
-        "node-firebird": "^1.1.9"
+        "node-firebird": "^1.1.9",
+        "nodemailer": "^7.0.10"
       },
       "devDependencies": {
         "electron": "^38.2.2",
@@ -954,7 +955,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1121,6 +1121,7 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -1140,6 +1141,7 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -1162,6 +1164,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1177,7 +1180,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1185,6 +1189,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -1883,6 +1888,7 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -2038,6 +2044,7 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -2051,6 +2058,7 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -2261,7 +2269,6 @@
       "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "builder-util": "25.1.7",
@@ -2462,6 +2469,7 @@
       "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "25.1.8",
         "archiver": "^5.3.1",
@@ -2475,6 +2483,7 @@
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2490,6 +2499,7 @@
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2503,6 +2513,7 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3633,7 +3644,8 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.6",
@@ -3788,6 +3800,7 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -3801,6 +3814,7 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3816,7 +3830,8 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3824,6 +3839,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -3840,35 +3856,40 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4363,6 +4384,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
+      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
@@ -4385,6 +4415,7 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4700,7 +4731,8 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4882,6 +4914,7 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -4892,6 +4925,7 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4902,6 +4936,7 @@
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6078,6 +6113,7 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -6093,6 +6129,7 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "express": "^5.1.0",
     "helmet": "^8.1.0",
     "joi": "^18.0.1",
-    "node-firebird": "^1.1.9"
+    "node-firebird": "^1.1.9",
+    "nodemailer": "^7.0.10"
   }
 }

--- a/src/db/sqlite.js
+++ b/src/db/sqlite.js
@@ -57,6 +57,49 @@ const crearTablas = () => {
       FOREIGN KEY(usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
     )
   `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS presupuestos_estado (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      empresa_id TEXT NOT NULL,
+      modulo TEXT NOT NULL,
+      anio INTEGER NOT NULL,
+      estado TEXT NOT NULL DEFAULT 'sin-cargar',
+      actualizado_por INTEGER,
+      actualizado_en TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(empresa_id, modulo, anio),
+      FOREIGN KEY(actualizado_por) REFERENCES usuarios(id) ON DELETE SET NULL
+    )
+  `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS presupuestos_estado_historial (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      empresa_id TEXT NOT NULL,
+      modulo TEXT NOT NULL,
+      anio INTEGER NOT NULL,
+      estado TEXT NOT NULL,
+      usuario_id INTEGER,
+      registrado_en TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(usuario_id) REFERENCES usuarios(id) ON DELETE SET NULL
+    )
+  `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS notificaciones (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      usuario_id INTEGER NOT NULL,
+      empresa_id TEXT,
+      modulo TEXT,
+      titulo TEXT NOT NULL,
+      mensaje TEXT NOT NULL,
+      tipo TEXT NOT NULL DEFAULT 'info',
+      enlace TEXT DEFAULT '',
+      creada_en TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      leida_en TEXT,
+      FOREIGN KEY(usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE
+    )
+  `).run();
 };
 
 const asegurarColumnasUsuarios = () => {

--- a/src/routes/notificaciones.js
+++ b/src/routes/notificaciones.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { db } = require('../db/sqlite');
+const {
+  listarNotificacionesPorUsuario,
+  marcarNotificacionComoLeida
+} = require('../services/notificacionesService');
+
+const router = express.Router();
+
+const normalizarUsuario = (valor) => (valor || '').toString().trim().toUpperCase();
+
+const cargarUsuarioActual = (req, res, next) => {
+  const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
+  if (!usuarioEncabezado) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+  const registro = db.prepare(`
+    SELECT id, usuario
+    FROM usuarios
+    WHERE usuario = ?
+  `).get(usuarioEncabezado);
+  if (!registro) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+  req.usuarioActual = registro;
+  next();
+};
+
+router.use(cargarUsuarioActual);
+
+router.get('/', (req, res) => {
+  const soloNoLeidas = req.query.leidas === 'false' || req.query.estado === 'pendientes';
+  const limite = Number(req.query.limite) || 20;
+  const notificaciones = listarNotificacionesPorUsuario(req.usuarioActual.id, {
+    soloNoLeidas,
+    limite
+  });
+  res.json({ notificaciones });
+});
+
+router.patch('/:id/leida', (req, res) => {
+  const notificacionId = Number(req.params.id);
+  if (!Number.isInteger(notificacionId) || notificacionId <= 0) {
+    return res.status(400).json({ mensaje: 'El identificador proporcionado no es válido.' });
+  }
+  const actualizado = marcarNotificacionComoLeida(req.usuarioActual.id, notificacionId);
+  if (!actualizado) {
+    return res.status(404).json({ mensaje: 'No se encontró la notificación solicitada.' });
+  }
+  res.json({ mensaje: 'Notificación actualizada.' });
+});
+
+module.exports = router;

--- a/src/routes/presupuestos.js
+++ b/src/routes/presupuestos.js
@@ -2,8 +2,9 @@ const express = require('express');
 const Joi = require('joi');
 const { db } = require('../db/sqlite');
 const { obtenerEmpresaPorId } = require('../config/empresas');
-const { construirMapaPermisos } = require('../services/permisosService');
+const { MODULOS, construirMapaPermisos } = require('../services/permisosService');
 const { obtenerPresupuestosMayor, PERIODOS } = require('../services/presupuestosService');
+const { notificarWorkflowPresupuesto } = require('../services/notificacionesService');
 
 const router = express.Router();
 
@@ -12,6 +13,17 @@ const normalizarUsuario = (valor) => (valor || '').toString().trim().toUpperCase
 const esquemaConsulta = Joi.object({
   anio: Joi.number().integer().min(2000).max(2100).optional(),
   empresaId: Joi.string().trim().optional()
+});
+
+const esquemaEstado = Joi.object({
+  modulo: Joi.string().trim().required(),
+  anio: Joi.number().integer().min(2000).max(2100).required()
+});
+
+const esquemaTransicion = Joi.object({
+  modulo: Joi.string().trim().required(),
+  anio: Joi.number().integer().min(2000).max(2100).required(),
+  accion: Joi.string().valid('cargar', 'revisar', 'autorizar', 'aprobar').required()
 });
 
 const serializarEmpresa = (empresa) => {
@@ -25,64 +37,139 @@ const serializarEmpresa = (empresa) => {
   };
 };
 
+const ESTADOS_VALIDOS = ['sin-cargar', 'borrador', 'revisado', 'autorizado', 'aprobado'];
+
+const TRANSICIONES = {
+  cargar: { destino: 'borrador', requiere: 'Cargar y guardar', habilita: (estado) => ['sin-cargar', 'borrador'].includes(estado) },
+  revisar: { destino: 'revisado', requiere: 'Revisar', habilita: (estado) => estado === 'borrador' },
+  autorizar: { destino: 'autorizado', requiere: 'Aprobar', habilita: (estado) => estado === 'revisado' },
+  aprobar: { destino: 'aprobado', requiere: 'Aprobar', habilita: (estado) => estado === 'autorizado' }
+};
+
+const construirNombreUsuario = (registro) => {
+  const partes = [registro?.nombres, registro?.apellido_primero, registro?.apellido_segundo].filter(Boolean);
+  const nombre = partes.join(' ').trim();
+  return nombre || registro?.usuario || 'Usuario';
+};
+
+const cargarUsuarioActual = (req, res, next) => {
+  const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
+  if (!usuarioEncabezado) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+  const registro = db.prepare(`
+    SELECT id, usuario, es_admin_global, nombres, apellido_primero, apellido_segundo, apellidos
+    FROM usuarios
+    WHERE usuario = ?
+  `).get(usuarioEncabezado);
+  if (!registro) {
+    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
+  }
+  req.usuarioActual = registro;
+  const esIconet = registro.usuario === 'ICONET';
+  req.esAdmin = esIconet || Boolean(registro.es_admin_global);
+  if (!req.esAdmin) {
+    const permisos = db.prepare(`
+      SELECT empresa_id, modulo, puede_cargar_guardar, puede_revisar, puede_aprobar
+      FROM permisos_modulo
+      WHERE usuario_id = ?
+    `).all(registro.id);
+    req.mapaPermisos = construirMapaPermisos(permisos);
+  } else {
+    req.mapaPermisos = {};
+  }
+  next();
+};
+
+router.use(cargarUsuarioActual);
+
 const tienePermisoEnEmpresa = (mapaPermisos, empresaId) => {
-  const permisos = mapaPermisos[empresaId];
+  const permisos = mapaPermisos?.[empresaId];
   if (!permisos) {
     return false;
   }
   return Object.values(permisos).some((acciones) => acciones['Cargar y guardar'] || acciones.Revisar || acciones.Aprobar);
 };
 
+const tienePermisoEnModulo = (mapaPermisos, empresaId, modulo, accion) => {
+  const permisos = mapaPermisos?.[empresaId]?.[modulo];
+  if (!permisos) {
+    return false;
+  }
+  if (!accion) {
+    return Boolean(permisos['Cargar y guardar'] || permisos.Revisar || permisos.Aprobar);
+  }
+  return Boolean(permisos[accion]);
+};
+
+const validarModulo = (modulo) => MODULOS.includes(modulo);
+
+const obtenerEstadoPresupuesto = (empresaId, modulo, anio) => {
+  const estadoActual = db.prepare(`
+    SELECT e.estado,
+           e.actualizado_en AS actualizadoEn,
+           TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS actualizadoPor
+    FROM presupuestos_estado e
+    LEFT JOIN usuarios u ON u.id = e.actualizado_por
+    WHERE e.empresa_id = ? AND e.modulo = ? AND e.anio = ?
+  `).get(empresaId, modulo, anio);
+  const historial = db.prepare(`
+    SELECT h.estado, h.registrado_en AS fecha,
+           TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS usuario
+    FROM presupuestos_estado_historial h
+    LEFT JOIN usuarios u ON u.id = h.usuario_id
+    WHERE h.empresa_id = ? AND h.modulo = ? AND h.anio = ?
+    ORDER BY h.registrado_en DESC
+    LIMIT 10
+  `).all(empresaId, modulo, anio);
+  return {
+    estado: estadoActual?.estado || 'sin-cargar',
+    actualizadoEn: estadoActual?.actualizadoEn || null,
+    actualizadoPor: estadoActual?.actualizadoPor || '',
+    historial: historial.map((registro) => ({
+      estado: registro.estado,
+      fecha: registro.fecha,
+      usuario: registro.usuario
+    }))
+  };
+};
+
+const guardarEstadoPresupuesto = (empresaId, modulo, anio, estado, usuarioId) => {
+  db.prepare(`
+    INSERT INTO presupuestos_estado (
+      empresa_id, modulo, anio, estado, actualizado_por, actualizado_en
+    ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    ON CONFLICT(empresa_id, modulo, anio) DO UPDATE SET
+      estado = excluded.estado,
+      actualizado_por = excluded.actualizado_por,
+      actualizado_en = CURRENT_TIMESTAMP
+  `).run(empresaId, modulo, anio, estado, usuarioId);
+  db.prepare(`
+    INSERT INTO presupuestos_estado_historial (
+      empresa_id, modulo, anio, estado, usuario_id, registrado_en
+    ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+  `).run(empresaId, modulo, anio, estado, usuarioId);
+  return obtenerEstadoPresupuesto(empresaId, modulo, anio);
+};
+
 router.get('/', async (req, res) => {
-  const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
-  if (!usuarioEncabezado) {
-    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
-  }
-
-  const consultaDatosSesion = db.prepare(`
-    SELECT id, usuario, es_admin_global
-    FROM usuarios
-    WHERE usuario = ?
-  `);
-  const usuario = consultaDatosSesion.get(usuarioEncabezado);
-  if (!usuario) {
-    return res.status(401).json({ mensaje: 'No fue posible validar al usuario actual.' });
-  }
-
-  const esIconet = usuario.usuario === 'ICONET';
-  const esAdmin = esIconet || Boolean(usuario.es_admin_global);
-
   const { value, error } = esquemaConsulta.validate(req.query, { abortEarly: false });
   if (error) {
     return res.status(400).json({ mensaje: 'Los parámetros proporcionados no son válidos.', detalles: error.details.map((detalle) => detalle.message) });
   }
-
   const empresaId = value.empresaId || req.headers['x-empresa-activa'];
   if (!empresaId) {
     return res.status(400).json({ mensaje: 'Debes indicar una empresa.' });
   }
-
   const empresa = obtenerEmpresaPorId(empresaId);
   if (!empresa) {
     return res.status(404).json({ mensaje: 'La empresa indicada no existe.' });
   }
-
-  let mapaPermisos = {};
-  if (!esAdmin) {
-    const permisos = db.prepare(`
-      SELECT empresa_id, modulo, puede_cargar_guardar, puede_revisar, puede_aprobar
-      FROM permisos_modulo
-      WHERE usuario_id = ?
-    `).all(usuario.id);
-    mapaPermisos = construirMapaPermisos(permisos);
-    if (!tienePermisoEnEmpresa(mapaPermisos, empresa.id)) {
-      return res.status(403).json({ mensaje: 'No cuentas con permisos para consultar esta empresa.' });
-    }
+  if (!req.esAdmin && !tienePermisoEnEmpresa(req.mapaPermisos, empresa.id)) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para consultar esta empresa.' });
   }
-
   const anioActual = new Date().getFullYear();
   const ejercicio = value.anio || anioActual;
-
   try {
     const cuentas = await obtenerPresupuestosMayor(empresa.id, ejercicio);
     res.json({
@@ -95,6 +182,77 @@ router.get('/', async (req, res) => {
     console.error('Error al consultar presupuestos:', err);
     res.status(500).json({ mensaje: 'No fue posible obtener la información de presupuestos.' });
   }
+});
+
+router.get('/estado', (req, res) => {
+  const { value, error } = esquemaEstado.validate(req.query, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Los parámetros proporcionados no son válidos.', detalles: error.details.map((detalle) => detalle.message) });
+  }
+  const empresaId = req.headers['x-empresa-activa'];
+  if (!empresaId) {
+    return res.status(400).json({ mensaje: 'Debes indicar una empresa.' });
+  }
+  const modulo = value.modulo;
+  if (!validarModulo(modulo)) {
+    return res.status(400).json({ mensaje: 'El módulo indicado no es válido.' });
+  }
+  const empresa = obtenerEmpresaPorId(empresaId);
+  if (!empresa) {
+    return res.status(404).json({ mensaje: 'La empresa indicada no existe.' });
+  }
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, empresaId, modulo)) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para este módulo.' });
+  }
+  const estado = obtenerEstadoPresupuesto(empresaId, modulo, value.anio);
+  res.json(estado);
+});
+
+router.post('/estado', (req, res) => {
+  const { value, error } = esquemaTransicion.validate(req.body || {}, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Verifica la información proporcionada.', detalles: error.details.map((detalle) => detalle.message) });
+  }
+  const empresaId = req.headers['x-empresa-activa'];
+  if (!empresaId) {
+    return res.status(400).json({ mensaje: 'Debes indicar una empresa.' });
+  }
+  const modulo = value.modulo;
+  if (!validarModulo(modulo)) {
+    return res.status(400).json({ mensaje: 'El módulo indicado no existe.' });
+  }
+  const empresa = obtenerEmpresaPorId(empresaId);
+  if (!empresa) {
+    return res.status(404).json({ mensaje: 'La empresa indicada no existe.' });
+  }
+  const transicion = TRANSICIONES[value.accion];
+  if (!transicion) {
+    return res.status(400).json({ mensaje: 'Acción no reconocida.' });
+  }
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, empresaId, modulo, transicion.requiere)) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para realizar esta acción.' });
+  }
+  const estadoActual = obtenerEstadoPresupuesto(empresaId, modulo, value.anio);
+  if (!transicion.habilita(estadoActual.estado)) {
+    return res.status(409).json({ mensaje: `El estado actual no permite ejecutar la acción ${value.accion}.` });
+  }
+  const nuevoEstado = guardarEstadoPresupuesto(empresaId, modulo, value.anio, transicion.destino, req.usuarioActual.id);
+  const mensaje = `El presupuesto se actualizó a ${transicion.destino}.`;
+  res.json({ mensaje, ...nuevoEstado });
+  notificarWorkflowPresupuesto({
+    empresaId,
+    modulo,
+    anio: value.anio,
+    accion: value.accion,
+    estado: transicion.destino,
+    ejecutor: {
+      id: req.usuarioActual.id,
+      usuario: req.usuarioActual.usuario,
+      nombre: construirNombreUsuario(req.usuarioActual)
+    }
+  }).catch((notifError) => {
+    console.warn('No fue posible enviar notificaciones del workflow.', notifError);
+  });
 });
 
 module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ const rutasEmpresas = require('./routes/empresas');
 const rutasModulos = require('./routes/modulos');
 const rutasPresupuestos = require('./routes/presupuestos');
 const rutasComites = require('./routes/comitesRoutes');
+const rutasNotificaciones = require('./routes/notificaciones');
 
 let instanciaServidor = null;
 
@@ -32,6 +33,7 @@ const iniciarServidor = (puerto = Number(process.env.PORT || 3000)) => {
   app.use('/api/modulos', rutasModulos);
   app.use('/api/presupuestos', rutasPresupuestos);
   app.use('/api/comites', rutasComites);
+  app.use('/api/notificaciones', rutasNotificaciones);
 
   app.use((req, res) => {
     res.status(404).json({ mensaje: 'Recurso no encontrado.' });

--- a/src/services/notificacionesService.js
+++ b/src/services/notificacionesService.js
@@ -1,0 +1,196 @@
+const nodemailer = require('nodemailer');
+const { db } = require('../db/sqlite');
+const { obtenerEmpresaPorId } = require('../config/empresas');
+
+let transporter = null;
+let transporterInicializado = false;
+
+const obtenerTransporter = () => {
+  if (transporterInicializado) {
+    return transporter;
+  }
+  transporterInicializado = true;
+  const host = process.env.SMTP_HOST;
+  if (!host) {
+    return null;
+  }
+  const puerto = Number(process.env.SMTP_PORT || 587);
+  const seguro = String(process.env.SMTP_SECURE || '').toLowerCase() === 'true';
+  const usuario = process.env.SMTP_USER;
+  const contrasena = process.env.SMTP_PASS;
+  transporter = nodemailer.createTransport({
+    host,
+    port: puerto,
+    secure: seguro,
+    auth: usuario && contrasena ? { user: usuario, pass: contrasena } : undefined
+  });
+  return transporter;
+};
+
+const enviarCorreoNotificacion = async ({ para, asunto, cuerpo }) => {
+  const activo = obtenerTransporter();
+  if (!activo) {
+    console.info('SMTP no configurado, notificación solo local.', { para, asunto });
+    return false;
+  }
+  try {
+    await activo.sendMail({
+      from: process.env.SMTP_FROM || 'notificaciones@amcham.org',
+      to: para,
+      subject: asunto,
+      html: cuerpo
+    });
+    return true;
+  } catch (error) {
+    console.warn('No fue posible enviar el correo de notificación.', error);
+    return false;
+  }
+};
+
+const registrarNotificacion = (notificacion) => {
+  const insert = db.prepare(`
+    INSERT INTO notificaciones (
+      usuario_id, empresa_id, modulo, titulo, mensaje, tipo, enlace
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  const resultado = insert.run(
+    notificacion.usuarioId,
+    notificacion.empresaId || null,
+    notificacion.modulo || null,
+    notificacion.titulo || 'Notificación',
+    notificacion.mensaje || '',
+    notificacion.tipo || 'info',
+    notificacion.enlace || ''
+  );
+  return resultado.lastInsertRowid;
+};
+
+const registrarNotificacionesMasivas = (destinatarios = [], datosBase = {}) => {
+  const transaccion = db.transaction((items) => {
+    return items.map((dest) => {
+      const id = registrarNotificacion({
+        usuarioId: dest.id,
+        empresaId: datosBase.empresaId,
+        modulo: datosBase.modulo,
+        titulo: datosBase.titulo,
+        mensaje: datosBase.mensaje,
+        tipo: datosBase.tipo,
+        enlace: datosBase.enlace
+      });
+      return { id, ...datosBase, usuarioId: dest.id };
+    });
+  });
+  return transaccion(destinatarios);
+};
+
+const listarNotificacionesPorUsuario = (usuarioId, { soloNoLeidas = false, limite = 20 } = {}) => {
+  const limiteSeguro = Math.max(1, Math.min(Number(limite) || 20, 50));
+  const query = `
+    SELECT id, empresa_id AS empresaId, modulo, titulo, mensaje, tipo, enlace,
+           creada_en AS creadaEn, leida_en AS leidaEn
+    FROM notificaciones
+    WHERE usuario_id = ?
+      ${soloNoLeidas ? 'AND leida_en IS NULL' : ''}
+    ORDER BY creada_en DESC
+    LIMIT ?
+  `;
+  return db.prepare(query).all(usuarioId, limiteSeguro);
+};
+
+const marcarNotificacionComoLeida = (usuarioId, notificacionId) => {
+  const update = db.prepare(`
+    UPDATE notificaciones
+    SET leida_en = CURRENT_TIMESTAMP
+    WHERE id = ? AND usuario_id = ? AND leida_en IS NULL
+  `);
+  const resultado = update.run(notificacionId, usuarioId);
+  return resultado.changes > 0;
+};
+
+const mapearColumnaPermiso = (permiso) => {
+  switch (permiso) {
+    case 'Cargar y guardar':
+      return 'puede_cargar_guardar';
+    case 'Revisar':
+      return 'puede_revisar';
+    case 'Aprobar':
+      return 'puede_aprobar';
+    default:
+      return null;
+  }
+};
+
+const obtenerUsuariosPorPermiso = (empresaId, modulo, columnaPermiso) => {
+  if (!columnaPermiso) {
+    return [];
+  }
+  const consulta = db.prepare(`
+    SELECT u.id, u.correo,
+           TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS nombre
+    FROM permisos_modulo pm
+    INNER JOIN usuarios u ON u.id = pm.usuario_id
+    WHERE pm.empresa_id = ?
+      AND pm.modulo = ?
+      AND pm.${columnaPermiso} = 1
+  `);
+  return consulta.all(empresaId, modulo);
+};
+
+const construirMensajeCorreo = ({ titulo, mensaje, enlace }) => {
+  const cuerpo = [`<p>${mensaje}</p>`];
+  if (enlace) {
+    cuerpo.push(`<p><a href="${enlace}">Abrir detalle</a></p>`);
+  }
+  return cuerpo.join('');
+};
+
+const MAPA_DESTINATARIOS = {
+  cargar: { permiso: 'Revisar', asunto: 'listo para revisión' },
+  revisar: { permiso: 'Aprobar', asunto: 'requiere autorización' },
+  autorizar: { permiso: 'Cargar y guardar', asunto: 'autorizado y listo para guardar' },
+  aprobar: { permiso: 'Cargar y guardar', asunto: 'aprobado y cerrado' }
+};
+
+const notificarWorkflowPresupuesto = async ({ empresaId, modulo, anio, accion, estado, ejecutor }) => {
+  const destino = MAPA_DESTINATARIOS[accion];
+  if (!destino) {
+    return [];
+  }
+  const columna = mapearColumnaPermiso(destino.permiso);
+  const usuarios = obtenerUsuariosPorPermiso(empresaId, modulo, columna)
+    .filter((usuario) => usuario.id !== ejecutor?.id);
+  if (usuarios.length === 0) {
+    return [];
+  }
+  const empresa = obtenerEmpresaPorId(empresaId);
+  const encabezado = `Presupuesto ${modulo}: ${destino.asunto}`;
+  const mensaje = `${ejecutor?.nombre || ejecutor?.usuario || 'Un colaborador'} actualizó el presupuesto ${modulo} (${empresa?.etiqueta || empresa?.nombre || empresaId}) al estado ${estado} (${anio}).`;
+  const notificaciones = registrarNotificacionesMasivas(usuarios, {
+    empresaId,
+    modulo,
+    titulo: encabezado,
+    mensaje,
+    tipo: 'info',
+    enlace: ''
+  });
+  await Promise.all(
+    usuarios
+      .filter((usuario) => usuario.correo)
+      .map((usuario) => enviarCorreoNotificacion({
+        para: usuario.correo,
+        asunto: encabezado,
+        cuerpo: construirMensajeCorreo({ titulo: encabezado, mensaje, enlace: '' })
+      }))
+  ).catch((error) => {
+    console.warn('No fue posible enviar todos los correos de notificación.', error);
+  });
+  return notificaciones;
+};
+
+module.exports = {
+  registrarNotificacion,
+  registrarNotificacionesMasivas,
+  listarNotificacionesPorUsuario,
+  marcarNotificacionComoLeida,
+  notificarWorkflowPresupuesto
+};

--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -1,469 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Comités</title>
-
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comités - Presupuestos</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
-  :root{
-    --color-primary:#2f5496;
-    --color-secondary:#8497b0;
-    --color-background:#f2f2f2;
-    --color-text:#2f5496;
-
-    --bs-primary:#2f5496;
-    --bs-primary-rgb:47,84,150;
-    --bs-success:#2f5496;
-    --bs-success-rgb:47,84,150;
-    --bs-success-bg-subtle:rgba(47,84,150,0.16);
-    --bs-success-border-subtle:rgba(47,84,150,0.35);
-
-    --comites-dup-bg:#fff7d6; /* duplicado: amarillo suave */
-  }
-
-  body{
-    background:var(--color-background);
-    font-family:'Manrope','Segoe UI',Tahoma,sans-serif;
-    color:var(--color-text);
-    min-height:100vh;
-    padding-top:20px;
-  }
-
-  .comites-container{
-    max-width:1440px;
-  }
-
-  .comites-panel{
-    background:#fff;
-    border-radius:18px;
-    border:1px solid rgba(47,84,150,0.08);
-    box-shadow:0 25px 55px rgba(47,84,150,0.10);
-    padding:1.75rem;
-  }
-
-  .comites-hero{
-    display:flex;
-    justify-content:space-between;
-    align-items:center;
-    gap:1rem;
-    flex-wrap:wrap;
-  }
-
-  .comites-title{
-    color:var(--color-primary);
-    font-weight:800;
-    margin:0;
-  }
-
-  .comites-status{
-    font-weight:600;
-    font-size:.9rem;
-  }
-
-  .comites-subtitle{
-    font-weight:600;
-    font-size:.9rem;
-    color:#6b7280;
-  }
-
-  .comites-controls{
-    display:flex;
-    align-items:flex-end;
-    gap:.75rem;
-    flex-wrap:wrap;
-  }
-
-  .comites-controls label{
-    color:#4567a8;
-    font-weight:700;
-    font-size:.85rem;
-  }
-
-  .comites-btn-toggle{
-    border-radius:10px;
-    padding:.6rem 1rem;
-    border:1px solid rgba(47,84,150,.25);
-    background:#fff;
-    color:var(--color-text);
-    font-weight:700;
-    font-size:.9rem;
-  }
-
-  .comites-btn-toggle:hover,
-  .comites-btn-toggle:focus{
-    background:rgba(47,84,150,0.06);
-  }
-
-  .comites-table-shell{
-    margin-top:.5rem;
-  }
-
-  .comites-table-wrap{
-    overflow-x:auto;
-  }
-
-  .comites-table{
-    width:100%;
-    min-width:1600px;
-    border-collapse:collapse;
-    font-size:.92rem;
-  }
-
-  .comites-table th,
-  .comites-table td{
-    border:1px solid rgba(47,84,150,.12);
-    padding:.55rem .6rem;
-    text-align:right;
-    background:#fff;
-    white-space:nowrap;
-  }
-
-  .comites-table thead th{
-    background:var(--color-primary);
-    color:#fff;
-    text-transform:uppercase;
-    letter-spacing:.05em;
-    font-size:.8rem;
-    position:sticky;
-    top:0;
-    z-index:1;
-  }
-
-  .comites-table thead th span{
-    display:block;
-    color:#d9d9d9;
-    font-weight:800;
-  }
-
-  .comites-account-col-h,
-  .comites-account-col{
-    text-align:left;
-    min-width:140px;
-    background:#f7f9fc;
-  }
-
-  .comites-account-col{
-    font-family:'Courier New',monospace;
-    font-weight:600;
-  }
-
-  .comites-desc-col{
-    text-align:left;
-    min-width:260px;
-    font-weight:600;
-    color:var(--color-text);
-  }
-
-  /* === Amarillos (columnas B) === */
-  th.comites-dup-head{
-    background:var(--comites-dup-bg) !important;
-    color:#374151 !important;
-  }
-  th.comites-dup-head span{
-    color:#374151 !important;
-  }
-  td.comites-dup-cell{
-    background:var(--comites-dup-bg) !important;
-  }
-
-  /* Filas de totales y resultados */
-  .comites-table tbody tr[data-kind="total"],
-  .comites-table tbody tr[data-kind="resultado"]{
-    background:#f2f2f2;
-    font-weight:800;
-  }
-
-  .comites-table tbody tr[data-kind="resultado"]{
-    background:#eef8ff;
-  }
-
-  .comites-spacer td{
-    background:transparent;
-    border:none;
-    height:.4rem;
-    padding:0;
-  }
-
-  /* Ocultar cuentas sin romper tabla */
-  body.comites-hide-accounts .comites-account-col,
-  body.comites-hide-accounts .comites-account-col-h{
-    max-width:0 !important;
-    width:0 !important;
-    padding:0 !important;
-    border:none !important;
-    font-size:0 !important;
-  }
-
-  @media (max-width:992px){
-    .comites-panel{
-      padding:1.25rem;
+    :root {
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
-    .comites-hero{
-      align-items:flex-start;
-    }
-    .comites-controls{
-      width:100%;
-      justify-content:flex-start;
-    }
-  }
-</style>
 
+    body {
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
+      min-height: 100vh;
+      padding-top: 70px;
+    }
+
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
+    }
+
+    .table-card,
+    .workflow-card {
+      background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
+    }
+
+    .table thead {
+      background-color: #d9d9d9;
+    }
+
+    .table thead th {
+      border: none;
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
+    }
+  </style>
 </head>
-<body>
-  <div class="container-xxl comites-container py-4">
-    <section class="comites-panel">
-      <div class="comites-hero mb-3">
-        <div>
-          <h1 class="comites-title h3 mb-1">Comités y Relaciones Externas</h1>
-          <div id="comitesStatus" class="comites-status text-success"></div>
-          <div id="comitesSubtitle" class="comites-subtitle mt-1">Capítulo —</div>
-        </div>
-        <div class="comites-controls">
-          <div class="text-end">
-            <label for="comitesYearSelect" class="form-label mb-1">Ejercicio</label>
-            <select id="comitesYearSelect" class="form-select form-select-sm">
-              <option value="2024">2024</option>
-              <option value="2025" selected>2025</option>
-              <option value="2026">2026</option>
-            </select>
-          </div>
-          <button id="comitesToggleAccounts" type="button" class="comites-btn-toggle">
-            Ocultar cuentas
-          </button>
-        </div>
-      </div>
 
-      <div class="comites-table-shell">
-        <div class="comites-table-wrap">
-          <table class="comites-table" id="comitesTable">
-            <thead id="comitesHead"></thead>
-            <tbody id="comitesBody"></tbody>
-          </table>
+<body data-modulo="Comités" data-modulo-alias="Comités">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Comités</h1>
+                <p class="mb-0 text-white-50">Presupuesto operativo de los comités especializados.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-  (()=>{
-    // ====== Capítulo por empresa activa ======
-    try{
-      const emp = (typeof Sesion!=='undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-      const ciudad = emp?.etiqueta || emp?.nombre || emp?.id || '—';
-      document.getElementById('comitesSubtitle').textContent = 'Capítulo ' + ciudad;
-    }catch{}
-
-    const els = {
-      head: document.getElementById('comitesHead'),
-      body: document.getElementById('comitesBody'),
-      yearSelect: document.getElementById('comitesYearSelect'),
-      status: document.getElementById('comitesStatus'),
-      toggleAccounts: document.getElementById('comitesToggleAccounts')
-    };
-
-    function tickStatus(){
-      if(!els.status) return;
-      els.status.textContent = 'Vista ' + new Date().toLocaleTimeString('es-MX') + '.';
-    }
-    tickStatus();
-
-    // ====== Definición de columnas (12 meses, A/B) ======
-    const COMITES_MONTHS = [
-      { k:'ene', l:'ENE' },
-      { k:'feb', l:'FEB' },
-      { k:'mar', l:'MAR' },
-      { k:'abr', l:'ABR' },
-      { k:'may', l:'MAY' },
-      { k:'jun', l:'JUN' },
-      { k:'jul', l:'JUL' },
-      { k:'ago', l:'AGO' },
-      { k:'sep', l:'SEP' },
-      { k:'oct', l:'OCT' },
-      { k:'nov', l:'NOV' },
-      { k:'dic', l:'DIC' }
-    ];
-
-    // Para Comités: par de columnas A/B por mes (ppto / real, visualmente)
-    const COMITES_COLUMNS = COMITES_MONTHS.flatMap(m => ([
-      { key: m.k + 'A', label: m.l, dup:false },
-      { key: m.k + 'B', label: m.l, dup:true  }
-    ]));
-
-    const TOTAL_COLUMNS = 2 + COMITES_COLUMNS.length + 1; // Cuenta + Comités + meses + Total
-
-    // ====== Bloques de filas (según Excel "Comités") ======
-    const filasIngresos = [
-      { cuenta:'404-017-000-00', nombre:'Agroindustria (Virtual)' },
-      { cuenta:'404-005-000-00', nombre:'Asuntos Fiscales' },
-      { cuenta:'404-001-000-00', nombre:'Capital Humano y Asuntos Laborales' },
-      { cuenta:'404-003-000-00', nombre:'Comercio Exterior y Logística' },
-      { cuenta:'404-013-000-00', nombre:'Innovación y TICs' },
-      { cuenta:'404-007-000-00', nombre:'Legalidad y Estado de Derecho' },
-      { cuenta:'404-016-000-00', nombre:'Salud' },
-      { cuenta:'404-004-000-00', nombre:'Seguridad' },
-      { cuenta:'',               nombre:'Sustentabilidad y Responsabilidad Social' },
-      { cuenta:'404-009-000-00', nombre:'Turismo' },
-      { cuenta:'404-018-000-00', nombre:'Programa de Mentoría (EWDP)' }
-    ];
-
-    const filasGastos = [
-      { cuenta:'502-014-000-00', nombre:'Agroindustria' },
-      { cuenta:'502-005-000-00', nombre:'Asuntos Fiscales' },
-      { cuenta:'502-001-000-00', nombre:'Capital Humano y Asuntos Laborales' },
-      { cuenta:'502-003-000-00', nombre:'Comercio Exterior y Logística' },
-      { cuenta:'502-013-000-00', nombre:'Innovación y TICs' },
-      { cuenta:'502-007-000-00', nombre:'Legalidad y Estado de Derecho' },
-      { cuenta:'502-016-000-00', nombre:'Salud' },
-      { cuenta:'502-004-000-00', nombre:'Seguridad' },
-      { cuenta:'502-002-000-00', nombre:'Sustentabilidad y Responsabilidad Social' },
-      { cuenta:'502-009-000-00', nombre:'Turismo' },
-      { cuenta:'502-017-000-00', nombre:'Programa de Mentoría (EWDP)' }
-    ];
-
-    // ====== Render encabezado ======
-    function renderHead(){
-      const year = Number(els.yearSelect.value || new Date().getFullYear());
-      const suf = String(year).slice(-2);
-
-      const colsHtml = COMITES_COLUMNS.map(col => {
-        const cls = col.dup ? 'comites-dup-head' : '';
-        return `<th class="${cls}"><span>${col.label.toLowerCase()}-${suf}</span></th>`;
-      }).join('');
-
-      els.head.innerHTML = `
-        <tr>
-          <th class="comites-account-col-h"><span>Cuenta</span></th>
-          <th><span>Comités</span></th>
-          ${colsHtml}
-          <th><span>${year}</span>Total</th>
-        </tr>
-      `;
-    }
-
-    const dash = '–';
-
-    function celdasMeses(dupClassBase){
-      return COMITES_COLUMNS.map(c => {
-        const cls = c.dup ? dupClassBase : '';
-        return `<td class="${cls}">${dash}</td>`;
-      }).join('');
-    }
-
-    function rowIngresoHtml(item){
-      const cuenta = item.cuenta && item.cuenta.trim() ? item.cuenta.trim() : '—';
-      const perMes = celdasMeses('comites-dup-cell');
-      // ID sólo en la celda total anual por ahora
-      const totalId = item.cuenta
-        ? `comites-total-ing-${item.cuenta.replace(/[^0-9A-Za-z]+/g,'_')}`
-        : `comites-total-ing-sin_cuenta-${item.nombre.replace(/\s+/g,'_')}`;
-
-      return `
-        <tr data-bloque="ingresos">
-          <td class="comites-account-col">${cuenta}</td>
-          <td class="comites-desc-col">${item.nombre}</td>
-          ${perMes}
-          <td id="${totalId}">${dash}</td>
-        </tr>
-      `;
-    }
-
-    function rowGastoHtml(item){
-      const cuenta = item.cuenta && item.cuenta.trim() ? item.cuenta.trim() : '—';
-      const perMes = celdasMeses('comites-dup-cell');
-      const totalId = `comites-total-gas-${item.cuenta.replace(/[^0-9A-Za-z]+/g,'_')}`;
-
-      return `
-        <tr data-bloque="gastos">
-          <td class="comites-account-col">${cuenta}</td>
-          <td class="comites-desc-col">${item.nombre}</td>
-          ${perMes}
-          <td id="${totalId}">${dash}</td>
-        </tr>
-      `;
-    }
-
-    function spacerRow(){
-      return `
-        <tr class="comites-spacer">
-          <td colspan="${TOTAL_COLUMNS}"></td>
-        </tr>
-      `;
-    }
-
-    function totalRow(label, id){
-      const perMes = celdasMeses('comites-dup-cell');
-      return `
-        <tr data-kind="total">
-          <td class="comites-account-col"></td>
-          <td class="comites-desc-col">${label}</td>
-          ${perMes}
-          <td id="${id}">${dash}</td>
-        </tr>
-      `;
-    }
-
-    function resultadoRow(label, id){
-      const perMes = celdasMeses('comites-dup-cell');
-      return `
-        <tr data-kind="resultado">
-          <td class="comites-account-col"></td>
-          <td class="comites-desc-col">${label}</td>
-          ${perMes}
-          <td id="${id}">${dash}</td>
-        </tr>
-      `;
-    }
-
-    function renderBody(){
-      const parts = [];
-
-      // Bloque Ingresos
-      filasIngresos.forEach(f => parts.push(rowIngresoHtml(f)));
-      parts.push(totalRow('Suma de Ingresos Comités', 'comites-suma-ingresos'));
-      parts.push(spacerRow());
-
-      // Bloque Gastos
-      filasGastos.forEach(f => parts.push(rowGastoHtml(f)));
-      parts.push(totalRow('Suma de Gastos Comités', 'comites-suma-gastos'));
-      parts.push(spacerRow());
-
-      // Resultado
-      parts.push(resultadoRow('Resultado Comités', 'comites-resultado'));
-
-      els.body.innerHTML = parts.join('');
-    }
-
-    // ====== Toggle mostrar/ocultar cuentas (colapsando columna) ======
-    function applyToggle(ocultar){
-      document.body.classList.toggle('comites-hide-accounts', !!ocultar);
-      els.toggleAccounts.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
-      els.toggleAccounts.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
-    }
-
-    els.toggleAccounts.addEventListener('click', ()=>{
-      const hide = !document.body.classList.contains('comites-hide-accounts');
-      applyToggle(hide);
-    });
-
-    // ====== Render inicial y cambio de año ======
-    function renderAll(){
-      tickStatus();
-      renderHead();
-      renderBody();
-    }
-
-    els.yearSelect.addEventListener('change', renderAll);
-
-    renderAll();
-    applyToggle(false);
-  })();
-  </script>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Comunicación.html
+++ b/vistas/Comunicación.html
@@ -1,388 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Comunicación</title>
-
+  <title>Comunicación - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
-
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-      --comm-color-primary: #2f5496;
-      --comm-color-secondary: #8497b0;
-      --comm-color-background: #f2f2f2;
-      --comm-color-text: #2f5496;
-
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
 
     body {
-      background: var(--comm-color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
-      color: var(--comm-color-text);
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
       min-height: 100vh;
-      padding-top: 20px;
+      padding-top: 70px;
     }
 
-    .comm-container {
-      max-width: 1440px;
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
     }
 
-    .comm-panel {
+    .table-card,
+    .workflow-card {
       background: #fff;
-      border-radius: 18px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 25px 55px rgba(47, 84, 150, 0.08);
-      padding: 1.75rem;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .comm-hero {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      flex-wrap: wrap;
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .comm-title {
-      color: var(--comm-color-primary);
-      font-weight: 800;
-      margin: 0;
-    }
-
-    .comm-status {
+    .table thead th {
+      border: none;
       font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
       font-size: 0.9rem;
     }
 
-    .comm-controls {
-      display: flex;
-      gap: 0.75rem;
-      align-items: flex-end;
-      flex-wrap: wrap;
-    }
-
-    .comm-controls .form-select {
-      min-width: 110px;
-    }
-
-    .comm-btn-toggle {
-      border-radius: 10px;
-      padding: 0.6rem 1rem;
-      border: 1px solid rgba(47, 84, 150, 0.25);
-      background: #fff;
-      color: var(--comm-color-text);
-      font-weight: 700;
-    }
-
-    .comm-table-wrapper {
-      width: 100%;
-      overflow-x: auto;
-      margin-top: 1rem;
-    }
-
-    .comm-table {
-      width: 100%;
-      min-width: 1600px;
-      border-collapse: collapse;
-      font-size: 0.92rem;
-    }
-
-    .comm-table th,
-    .comm-table td {
-      border: 1px solid rgba(47, 84, 150, 0.12);
-      padding: 0.55rem 0.6rem;
-      text-align: right;
-      min-width: 90px;
-      background: #fff;
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
       white-space: nowrap;
     }
 
-    .comm-table thead th {
-      background: #2f5496;
-      color: #fff;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      font-size: 0.8rem;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
-
-    .comm-table thead th span {
-      display: block;
-      color: #d9d9d9;
-      font-weight: 800;
-    }
-
-    .comm-account-col-h {
+    .account-column-header {
       text-align: left;
-      min-width: 160px;
-      background: #f7f9fc;
+      white-space: nowrap;
     }
 
-    .comm-account-col {
-      text-align: left;
-      min-width: 160px;
-      background: #f7f9fc;
-      font-family: 'Courier New', monospace;
-      font-weight: 600;
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
 
-    .comm-desc-col {
-      text-align: left;
-      min-width: 260px;
-      font-weight: 600;
-      color: var(--comm-color-text);
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
     }
 
-    .comm-table th.comm-dup,
-    .comm-table td.comm-dup {
-      background: #fff7d6;
-      border-left: 2px solid rgba(47, 84, 150, 0.25);
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
     }
 
-    .comm-table tbody tr[data-kind="total"],
-    .comm-table tbody tr[data-kind="resultado"] {
-      background: #f2f2f2;
-      font-weight: 800;
-    }
-
-    .comm-table tbody tr[data-kind="resultado-final"] {
-      background: #eef8ff;
-      font-weight: 900;
-    }
-
-    .comm-section-row {
-      background: rgba(47, 84, 150, 0.05);
-      font-weight: 800;
-      color: var(--comm-color-primary);
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
-  <div class="container-xxl comm-container py-4">
-    <section class="comm-panel">
-      <div class="comm-hero mb-3">
-        <div>
-          <h1 class="comm-title h3 mb-1">Comunicación</h1>
-          <span id="commStatus" class="comm-status text-success"></span>
-          <div id="chapterSubtitle" class="fw-semibold mt-1" style="color:#6b7280"></div>
-        </div>
-        <div class="comm-controls">
-          <div>
-            <label for="yearSelect" class="form-label mb-1 fw-bold" style="color:#4567a8">Ejercicio</label>
-            <select id="yearSelect" class="form-select">
-              <option value="2024">2024</option>
-              <option value="2025">2025</option>
-              <option value="2026" selected>2026</option>
-            </select>
-          </div>
-          <button id="toggleAccounts" type="button" class="comm-btn-toggle">
-            Ocultar cuentas
-          </button>
-        </div>
-      </div>
 
-      <div class="comm-table-wrapper">
-        <table class="comm-table" id="tblComunicacion">
-          <thead></thead>
-          <tbody></tbody>
-        </table>
+<body data-modulo="Comunicación" data-modulo-alias="Comunicación">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Comunicación</h1>
+                <p class="mb-0 text-white-50">Estrategia presupuestal para comunicación y posicionamiento.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-    (function () {
-      // ======= Datos de sesión / capítulo =======
-      try {
-        const emp = (typeof Sesion !== 'undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-        const ciudad = emp?.etiqueta || emp?.nombre || emp?.id || '—';
-        document.getElementById('chapterSubtitle').textContent = ciudad ? 'Capítulo ' + ciudad : '';
-      } catch {}
-
-      const statusEl   = document.getElementById('commStatus');
-      const yearSelect = document.getElementById('yearSelect');
-      const tableHead  = document.querySelector('#tblComunicacion thead');
-      const tableBody  = document.querySelector('#tblComunicacion tbody');
-      const toggleBtn  = document.getElementById('toggleAccounts');
-      const STORAGE_KEY = 'comunicacion_ocultar_cuentas';
-
-      function updateStatusTime() {
-        if (!statusEl) return;
-        statusEl.textContent = 'Vista ' + new Date().toLocaleTimeString('es-MX') + '.';
-      }
-
-      // ======= Meses (A normal, B duplicado amarillito) =======
-      const COMM_MONTHS = [
-        { key: 'eneA', label: 'ENE', dup: false }, { key: 'eneB', label: 'ENE', dup: true },
-        { key: 'febA', label: 'FEB', dup: false }, { key: 'febB', label: 'FEB', dup: true },
-        { key: 'marA', label: 'MAR', dup: false }, { key: 'marB', label: 'MAR', dup: true },
-        { key: 'abrA', label: 'ABR', dup: false }, { key: 'abrB', label: 'ABR', dup: true },
-        { key: 'mayA', label: 'MAY', dup: false }, { key: 'mayB', label: 'MAY', dup: true },
-        { key: 'junA', label: 'JUN', dup: false }, { key: 'junB', label: 'JUN', dup: true },
-        { key: 'julA', label: 'JUL', dup: false }, { key: 'julB', label: 'JUL', dup: true },
-        { key: 'agoA', label: 'AGO', dup: false }, { key: 'agoB', label: 'AGO', dup: true },
-        { key: 'sepA', label: 'SEP', dup: false }, { key: 'sepB', label: 'SEP', dup: true },
-        { key: 'octA', label: 'OCT', dup: false }, { key: 'octB', label: 'OCT', dup: true },
-        { key: 'novA', label: 'NOV', dup: false }, { key: 'novB', label: 'NOV', dup: true },
-        { key: 'dicA', label: 'DIC', dup: false }, { key: 'dicB', label: 'DIC', dup: true }
-      ];
-
-      const dash = '–';
-
-      // ======= Filas según el Excel "Mex Comunicación 2026" =======
-      const COMM_ROWS = [
-        { tipo: 'section', nombre: 'Ingresos Comunicación' },
-        { tipo: 'ing', cuenta: '—', nombre: 'Ingresos' },
-        { tipo: 'total', nombre: 'Suma de Ingresos Comunicación' },
-
-        { tipo: 'sep' },
-
-        { tipo: 'section', nombre: 'Gastos Comunicación' },
-        { tipo: 'gto', cuenta: '801-013-006-00', nombre: 'Agencias de Comunicación' },
-        { tipo: 'gto', cuenta: '801-013-016-00', nombre: 'Contenidos multimedia' },
-        { tipo: 'gto', cuenta: '801-013-015-00', nombre: 'Marketing Licencias' },
-        { tipo: 'gto', cuenta: '801-013-010-00', nombre: 'Traductor' },
-        { tipo: 'total', nombre: 'Suma de Gastos Comunicación' },
-
-        { tipo: 'sep' },
-
-        { tipo: 'res', nombre: 'Resultado Operativo Comunicación' }
-      ];
-
-      // ======= Render =======
-      let ocultarCuentas = (localStorage.getItem(STORAGE_KEY) === '1');
-
-      function renderHead() {
-        const year = yearSelect.value || new Date().getFullYear();
-        const suf  = String(year).slice(-2);
-
-        const monthTh = COMM_MONTHS.map(m =>
-          `<th class="${m.dup ? 'comm-dup' : ''}"><span>${m.label.toLowerCase()}-${suf}</span></th>`
-        ).join('');
-
-        if (ocultarCuentas) {
-          tableHead.innerHTML = `
-            <tr>
-              <th>COMUNICACIÓN</th>
-              ${monthTh}
-              <th><span>${year}</span>Total</th>
-            </tr>
-          `;
-        } else {
-          tableHead.innerHTML = `
-            <tr>
-              <th class="comm-account-col-h">Cuenta</th>
-              <th>COMUNICACIÓN</th>
-              ${monthTh}
-              <th><span>${year}</span>Total</th>
-            </tr>
-          `;
-        }
-      }
-
-      function renderBody() {
-        const TOTAL_COLS = ocultarCuentas
-          ? (1 + COMM_MONTHS.length + 1)      // descripción + meses + total
-          : (2 + COMM_MONTHS.length + 1);     // cuenta + descripción + meses + total
-
-        const rowsHtml = [];
-
-        COMM_ROWS.forEach(row => {
-          if (row.tipo === 'sep') {
-            rowsHtml.push(
-              `<tr><td colspan="${TOTAL_COLS}" style="background:transparent;border:none;height:.35rem;"></td></tr>`
-            );
-            return;
-          }
-
-          if (row.tipo === 'section') {
-            rowsHtml.push(
-              `<tr>
-                 <td colspan="${TOTAL_COLS}" class="comm-section-row">${row.nombre}</td>
-               </tr>`
-            );
-            return;
-          }
-
-          const cells = COMM_MONTHS
-            .map(m => `<td class="${m.dup ? 'comm-dup' : ''}">${dash}</td>`)
-            .join('');
-
-          if (row.tipo === 'total' || row.tipo === 'res') {
-            const kind = row.tipo === 'res' ? 'resultado-final' : 'total';
-            const labelColspan = ocultarCuentas ? 1 : 2;
-
-            rowsHtml.push(`
-              <tr data-kind="${kind}">
-                <td colspan="${labelColspan}">${row.nombre}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-            return;
-          }
-
-          // Fila normal
-          if (ocultarCuentas) {
-            rowsHtml.push(`
-              <tr data-tipo="${row.tipo}">
-                <td class="comm-desc-col">${row.nombre || ''}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-          } else {
-            rowsHtml.push(`
-              <tr data-tipo="${row.tipo}">
-                <td class="comm-account-col">${row.cuenta || '—'}</td>
-                <td class="comm-desc-col">${row.nombre || ''}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-          }
-        });
-
-        tableBody.innerHTML = rowsHtml.join('');
-      }
-
-      function updateToggleButton() {
-        toggleBtn.textContent = ocultarCuentas ? 'Mostrar cuentas' : 'Ocultar cuentas';
-        toggleBtn.setAttribute('aria-pressed', ocultarCuentas ? 'true' : 'false');
-      }
-
-      function renderAll() {
-        updateStatusTime();
-        renderHead();
-        renderBody();
-        updateToggleButton();
-      }
-
-      // ======= Eventos =======
-      yearSelect.addEventListener('change', renderAll);
-
-      toggleBtn.addEventListener('click', () => {
-        ocultarCuentas = !ocultarCuentas;
-        localStorage.setItem(STORAGE_KEY, ocultarCuentas ? '1' : '0');
-        renderAll();
-      });
-
-      // Primera pinta
-      renderAll();
-    })();
-  </script>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Eventos.html
+++ b/vistas/Eventos.html
@@ -1,428 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Eventos</title>
-
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Eventos - Presupuestos</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
-    :root{
-      --evt-color-primary:#2f5496;
-      --evt-color-secondary:#8497b0;
-      --evt-color-background:#f2f2f2;
-      --evt-color-text:#2f5496;
-
-      --bs-primary:#2f5496;
-      --bs-primary-rgb:47,84,150;
-      --bs-success:#2f5496;
-      --bs-success-rgb:47,84,150;
-      --bs-success-bg-subtle:rgba(47,84,150,0.16);
-      --bs-success-border-subtle:rgba(47,84,150,0.35);
+    :root {
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
 
-    body{
-      background:var(--evt-color-background);
-      font-family:'Manrope','Segoe UI',Tahoma,sans-serif;
-      color:var(--evt-color-text);
-      min-height:100vh;
-      padding-top:20px;
+    body {
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
+      min-height: 100vh;
+      padding-top: 70px;
     }
 
-    .evt-container{
-      max-width:1440px;
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
     }
 
-    .evt-panel{
-      background:#fff;
-      border-radius:18px;
-      border:1px solid rgba(47,84,150,0.08);
-      box-shadow:0 25px 55px rgba(47,84,150,0.08);
-      padding:1.75rem;
+    .table-card,
+    .workflow-card {
+      background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .evt-hero{
-      display:flex;
-      justify-content:space-between;
-      align-items:center;
-      gap:1rem;
-      flex-wrap:wrap;
-    }
-    .evt-title{
-      color:var(--evt-color-primary);
-      font-weight:800;
-      margin:0;
-    }
-    .evt-status{
-      font-weight:600;
-      font-size:.9rem;
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .evt-controls{
-      display:flex;
-      gap:.75rem;
-      align-items:flex-end;
-      flex-wrap:wrap;
-    }
-    .evt-controls .form-select{
-      min-width:110px;
-    }
-    .evt-btn-toggle{
-      border-radius:10px;
-      padding:.6rem 1rem;
-      border:1px solid rgba(47,84,150,.25);
-      background:#fff;
-      color:var(--evt-color-text);
-      font-weight:700;
+    .table thead th {
+      border: none;
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    /* ===== Tabla Eventos ===== */
-    .evt-table-wrapper{
-      width:100%;
-      overflow-x:auto;
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
     }
 
-    .evt-table{
-      width:100%;
-      min-width:1600px;
-      border-collapse:collapse;
-      font-size:0.92rem;
-    }
-    .evt-table th,
-    .evt-table td{
-      border:1px solid rgba(47,84,150,0.12);
-      padding:.55rem .6rem;
-      text-align:right;
-      min-width:90px;
-      background:#fff;
-      white-space:nowrap;
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
     }
 
-    .evt-table thead th{
-      background:#2f5496;
-      color:#fff;
-      text-transform:uppercase;
-      letter-spacing:.05em;
-      font-size:.8rem;
-      position:sticky;
-      top:0;
-      z-index:1;
-    }
-    .evt-table thead th span{
-      color:#d9d9d9;
-      font-weight:800;
-      display:block;
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
     }
 
-    .evt-account-col-h{
-      text-align:left;
-      min-width:160px;
-      background:#f7f9fc;
-    }
-    .evt-account-col{
-      text-align:left;
-      min-width:160px;
-      background:#f7f9fc;
-      font-family:'Courier New',monospace;
-      font-weight:600;
-    }
-    .evt-desc-col{
-      text-align:left;
-      min-width:260px;
-      font-weight:600;
-      color:var(--evt-color-text);
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
     }
 
-    /* Duplicado (segunda columna del mes) en amarillo */
-    .evt-table th.evt-dup,
-    .evt-table td.evt-dup{
-      background:#fff7d6;
-      border-left:2px solid rgba(47,84,150,.25);
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
 
-    /* Totales y resultados */
-    .evt-table tbody tr[data-kind="total"],
-    .evt-table tbody tr[data-kind="resultado"]{
-      background:#f2f2f2;
-      font-weight:800;
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
     }
-    .evt-table tbody tr[data-kind="resultado-final"]{
-      background:#eef8ff;
-      font-weight:900;
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
 
-  <div class="container-xxl evt-container py-4">
-    <section class="evt-panel">
-      <div class="evt-hero mb-3">
-        <div>
-          <h1 class="evt-title h3 mb-1">Eventos</h1>
-          <span id="panelTime" class="evt-status text-success"></span>
-          <div id="chapterSubtitle" class="fw-semibold mt-1" style="color:#6b7280"></div>
-        </div>
-        <div class="evt-controls">
-          <div>
-            <label for="yearSelect" class="form-label mb-1 fw-bold" style="color:#4567a8">Ejercicio</label>
-            <select id="yearSelect" class="form-select">
-              <option value="2024">2024</option>
-              <option value="2025" selected>2025</option>
-              <option value="2026">2026</option>
-            </select>
+<body data-modulo="Eventos" data-modulo-alias="Eventos">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Eventos</h1>
+                <p class="mb-0 text-white-50">Planeación y control del presupuesto de eventos.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
           </div>
-          <button id="toggleAccounts" type="button" class="evt-btn-toggle">
-            Ocultar cuentas
-          </button>
         </div>
       </div>
+    </div>
 
-      <div class="evt-table-wrapper">
-        <table class="evt-table" id="eventosTable">
-          <thead></thead>
-          <tbody></tbody>
-        </table>
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-  (() => {
-    // ======= Encabezados de sesión / capítulo =======
-    try{
-      const emp = (typeof Sesion!=='undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-      const ciudad = emp?.etiqueta || emp?.nombre || emp?.id || '—';
-      document.getElementById('chapterSubtitle').textContent = ciudad ? 'Capítulo ' + ciudad : '';
-    }catch{}
-
-    const timeEl      = document.getElementById('panelTime');
-    const yearSelect  = document.getElementById('yearSelect');
-    const tableHead   = document.querySelector('#eventosTable thead');
-    const tableBody   = document.querySelector('#eventosTable tbody');
-    const toggleBtn   = document.getElementById('toggleAccounts');
-    const STORAGE_KEY = 'eventos_ocultar_cuentas';
-
-    function setStaticViewTime(){
-      if(!timeEl) return;
-      timeEl.textContent = 'Vista ' + new Date().toLocaleTimeString('es-MX') + '.';
-    }
-
-    // ===== Meses duplicados (A normal / B duplicado amarillo) =====
-    const MONTHS = [
-      {k:'eneA',m:'ENE',dup:false},{k:'eneB',m:'ENE',dup:true},
-      {k:'febA',m:'FEB',dup:false},{k:'febB',m:'FEB',dup:true},
-      {k:'marA',m:'MAR',dup:false},{k:'marB',m:'MAR',dup:true},
-      {k:'abrA',m:'ABR',dup:false},{k:'abrB',m:'ABR',dup:true},
-      {k:'mayA',m:'MAY',dup:false},{k:'mayB',m:'MAY',dup:true},
-      {k:'junA',m:'JUN',dup:false},{k:'junB',m:'JUN',dup:true},
-      {k:'julA',m:'JUL',dup:false},{k:'julB',m:'JUL',dup:true},
-      {k:'agoA',m:'AGO',dup:false},{k:'agoB',m:'AGO',dup:true},
-      {k:'sepA',m:'SEP',dup:false},{k:'sepB',m:'SEP',dup:true},
-      {k:'octA',m:'OCT',dup:false},{k:'octB',m:'OCT',dup:true},
-      {k:'novA',m:'NOV',dup:false},{k:'novB',m:'NOV',dup:true},
-      {k:'dicA',m:'DIC',dup:false},{k:'dicB',m:'DIC',dup:true},
-    ];
-
-    const dash = '–';
-
-    // ===== Filas estáticas según Excel =====
-    const filas = [
-      // Ingresos Boletaje
-      { tipo:'ing', cuenta:'407-005-000-00', nombre:'Asamblea Anual' },
-      { tipo:'ing', cuenta:'407-010-000-00', nombre:'Torneo Golf' },
-      { tipo:'ing', cuenta:'407-002-000-00', nombre:'Secretarias' },
-      { tipo:'ing', cuenta:'407-008-000-00', nombre:'Foro Económico' },
-      { tipo:'ing', cuenta:'407-009-000-00', nombre:'Foros Comités' },
-      { tipo:'ing', cuenta:'407-012-000-00', nombre:'Cena Gala' },
-      { tipo:'ing', cuenta:'407-013-000-00', nombre:'AmCham Connect' },
-      { tipo:'ing', cuenta:'407-014-000-00', nombre:'North America Week' },
-      { tipo:'ing', cuenta:'407-007-000-00', nombre:'Sondeo de Seguridad' },
-      { tipo:'subtotal', nombre:'Ingresos Boletaje' },
-
-      { tipo:'sep' },
-
-      // Ingresos Patrocinios
-      { tipo:'ing', cuenta:'408-005-000-00', nombre:'Asamblea Anual' },
-      { tipo:'ing', cuenta:'408-010-000-00', nombre:'Torneo Golf' },
-      { tipo:'ing', cuenta:'408-002-000-00', nombre:'Secretarias' },
-      { tipo:'ing', cuenta:'408-008-000-00', nombre:'Foro Económico' },
-      { tipo:'ing', cuenta:'408-009-000-00', nombre:'Sondeo de Seguridad' },
-      { tipo:'ing', cuenta:'408-003-000-00', nombre:'Foros Comités' },
-      { tipo:'ing', cuenta:'408-016-000-00', nombre:'Select USA Conference' },
-      { tipo:'ing', cuenta:'408-006-000-00', nombre:'AmCham Connect' },
-      { tipo:'ing', cuenta:'408-013-000-00', nombre:'Cena Gala' },
-      { tipo:'ing', cuenta:'408-004-000-00', nombre:'CEO Talk' },
-      { tipo:'ing', cuenta:'408-015-000-00', nombre:'AmCham B2B' },
-      { tipo:'ing', cuenta:'408-014-000-00', nombre:'North America Week' },
-      { tipo:'ing', cuenta:'408-018-000-00', nombre:'Incidencia' },
-      { tipo:'subtotal', nombre:'Ingresos Patrocinios' },
-
-      { tipo:'total', nombre:'Suma Ingresos Eventos' },
-
-      { tipo:'sep' },
-
-      // Costos y Gastos Eventos
-      { tipo:'gto', cuenta:'701-001-004-00', nombre:'Asamblea Anual' },
-      { tipo:'gto', cuenta:'701-001-013-00', nombre:'Torneo Golf' },
-      { tipo:'gto', cuenta:'701-001-011-00', nombre:'Secretarias' },
-      { tipo:'gto', cuenta:'701-001-006-00', nombre:'Foro Económico' },
-      { tipo:'gto', cuenta:'701-001-014-00', nombre:'Foros de Comités' },
-      { tipo:'gto', cuenta:'701-001-017-00', nombre:'AmCham Connect' },
-      { tipo:'gto', cuenta:'701-001-012-00', nombre:'Cena Gala' },
-      { tipo:'gto', cuenta:'701-001-003-00', nombre:'CEO Talk' },
-      { tipo:'gto', cuenta:'701-001-018-00', nombre:'AmCham B2B' },
-      { tipo:'gto', cuenta:'701-001-008-00', nombre:'Sondeo de Seguridad' },
-      { tipo:'gto', cuenta:'701-001-015-00', nombre:'NORTH AMERICA WEEK' },
-      { tipo:'gto', cuenta:'701-001-002-00', nombre:'Incidencia' },
-      { tipo:'gto', cuenta:'701-001-016-00', nombre:'Ppto Marketing' },
-      { tipo:'total', nombre:'Suma Costos y Gastos Eventos' },
-      { tipo:'res-op', nombre:'Resultado Operativo Eventos' },
-
-      { tipo:'sep' },
-
-      // Gastos Administrativos
-      { tipo:'adm', cuenta:'801-010-001-00', nombre:'Teléfono Móvil' },
-      { tipo:'adm', cuenta:'801-010-003-00', nombre:'Gasolina' },
-      { tipo:'adm', cuenta:'801-010-004-00', nombre:'Mantenimiento auto' },
-      { tipo:'adm', cuenta:'801-010-016-00', nombre:'Gastos de viaje' },
-      { tipo:'adm', cuenta:'801-010-005-00', nombre:'Pasajes y estacionamientos' },
-      { tipo:'adm', cuenta:'801-010-007-00', nombre:'Papelería' },
-      { tipo:'adm', cuenta:'801-010-011-00', nombre:'Promoción' },
-      { tipo:'adm', cuenta:'801-010-010-00', nombre:'Becarios' },
-      { tipo:'adm', cuenta:'801-010-013-00', nombre:'Gastos Administrativos (impresión tarjetas)' },
-      { tipo:'adm', cuenta:'801-010-015-00', nombre:'Herramientas Tele-trabajo' },
-      { tipo:'total', nombre:'Suma Gastos Administrativos' },
-
-      { tipo:'res', nombre:'Resultado  Eventos y Serv Membresía' }
-    ];
-
-    // ===== Render =====
-    let ocultarCuentas = (localStorage.getItem(STORAGE_KEY) === '1');
-
-    function renderHead(){
-      const year = yearSelect.value || new Date().getFullYear();
-      const suf  = String(year).slice(-2);
-
-      const monthTh = MONTHS.map(m =>
-        `<th class="${m.dup ? 'evt-dup' : ''}"><span>${m.m.toLowerCase()}-${suf}</span></th>`
-      ).join('');
-
-      if(ocultarCuentas){
-        // Sin columna de cuentas
-        tableHead.innerHTML = `
-          <tr>
-            <th>EVENTOS</th>
-            ${monthTh}
-            <th><span>${year}</span>Total</th>
-          </tr>
-        `;
-      }else{
-        // Con columna de cuentas
-        tableHead.innerHTML = `
-          <tr>
-            <th class="evt-account-col-h">Cuenta</th>
-            <th>EVENTOS</th>
-            ${monthTh}
-            <th><span>${year}</span>Total</th>
-          </tr>
-        `;
-      }
-    }
-
-    function renderBody(){
-      const TOTAL_COLS = ocultarCuentas
-        ? (1 + MONTHS.length + 1)   // desc + meses + total
-        : (2 + MONTHS.length + 1);  // cuenta + desc + meses + total
-
-      const out = [];
-
-      filas.forEach(f => {
-        if (f.tipo === 'sep'){
-          out.push(
-            `<tr><td colspan="${TOTAL_COLS}" style="background:transparent;border:none;height:.35rem;"></td></tr>`
-          );
-          return;
-        }
-
-        if (f.tipo === 'total' || f.tipo === 'subtotal' || f.tipo === 'res-op' || f.tipo === 'res'){
-          const kind =
-            f.tipo === 'res'    ? 'resultado-final' :
-            f.tipo === 'res-op' ? 'resultado' :
-            'total';
-
-          const cells = MONTHS.map(m =>
-            `<td class="${m.dup ? 'evt-dup' : ''}">${dash}</td>`
-          ).join('');
-
-          const labelColspan = ocultarCuentas ? 1 : 2;
-
-          out.push(`
-            <tr data-kind="${kind}">
-              <td colspan="${labelColspan}">${f.nombre}</td>
-              ${cells}
-              <td>${dash}</td>
-            </tr>
-          `);
-          return;
-        }
-
-        // Fila normal (ing/gto/adm)
-        const cells = MONTHS.map(m =>
-          `<td class="${m.dup ? 'evt-dup' : ''}">${dash}</td>`
-        ).join('');
-
-        if(ocultarCuentas){
-          out.push(`
-            <tr data-tipo="${f.tipo}">
-              <td class="evt-desc-col">${f.nombre || ''}</td>
-              ${cells}
-              <td>${dash}</td>
-            </tr>
-          `);
-        }else{
-          out.push(`
-            <tr data-tipo="${f.tipo}">
-              <td class="evt-account-col">${f.cuenta || '—'}</td>
-              <td class="evt-desc-col">${f.nombre || ''}</td>
-              ${cells}
-              <td>${dash}</td>
-            </tr>
-          `);
-        }
-      });
-
-      tableBody.innerHTML = out.join('');
-    }
-
-    function updateToggleButton(){
-      toggleBtn.textContent = ocultarCuentas ? 'Mostrar cuentas' : 'Ocultar cuentas';
-      toggleBtn.setAttribute('aria-pressed', ocultarCuentas ? 'true' : 'false');
-    }
-
-    function renderAll(){
-      setStaticViewTime();
-      renderHead();
-      renderBody();
-      updateToggleButton();
-    }
-
-    // Eventos
-    yearSelect.addEventListener('change', renderAll);
-
-    toggleBtn.addEventListener('click', () => {
-      ocultarCuentas = !ocultarCuentas;
-      localStorage.setItem(STORAGE_KEY, ocultarCuentas ? '1' : '0');
-      renderAll();
-    });
-
-    // Primera pinta
-    renderAll();
-  })();
-  </script>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Finanzas.html
+++ b/vistas/Finanzas.html
@@ -1,116 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Finanzas</title>
+  <title>Finanzas - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-       --color-primary: #2f5496;
+      --color-primary: #2f5496;
       --color-secondary: #8497b0;
       --color-background: #f2f2f2;
       --color-text: #2f5496;
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
     }
 
     body {
-      background: var(--color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       color: var(--color-text);
       min-height: 100vh;
-      padding-top: 60px;
+      padding-top: 70px;
     }
 
     .header-card {
       background: var(--color-primary);
-      color: #fff;
-      border-radius: 18px;
+      border-radius: 16px;
       border: 1px solid rgba(47, 84, 150, 0.1);
-      box-shadow: 0 18px 42px rgba(47, 84, 150, 0.18);
+      color: #fff;
     }
 
-    .module-card {
-      border-radius: 20px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 22px 48px rgba(47, 84, 150, 0.16);
+    .table-card,
+    .workflow-card {
       background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .module-card .card-body {
-      padding: clamp(1.5rem, 2vw, 2.5rem);
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .pill-accent {
-      background: rgba(255, 255, 255, 0.18);
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-    }
-
-    .module-grid {
-      min-height: 180px;
-    }
-
-    .module-card article {
+    .table thead th {
       border: none;
-      border-radius: 18px;
-      background: linear-gradient(145deg, #ffffff 0%, #f2f2f2 100%);
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    .module-card .card h3 {
-      color: var(--color-primary);
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
       font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
+
+<body data-modulo="Finanzas" data-modulo-alias="Finanzas">
   <div class="container py-4 py-lg-5">
     <div class="row mb-4">
       <div class="col-12">
-        <div class="card header-card">
-          <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
-            <div>
-              <h1 class="h3 fw-bold mb-1">Finanzas</h1>
-              <p class="mb-0">Visión integral de ingresos, egresos y desempeño financiero.</p>
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Finanzas</h1>
+                <p class="mb-0 text-white-50">Visión integral de ingresos, egresos y desempeño financiero.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
             </div>
-            <span class="pill-accent">Datos dinámicos</span>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="row g-4">
+    <div class="row mb-4">
       <div class="col-12">
-        <div class="card module-card">
-          <div class="card-body">
-            <div id="moduleLoader" class="d-flex align-items-center gap-2 mb-3 visually-hidden">
-              <div class="spinner-border text-success" role="status" aria-hidden="true"></div>
-              <span class="fw-semibold text-success">Actualizando información…</span>
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
             </div>
-            <div id="moduleStatus" class="alert alert-info">Preparando información…</div>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 module-grid" id="moduleDynamicList"></div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
         </div>
       </div>
     </div>
   </div>
 
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
+  </div>
+
   <script src="js/sesion.js"></script>
-  <script src="js/modulo-generico.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      initGenericModule('finanzas');
-    });
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Gtos_Corporativos.html
+++ b/vistas/Gtos_Corporativos.html
@@ -1,116 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Gastos Corporativos</title>
+  <title>Gastos Corporativos - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-       --color-primary: #2f5496;
+      --color-primary: #2f5496;
       --color-secondary: #8497b0;
       --color-background: #f2f2f2;
       --color-text: #2f5496;
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
     }
 
     body {
-      background: var(--color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       color: var(--color-text);
       min-height: 100vh;
-      padding-top: 60px;
+      padding-top: 70px;
     }
 
     .header-card {
       background: var(--color-primary);
-      color: #fff;
-      border-radius: 18px;
+      border-radius: 16px;
       border: 1px solid rgba(47, 84, 150, 0.1);
-      box-shadow: 0 18px 42px rgba(47, 84, 150, 0.18);
+      color: #fff;
     }
 
-    .module-card {
-      border-radius: 20px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 22px 48px rgba(47, 84, 150, 0.16);
+    .table-card,
+    .workflow-card {
       background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .module-card .card-body {
-      padding: clamp(1.5rem, 2vw, 2.5rem);
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .pill-accent {
-      background: rgba(255, 255, 255, 0.18);
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-    }
-
-    .module-grid {
-      min-height: 180px;
-    }
-
-    .module-card article {
+    .table thead th {
       border: none;
-      border-radius: 18px;
-      background: linear-gradient(145deg, #ffffff 0%, #f2f2f2 100%);
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    .module-card .card h3 {
-      color: var(--color-primary);
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
       font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
+
+<body data-modulo="Gtos Corporativos" data-modulo-alias="Gastos Corporativos">
   <div class="container py-4 py-lg-5">
     <div class="row mb-4">
       <div class="col-12">
-        <div class="card header-card">
-          <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
-            <div>
-              <h1 class="h3 fw-bold mb-1">Gastos Corporativos</h1>
-              <p class="mb-0">Control y seguimiento de los gastos compartidos en la organización.</p>
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Gastos Corporativos</h1>
+                <p class="mb-0 text-white-50">Control y seguimiento de los gastos compartidos en la organización.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
             </div>
-            <span class="pill-accent">Datos dinámicos</span>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="row g-4">
+    <div class="row mb-4">
       <div class="col-12">
-        <div class="card module-card">
-          <div class="card-body">
-            <div id="moduleLoader" class="d-flex align-items-center gap-2 mb-3 visually-hidden">
-              <div class="spinner-border text-success" role="status" aria-hidden="true"></div>
-              <span class="fw-semibold text-success">Actualizando información…</span>
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
             </div>
-            <div id="moduleStatus" class="alert alert-info">Preparando información…</div>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 module-grid" id="moduleDynamicList"></div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
         </div>
       </div>
     </div>
   </div>
 
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
+  </div>
+
   <script src="js/sesion.js"></script>
-  <script src="js/modulo-generico.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      initGenericModule('gtos-corporativos');
-    });
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Membresía.html
+++ b/vistas/Membresía.html
@@ -1,340 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Membresía</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Membresía - Presupuestos</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
-    :root{
-      --color-primary:#2f5496;
-      --color-secondary:#8497b0;
-      --color-background:#f2f2f2;
-      --color-text:#2f5496;
-
-      --bs-primary:#2f5496;
-      --bs-primary-rgb:47,84,150;
-      --bs-success:#2f5496;
-      --bs-success-rgb:47,84,150;
-      --bs-success-bg-subtle:rgba(47,84,150,0.16);
-      --bs-success-border-subtle:rgba(47,84,150,0.35);
+    :root {
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
 
-    body{
-      background:var(--color-background);
-      font-family:'Manrope','Segoe UI',Tahoma,sans-serif;
-      color:var(--color-text);
-      min-height:100vh;
-      padding-top:20px;
+    body {
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
+      min-height: 100vh;
+      padding-top: 70px;
     }
 
-    /* Contenedor más ancho en esta página */
-    .membresia-container{
-      max-width:1440px;  /* ajusta si necesitas aún más ancho */
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
     }
 
-    .panel{
-      background:#fff;
-      border-radius:18px;
-      border:1px solid rgba(47,84,150,0.08);
-      box-shadow:0 25px 55px rgba(47,84,150,0.08);
-      padding:1.75rem;
+    .table-card,
+    .workflow-card {
+      background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .table-membresia{
-      width:100%;
-      border-collapse:collapse;
-      font-size:0.92rem;
-    }
-    .table-membresia th,
-    .table-membresia td{
-      border:1px solid rgba(47,84,150,0.12);
-      padding:.55rem .6rem;
-      text-align:right;
-      min-width:90px;
-      background:#fff;
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .table-membresia thead th{
-      background:#2f5496;
-      color:#fff;
-      text-transform:uppercase;
-      letter-spacing:.05em;
-      font-size:.8rem;
-      position:sticky;
-      top:0;
-      z-index:1;
-    }
-    .table-membresia thead th span{ color:#d9d9d9; font-weight:800; display:block; }
-
-    .account-col-h,
-    .account-col{
-      text-align:left;
-      min-width:120px;
-      background:#f7f9fc;
-    }
-    .account-col{
-      font-family:'Courier New',monospace;
-      font-weight:600;
-    }
-    .desc-col{
-      text-align:left;
-      min-width:260px;
-      font-weight:600;
-      color:var(--color-text);
+    .table thead th {
+      border: none;
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    /* Totales y resultados */
-    .table-membresia tbody tr[data-kind="total"],
-    .table-membresia tbody tr[data-kind="resultado"]{
-      background:#f2f2f2;
-      font-weight:800;
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
     }
 
-    /* Duplicado (segunda columna del mes) en amarillo */
-    .table-membresia th.dup,
-    .table-membresia td.dup{
-      background:#fff7d6; /* amarillo suave */
-      border-left:2px solid rgba(47,84,150,.25);
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
     }
 
-    /* Botón ocultar/mostrar cuentas y clase global */
-    body.ocultar-cuentas .account-col,
-    body.ocultar-cuentas .account-col-h{
-      display:none;
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
     }
 
-    /* Encabezado de página */
-    .hero{
-      display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
     }
-    .title{
-      color:var(--color-primary);
-      font-weight:800;
-      margin:0;
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
-    .status{
-      font-weight:600;font-size:.9rem;
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
 
-  <div class="container-xxl membresia-container py-4">
-    <section class="panel">
-      <div class="hero mb-3">
-        <div>
-          <h1 class="title h3 mb-1">Membresía</h1>
-          <span id="membStatus" class="status text-success"></span>
-        </div>
-        <div class="d-flex align-items-end gap-2 flex-wrap">
-          <div>
-            <label class="form-label mb-1" for="yearSelect">Ejercicio</label>
-            <select id="yearSelect" class="form-select">
-              <option value="2024">2024</option>
-              <option value="2025" selected>2025</option>
-              <option value="2026">2026</option>
-            </select>
+<body data-modulo="Membresía" data-modulo-alias="Membresía">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Membresía</h1>
+                <p class="mb-0 text-white-50">Planeación financiera del área de Membresía.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
           </div>
-          <button id="toggleAccounts" type="button" class="btn btn-outline-secondary">
-            Ocultar cuentas
-          </button>
         </div>
       </div>
+    </div>
 
-      <div class="table-responsive">
-        <table class="table-membresia" id="tblMembresia">
-          <thead></thead>
-          <tbody></tbody>
-        </table>
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-    (()=>{
-      // ====== Estado mínimo (estático por ahora) ======
-      const els = {
-        head: document.querySelector('#tblMembresia thead'),
-        body: document.querySelector('#tblMembresia tbody'),
-        yearSelect: document.getElementById('yearSelect'),
-        status: document.getElementById('membStatus'),
-        toggleAccounts: document.getElementById('toggleAccounts')
-      };
-
-      // Si existe tu helper Sesion, mostramos el capítulo; si no, lo omitimos (estático)
-      try{
-        const emp = (typeof Sesion!=='undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-        if(emp?.etiqueta){
-          document.title = `Membresía – ${emp.etiqueta}`;
-        }
-      }catch{}
-
-      function tickStatus(){
-        if(!els.status) return;
-        els.status.textContent = `Vista ${new Date().toLocaleTimeString('es-MX')}.`;
-      }
-      tickStatus();
-
-      // ====== Columnas (meses duplicados como Excel) ======
-      const MONTHS = [
-        { k:'ene', l:'ENE' },{ k:'feb', l:'FEB' },{ k:'mar', l:'MAR' },
-        { k:'abr', l:'ABR' },{ k:'may', l:'MAY' },{ k:'jun', l:'JUN' },
-        { k:'jul', l:'JUL' },{ k:'ago', l:'AGO' },{ k:'sep', l:'SEP' },
-        { k:'oct', l:'OCT' },{ k:'nov', l:'NOV' },{ k:'dic', l:'DIC' }
-      ];
-
-      // Par de columnas por mes: normal + duplicada (amarilla)
-      const COLUMNS = MONTHS.flatMap(m => ([
-        { key: m.k,          label: m.l, dup:false },
-        { key: m.k + '_b',   label: m.l, dup:true  }
-      ]));
-      const TOTAL_COLUMNS = COLUMNS.length + 3; // Cuenta + Membresía + Total
-
-      // ====== Datos ESTÁTICOS (solo nombres/estructura) ======
-      const bloqueIngresos = [
-        { cuenta:'—', nombre:'Renovaciones' },
-        { cuenta:'—', nombre:'Descuentos por pronto pago' },
-        { cuenta:'—', nombre:'Socios nuevos' },
-        { cuenta:'—', nombre:'Cuotas suscripción' },
-        { cuenta:'—', nombre:'Diamond Publicidad en Publicaciones' },
-      ];
-
-      const bloqueGastos = [
-        { cuenta:'—', nombre:'Intercambios membresía-especie' },
-        { cuenta:'—', nombre:'Intercambios membresía' },
-        { cuenta:'—', nombre:"Comisiones KAM's" },
-        { cuenta:'—', nombre:'Promoción Servicios Membresías (Representación)' },
-        { cuenta:'—', nombre:'Onboarding' },
-      ];
-
-      const bloqueGastosAdm = [
-        { cuenta:'—', nombre:'Teléfono móvil' },
-        { cuenta:'—', nombre:'Mantenimientos de automóvil' },
-        { cuenta:'—', nombre:'Gasolina' },
-        { cuenta:'—', nombre:'Pasajes y taxis' },
-        { cuenta:'—', nombre:'Estacionamientos' },
-        { cuenta:'—', nombre:'Becario' },
-        { cuenta:'—', nombre:'Gastos de viaje' },
-        { cuenta:'—', nombre:'Gastos Administrativos (impresión tarjetas)' },
-        { cuenta:'—', nombre:'Papelería y artículos de oficina' },
-        { cuenta:'—', nombre:'Juntas de trabajo' },
-        { cuenta:'—', nombre:'No deducibles' },
-        { cuenta:'—', nombre:'Herramientas Tele-trabajo' },
-      ];
-
-      // ====== Render ======
-      let anio = Number(els.yearSelect.value || new Date().getFullYear());
-
-      function renderHead(){
-        const suf = String(anio).slice(-2);
-        const cols = COLUMNS.map(c =>
-          `<th class="${c.dup ? 'dup' : ''}"><span>${c.label.toLowerCase()}-${suf}</span></th>`
-        ).join('');
-        els.head.innerHTML = `
-          <tr>
-            <th class="account-col-h">Cuenta</th>
-            <th>MEMBRESÍA</th>
-            ${cols}
-            <th><span>${anio}</span>Total</th>
-          </tr>
-        `;
-      }
-
-      // Para estático, todas las celdas muestran "–"
-      const dash = '–';
-
-      function rowHtml(item){
-        const celdas = COLUMNS.map(c => `<td class="${c.dup?'dup':''}">${dash}</td>`).join('');
-        return `
-          <tr>
-            <td class="account-col">${item.cuenta || '—'}</td>
-            <td class="desc-col">${item.nombre || ''}</td>
-            ${celdas}
-            <td>${dash}</td>
-          </tr>
-        `;
-      }
-
-      function spacer(){
-        return `<tr><td colspan="${TOTAL_COLUMNS}" style="background:transparent;border:none;height:.35rem;"></td></tr>`;
-      }
-
-      function totalRow(label){
-        const celdas = COLUMNS.map(()=>`<td>${dash}</td>`).join('');
-        return `
-          <tr data-kind="total">
-            <td colspan="2">${label}</td>
-            ${celdas}
-            <td>${dash}</td>
-          </tr>
-        `;
-      }
-
-      function resultadoRow(label){
-        const celdas = COLUMNS.map(()=>`<td>${dash}</td>`).join('');
-        return `
-          <tr data-kind="resultado">
-            <td colspan="2">${label}</td>
-            ${celdas}
-            <td>${dash}</td>
-          </tr>
-        `;
-      }
-
-      function renderBody(){
-        const parts = [];
-
-        // Ingresos
-        bloqueIngresos.forEach(it => parts.push(rowHtml(it)));
-        parts.push(totalRow('Suma de Ingresos Membresía'));
-        parts.push(spacer());
-
-        // Gastos
-        bloqueGastos.forEach(it => parts.push(rowHtml(it)));
-        parts.push(totalRow('Suma de Gastos Membresía'));
-        parts.push(resultadoRow('Resultado Operativo Membresía'));
-        parts.push(spacer());
-
-        // Gastos Administrativos
-        bloqueGastosAdm.forEach(it => parts.push(rowHtml(it)));
-        parts.push(totalRow('Suma Gastos Administrativos'));
-        parts.push(spacer());
-
-        // Resultado final
-        parts.push(resultadoRow('Resultado Membresía'));
-
-        els.body.innerHTML = parts.join('');
-      }
-
-      // Toggle mostrar/ocultar columna "Cuenta"
-      function applyToggle(ocultar){
-        document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
-        els.toggleAccounts.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
-        els.toggleAccounts.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
-      }
-
-      // Eventos
-      els.yearSelect.addEventListener('change', ()=>{
-        anio = Number(els.yearSelect.value);
-        renderHead();
-      });
-
-      els.toggleAccounts.addEventListener('click', ()=>{
-        const hide = !document.body.classList.contains('ocultar-cuentas');
-        applyToggle(hide);
-      });
-
-      // Primera pinta
-      renderHead();
-      renderBody();
-      applyToggle(false);
-    })();
-  </script>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 
 <head>
   <meta charset="UTF-8">
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/estilos.css">
   <style>
     :root {
@@ -41,7 +42,8 @@
       color: #fff;
     }
 
-    .table-card {
+    .table-card,
+    .workflow-card {
       background: #fff;
       border-radius: 16px;
       border: 1px solid rgba(47, 84, 150, 0.1);
@@ -91,32 +93,6 @@
       font-weight: 500;
     }
 
-    .fade-in {
-      animation: fadeIn 0.5s ease-in;
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(20px);
-      }
-
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    .btn-group-custom {
-      gap: 0.5rem;
-    }
-
-    .btn-custom {
-      border-radius: 8px;
-      font-weight: 600;
-      padding: 0.75rem 1.5rem;
-    }
-
     .search-container {
       position: relative;
     }
@@ -132,10 +108,6 @@
     .search-input:focus {
       border-color: var(--color-primary);
       box-shadow: 0 0 0 0.2rem rgba(47, 84, 150, 0.1);
-    }
-
-    .hidden-row {
-      display: none;
     }
 
     .account-column {
@@ -154,10 +126,30 @@
     body.ocultar-cuentas .account-column-header {
       display: none;
     }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
+    }
+
+    .workflow-card small {
+      font-variant-numeric: tabular-nums;
+    }
   </style>
 </head>
 
-<body>
+<body data-modulo="Presupuestos" data-modulo-alias="Presupuestos">
   <div class="container py-4 py-lg-5">
     <div class="row mb-4">
       <div class="col-12">
@@ -179,12 +171,38 @@
       <div class="col-12">
         <div class="card table-card fade-in">
           <div class="card-body p-3">
-            <h5 class="fw-bold mb-3" style="color: var(--color-primary);">Controles de Presupuesto</h5>
-            <div class="btn-group btn-group-custom flex-wrap" role="group">
-              <button type="button" class="btn btn-primario btn-custom" id="saveBudgetBtn">Crear</button>
-              <button type="button" class="btn btn-success btn-custom">Autorizar</button>
-              <button type="button" class="btn btn-outline-success btn-custom" id="loadBudgetBtn">Cargar</button>
-              <button type="button" class="btn btn-outline-secondary btn-custom d-none" id="toggleAccountColumnBtn">Ocultar cuentas</button>
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none">
           </div>
@@ -200,8 +218,8 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-12">
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
         <div class="table-card fade-in">
           <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
           <div class="table-responsive">
@@ -230,352 +248,35 @@
           </div>
         </div>
       </div>
-
-      <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
-        <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
-          aria-live="assertive" aria-atomic="true">
-          <div class="d-flex">
-            <div class="toast-body" id="actionToastBody">
-              Acción realizada correctamente.
-            </div>
-            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
-              aria-label="Close"></button>
-          </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
         </div>
       </div>
+    </div>
+  </div>
 
-      <script src="js/sesion.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-        crossorigin="anonymous"></script>
-      <script>
-        const API_BASE = 'http://localhost:3000/api';
-        const sesion = Sesion.requerirSesion();
-        if (!sesion) {
-          throw new Error('Redireccionando al inicio de sesión.');
-        }
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive"
+      aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">
+          Acción realizada correctamente.
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  </div>
 
-        Sesion.asegurarEnlaceAdministrarUsuarios(document.querySelector('#navbarNav .navbar-nav'));
-
-        const accountSearchInput = document.getElementById('accountSearch');
-        const saveBudgetBtn = document.getElementById('saveBudgetBtn');
-        const loadBudgetBtn = document.getElementById('loadBudgetBtn');
-        const budgetFileInput = document.getElementById('budgetFileInput');
-        const toastElement = document.getElementById('actionToast');
-        const toastBody = document.getElementById('actionToastBody');
-        const toastInstance = bootstrap.Toast.getOrCreateInstance(toastElement, { delay: 3000 });
-        const tablaBody = document.querySelector('#tablaPresupuestos tbody');
-        const presupuestoStatus = document.getElementById('presupuestoStatus');
-        const yearLabel = document.getElementById('yearLabel');
-        const yearColumn = document.getElementById('yearColumn');
-        const empresaLabel = document.getElementById('empresaLabel');
-        const toggleAccountColumnBtn = document.getElementById('toggleAccountColumnBtn');
-
-        const ACCOUNT_COLUMN_STORAGE_KEY = 'presupuestos_ocultar_cuentas';
-
-        const EJERCICIO = new Date().getFullYear();
-        const MESES = [
-          { etiqueta: 'Ene', clave: 'ene' },
-          { etiqueta: 'Feb', clave: 'feb' },
-          { etiqueta: 'Mar', clave: 'mar' },
-          { etiqueta: 'Abr', clave: 'abr' },
-          { etiqueta: 'May', clave: 'may' },
-          { etiqueta: 'Jun', clave: 'jun' },
-          { etiqueta: 'Jul', clave: 'jul' },
-          { etiqueta: 'Ago', clave: 'ago' },
-          { etiqueta: 'Sep', clave: 'sep' },
-          { etiqueta: 'Oct', clave: 'oct' },
-          { etiqueta: 'Nov', clave: 'nov' },
-          { etiqueta: 'Dic', clave: 'dic' }
-        ];
-        const formatoNumero = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-
-        yearLabel.textContent = EJERCICIO;
-        yearColumn.textContent = EJERCICIO;
-
-        const estado = {
-          cuentas: [],
-          filtro: ''
-        };
-
-        const actualizarEtiquetaBotonCuentas = (ocultar) => {
-          if (!toggleAccountColumnBtn) return;
-          toggleAccountColumnBtn.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
-          toggleAccountColumnBtn.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
-        };
-
-        const aplicarVisibilidadCuentas = (ocultar) => {
-          document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
-          actualizarEtiquetaBotonCuentas(Boolean(ocultar));
-        };
-
-        const inicializarControlCuentas = () => {
-          const esAdminGlobal = typeof Sesion !== 'undefined'
-            && typeof Sesion.esAdminGlobal === 'function'
-            && Sesion.esAdminGlobal(sesion);
-          if (!esAdminGlobal || !toggleAccountColumnBtn) {
-            aplicarVisibilidadCuentas(true);
-            if (toggleAccountColumnBtn) {
-              toggleAccountColumnBtn.classList.add('d-none');
-              toggleAccountColumnBtn.setAttribute('aria-pressed', 'true');
-              toggleAccountColumnBtn.setAttribute('disabled', 'true');
-              toggleAccountColumnBtn.setAttribute('aria-disabled', 'true');
-              toggleAccountColumnBtn.setAttribute('tabindex', '-1');
-            }
-            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, '1');
-            return;
-          }
-
-          toggleAccountColumnBtn.classList.remove('d-none');
-          const preferencia = localStorage.getItem(ACCOUNT_COLUMN_STORAGE_KEY) === '1';
-          aplicarVisibilidadCuentas(preferencia);
-
-          toggleAccountColumnBtn.addEventListener('click', () => {
-            const ocultar = !document.body.classList.contains('ocultar-cuentas');
-            aplicarVisibilidadCuentas(ocultar);
-            localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, ocultar ? '1' : '0');
-          });
-        };
-
-        inicializarControlCuentas();
-
-        function showToast(message, variant = 'text-bg-success') {
-          toastElement.classList.remove('text-bg-success', 'text-bg-danger', 'text-bg-warning', 'text-bg-info');
-          toastElement.classList.add(variant);
-          toastBody.textContent = message;
-          toastInstance.show();
-        }
-
-        const mostrarEstado = (mensaje, tipo = 'info') => {
-          presupuestoStatus.textContent = mensaje;
-          presupuestoStatus.className = `alert alert-${tipo} mb-3`;
-        };
-
-        const limpiarEstado = () => {
-          presupuestoStatus.textContent = '';
-          presupuestoStatus.className = 'alert alert-info visually-hidden';
-        };
-
-        const obtenerEmpresaActiva = () => Sesion.obtenerEmpresaActiva();
-
-        const actualizarEncabezadoEmpresa = (empresa) => {
-          const activa = empresa || obtenerEmpresaActiva();
-          if (activa && activa.nombre) {
-            empresaLabel.textContent = activa.etiqueta ? `${activa.etiqueta} — ${activa.nombre}` : activa.nombre;
-          } else {
-            empresaLabel.textContent = 'Sin empresa asignada';
-          }
-        };
-
-        const formatearValor = (valor) => formatoNumero.format(Number.isFinite(Number(valor)) ? Number(valor) : 0);
-
-        const renderizarTabla = () => {
-          tablaBody.innerHTML = '';
-          const termino = estado.filtro.trim().toLowerCase();
-          const cuentasFiltradas = estado.cuentas.filter((cuenta) => {
-            if (!termino) {
-              return true;
-            }
-            const texto = `${cuenta.numCta || ''} ${cuenta.descripcion || ''}`.toLowerCase();
-            return texto.includes(termino);
-          });
-
-          if (cuentasFiltradas.length === 0) {
-            const fila = document.createElement('tr');
-            fila.innerHTML = '<td colspan="15" class="text-center text-muted py-4">No hay información para mostrar.</td>';
-            tablaBody.appendChild(fila);
-            return;
-          }
-
-          cuentasFiltradas.forEach((cuenta) => {
-            const fila = document.createElement('tr');
-            fila.dataset.account = cuenta.numCta || '';
-            fila.dataset.desc = cuenta.descripcion || '';
-
-            const celdaCuenta = document.createElement('td');
-            celdaCuenta.textContent = cuenta.numCta || '—';
-            celdaCuenta.className = 'account-column';
-            fila.appendChild(celdaCuenta);
-
-            const celdaNombre = document.createElement('td');
-            celdaNombre.textContent = cuenta.descripcion || '—';
-            fila.appendChild(celdaNombre);
-
-            MESES.forEach(({ clave }) => {
-              const celda = document.createElement('td');
-              celda.className = 'budget-value text-end';
-              celda.textContent = formatearValor(cuenta[clave]);
-              fila.appendChild(celda);
-            });
-
-            const celdaAnual = document.createElement('td');
-            celdaAnual.className = 'budget-value text-end';
-            celdaAnual.textContent = formatearValor(cuenta.anual);
-            fila.appendChild(celdaAnual);
-
-            tablaBody.appendChild(fila);
-          });
-        };
-
-        const cargarPresupuestos = async () => {
-          const empresa = obtenerEmpresaActiva();
-          if (!empresa) {
-            actualizarEncabezadoEmpresa(null);
-            estado.cuentas = [];
-            renderizarTabla();
-            mostrarEstado('Selecciona una empresa desde el panel principal para visualizar sus presupuestos.', 'warning');
-            return;
-          }
-
-          actualizarEncabezadoEmpresa(empresa);
-          mostrarEstado('Cargando presupuestos…', 'info');
-
-          try {
-            const respuesta = await fetch(`${API_BASE}/presupuestos?anio=${EJERCICIO}`, {
-              headers: Sesion.headersAutenticacion()
-            });
-            const datos = await respuesta.json();
-            if (!respuesta.ok) {
-              throw new Error(datos.mensaje || 'No fue posible obtener los presupuestos.');
-            }
-
-            if (datos.empresa) {
-              actualizarEncabezadoEmpresa(datos.empresa);
-            }
-
-            const normalizarNumero = (valor) => {
-              const numerico = Number(valor);
-              return Number.isFinite(numerico) ? numerico : 0;
-            };
-
-            const obtenerNaturaleza = (valor) => (valor || '').toString().trim().toUpperCase();
-            const esAcreedora = (naturaleza) => ['A', 'C'].includes(naturaleza);
-
-            estado.cuentas = Array.isArray(datos.cuentas)
-              ? datos.cuentas.map((cuenta) => {
-                const naturaleza = obtenerNaturaleza(cuenta.naturaleza || cuenta.NATURALEZA);
-                const factor = esAcreedora(naturaleza) ? -1 : 1;
-
-                const normalizada = {
-                  numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
-                  descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || '',
-                  naturaleza
-                };
-
-                MESES.forEach(({ clave }) => {
-                  normalizada[clave] = normalizarNumero(cuenta[clave]) * factor;
-                });
-
-                normalizada.anual = normalizarNumero(cuenta.anual) * factor;
-                return normalizada;
-              })
-              : [];
-
-            estado.filtro = '';
-            accountSearchInput.value = '';
-            limpiarEstado();
-            renderizarTabla();
-          } catch (error) {
-            estado.cuentas = [];
-            renderizarTabla();
-            mostrarEstado(error.message || 'Ocurrió un problema al cargar la información.', 'danger');
-          }
-        };
-
-        const convertirTablaACsv = () => {
-          const encabezados = ['Cuenta', 'Descripción', ...MESES.map((mes) => mes.etiqueta), `Anual ${EJERCICIO}`];
-          const filas = estado.cuentas.map((cuenta) => {
-            const periodos = MESES.map(({ clave }) => cuenta[clave] ?? 0);
-            const anual = cuenta.anual ?? 0;
-            return [
-              cuenta.numCta || '',
-              cuenta.descripcion || '',
-              ...periodos.map((valor) => Number(valor).toFixed(2)),
-              Number(anual).toFixed(2)
-            ];
-          });
-          const csv = [encabezados.join(',')];
-          filas.forEach((fila) => csv.push(fila.join(',')));
-          return csv.join('\n');
-        };
-
-        const actualizarDesdeCsv = (texto) => {
-          const lineas = texto.split(/\r?\n/).filter((linea) => linea.trim().length > 0);
-          if (lineas.length <= 1) {
-            return false;
-          }
-
-          const mapaCuentas = new Map(estado.cuentas.map((cuenta) => [cuenta.numCta, cuenta]));
-          for (let i = 1; i < lineas.length; i += 1) {
-            const columnas = lineas[i].split(',');
-            if (columnas.length < MESES.length + 2) {
-              continue;
-            }
-            const cuenta = mapaCuentas.get(columnas[0].trim());
-            if (!cuenta) {
-              continue;
-            }
-            MESES.forEach((mes, indice) => {
-              const columna = columnas[indice + 2] || '0';
-              const numerico = Number(columna.replace(/[^0-9+\-.,]/g, '').replace(',', '.'));
-              cuenta[mes.clave] = Number.isFinite(numerico) ? numerico : 0;
-            });
-            cuenta.anual = MESES.reduce((acumulado, mes) => acumulado + (cuenta[mes.clave] ?? 0), 0);
-          }
-          renderizarTabla();
-          return true;
-        };
-
-        accountSearchInput.addEventListener('input', (event) => {
-          estado.filtro = event.target.value.trim().toLowerCase();
-          renderizarTabla();
-        });
-
-        saveBudgetBtn.addEventListener('click', () => {
-          const csvContent = convertirTablaACsv();
-          const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-          const downloadLink = document.createElement('a');
-          const url = URL.createObjectURL(blob);
-          downloadLink.href = url;
-          downloadLink.download = `presupuesto_${EJERCICIO}.csv`;
-          document.body.appendChild(downloadLink);
-          downloadLink.click();
-          document.body.removeChild(downloadLink);
-          URL.revokeObjectURL(url);
-          showToast('Presupuesto exportado correctamente.');
-        });
-
-        loadBudgetBtn.addEventListener('click', () => {
-          budgetFileInput.click();
-        });
-
-        budgetFileInput.addEventListener('change', (event) => {
-          const file = event.target.files?.[0];
-          if (!file) {
-            return;
-          }
-
-          const reader = new FileReader();
-          reader.onload = (e) => {
-            const exito = actualizarDesdeCsv(e.target?.result || '');
-            if (exito) {
-              showToast('Presupuesto cargado correctamente.', 'text-bg-info');
-            } else {
-              showToast('El archivo seleccionado no contiene datos válidos.', 'text-bg-warning');
-            }
-          };
-          reader.onerror = () => {
-            showToast('No se pudo leer el archivo seleccionado.', 'text-bg-danger');
-          };
-          reader.readAsText(file);
-          event.target.value = '';
-        });
-
-        document.addEventListener('DOMContentLoaded', () => {
-          actualizarEncabezadoEmpresa();
-          cargarPresupuestos();
-        });
-      </script>
+  <script src="js/sesion.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+    crossorigin="anonymous"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
 
 </html>

--- a/vistas/RH.html
+++ b/vistas/RH.html
@@ -1,116 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Recursos Humanos</title>
+  <title>Recursos Humanos - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-     --color-primary: #2f5496;
+      --color-primary: #2f5496;
       --color-secondary: #8497b0;
       --color-background: #f2f2f2;
       --color-text: #2f5496;
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
     }
 
     body {
-      background: var(--color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       color: var(--color-text);
       min-height: 100vh;
-      padding-top: 60px;
+      padding-top: 70px;
     }
 
     .header-card {
       background: var(--color-primary);
-      color: #fff;
-      border-radius: 18px;
+      border-radius: 16px;
       border: 1px solid rgba(47, 84, 150, 0.1);
-      box-shadow: 0 18px 42px rgba(47, 84, 150, 0.18);
+      color: #fff;
     }
 
-    .module-card {
-      border-radius: 20px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 22px 48px rgba(47, 84, 150, 0.16);
+    .table-card,
+    .workflow-card {
       background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .module-card .card-body {
-      padding: clamp(1.5rem, 2vw, 2.5rem);
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .pill-accent {
-      background: rgba(255, 255, 255, 0.18);
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-    }
-
-    .module-grid {
-      min-height: 180px;
-    }
-
-    .module-card article {
+    .table thead th {
       border: none;
-      border-radius: 18px;
-      background: linear-gradient(145deg, #ffffff 0%, #f2f2f2 100%);
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    .module-card .card h3 {
-      color: var(--color-primary);
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
       font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
+
+<body data-modulo="RH" data-modulo-alias="Recursos Humanos">
   <div class="container py-4 py-lg-5">
     <div class="row mb-4">
       <div class="col-12">
-        <div class="card header-card">
-          <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
-            <div>
-              <h1 class="h3 fw-bold mb-1">Recursos Humanos</h1>
-              <p class="mb-0">Equipo, cultura y desarrollo de talento dentro de la cámara.</p>
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Recursos Humanos</h1>
+                <p class="mb-0 text-white-50">Presupuesto de talento y cultura organizacional.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
             </div>
-            <span class="pill-accent">Datos dinámicos</span>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="row g-4">
+    <div class="row mb-4">
       <div class="col-12">
-        <div class="card module-card">
-          <div class="card-body">
-            <div id="moduleLoader" class="d-flex align-items-center gap-2 mb-3 visually-hidden">
-              <div class="spinner-border text-success" role="status" aria-hidden="true"></div>
-              <span class="fw-semibold text-success">Actualizando información…</span>
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
             </div>
-            <div id="moduleStatus" class="alert alert-info">Preparando información…</div>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 module-grid" id="moduleDynamicList"></div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
         </div>
       </div>
     </div>
   </div>
 
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
+  </div>
+
   <script src="js/sesion.js"></script>
-  <script src="js/modulo-generico.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      initGenericModule('rh');
-    });
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/Serv_Membresía.html
+++ b/vistas/Serv_Membresía.html
@@ -1,387 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Servicios a la Membresía</title>
-
+  <title>Servicios a la Membresía - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
-
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-      --servm-color-primary: #2f5496;
-      --servm-color-secondary: #8497b0;
-      --servm-color-background: #f2f2f2;
-      --servm-color-text: #2f5496;
-
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
 
     body {
-      background: var(--servm-color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
-      color: var(--servm-color-text);
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
       min-height: 100vh;
-      padding-top: 20px;
+      padding-top: 70px;
     }
 
-    .servm-container {
-      max-width: 1440px;
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
     }
 
-    .servm-panel {
+    .table-card,
+    .workflow-card {
       background: #fff;
-      border-radius: 18px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 25px 55px rgba(47, 84, 150, 0.08);
-      padding: 1.75rem;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .servm-hero {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      flex-wrap: wrap;
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .servm-title {
-      color: var(--servm-color-primary);
-      font-weight: 800;
-      margin: 0;
-    }
-
-    .servm-status {
+    .table thead th {
+      border: none;
       font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
       font-size: 0.9rem;
     }
 
-    .servm-controls {
-      display: flex;
-      gap: 0.75rem;
-      align-items: flex-end;
-      flex-wrap: wrap;
-    }
-
-    .servm-controls .form-select {
-      min-width: 110px;
-    }
-
-    .servm-btn-toggle {
-      border-radius: 10px;
-      padding: 0.6rem 1rem;
-      border: 1px solid rgba(47, 84, 150, 0.25);
-      background: #fff;
-      color: var(--servm-color-text);
-      font-weight: 700;
-    }
-
-    .servm-table-wrapper {
-      width: 100%;
-      overflow-x: auto;
-      margin-top: 1rem;
-    }
-
-    .servm-table {
-      width: 100%;
-      min-width: 1600px;
-      border-collapse: collapse;
-      font-size: 0.92rem;
-    }
-
-    .servm-table th,
-    .servm-table td {
-      border: 1px solid rgba(47, 84, 150, 0.12);
-      padding: 0.55rem 0.6rem;
-      text-align: right;
-      min-width: 90px;
-      background: #fff;
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
       white-space: nowrap;
     }
 
-    .servm-table thead th {
-      background: #2f5496;
-      color: #fff;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      font-size: 0.8rem;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
-
-    .servm-table thead th span {
-      display: block;
-      color: #d9d9d9;
-      font-weight: 800;
-    }
-
-    .servm-account-col-h {
+    .account-column-header {
       text-align: left;
-      min-width: 160px;
-      background: #f7f9fc;
+      white-space: nowrap;
     }
 
-    .servm-account-col {
-      text-align: left;
-      min-width: 160px;
-      background: #f7f9fc;
-      font-family: 'Courier New', monospace;
-      font-weight: 600;
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
 
-    .servm-desc-col {
-      text-align: left;
-      min-width: 260px;
-      font-weight: 600;
-      color: var(--servm-color-text);
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
     }
 
-    .servm-table th.servm-dup,
-    .servm-table td.servm-dup {
-      background: #fff7d6;
-      border-left: 2px solid rgba(47, 84, 150, 0.25);
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
     }
 
-    .servm-table tbody tr[data-kind="total"],
-    .servm-table tbody tr[data-kind="resultado"] {
-      background: #f2f2f2;
-      font-weight: 800;
-    }
-
-    .servm-table tbody tr[data-kind="resultado-final"] {
-      background: #eef8ff;
-      font-weight: 900;
-    }
-
-    .servm-section-row {
-      background: rgba(47, 84, 150, 0.05);
-      font-weight: 800;
-      color: var(--servm-color-primary);
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
-  <div class="container-xxl servm-container py-4">
-    <section class="servm-panel">
-      <div class="servm-hero mb-3">
-        <div>
-          <h1 class="servm-title h3 mb-1">Servicios a la Membresía</h1>
-          <span id="servmStatus" class="servm-status text-success"></span>
-          <div id="chapterSubtitle" class="fw-semibold mt-1" style="color:#6b7280"></div>
-        </div>
-        <div class="servm-controls">
-          <div>
-            <label for="yearSelect" class="form-label mb-1 fw-bold" style="color:#4567a8">Ejercicio</label>
-            <select id="yearSelect" class="form-select">
-              <option value="2024">2024</option>
-              <option value="2025">2025</option>
-              <option value="2026" selected>2026</option>
-            </select>
-          </div>
-          <button id="toggleAccounts" type="button" class="servm-btn-toggle">
-            Ocultar cuentas
-          </button>
-        </div>
-      </div>
 
-      <div class="servm-table-wrapper">
-        <table class="servm-table" id="tblServMembresia">
-          <thead></thead>
-          <tbody></tbody>
-        </table>
+<body data-modulo="Serv Membresía" data-modulo-alias="Servicios a la Membresía">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">Servicios a la Membresía</h1>
+                <p class="mb-0 text-white-50">Seguimiento de iniciativas y servicios para socios.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-    (function () {
-      // ===== Capítulo según empresa activa =====
-      try {
-        const emp = (typeof Sesion !== 'undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-        const ciudad = emp?.etiqueta || emp?.nombre || emp?.id || '—';
-        document.getElementById('chapterSubtitle').textContent = ciudad ? 'Capítulo ' + ciudad : '';
-      } catch {}
-
-      const statusEl    = document.getElementById('servmStatus');
-      const yearSelect  = document.getElementById('yearSelect');
-      const tableHead   = document.querySelector('#tblServMembresia thead');
-      const tableBody   = document.querySelector('#tblServMembresia tbody');
-      const toggleBtn   = document.getElementById('toggleAccounts');
-      const STORAGE_KEY = 'servmemb_ocultar_cuentas';
-
-      function updateStatusTime() {
-        if (!statusEl) return;
-        statusEl.textContent = 'Vista ' + new Date().toLocaleTimeString('es-MX') + '.';
-      }
-
-      // ===== Meses duplicados (A normal, B duplicado amarillo) =====
-      const SERVM_MONTHS = [
-        { key: 'eneA', label: 'ENE', dup: false }, { key: 'eneB', label: 'ENE', dup: true },
-        { key: 'febA', label: 'FEB', dup: false }, { key: 'febB', label: 'FEB', dup: true },
-        { key: 'marA', label: 'MAR', dup: false }, { key: 'marB', label: 'MAR', dup: true },
-        { key: 'abrA', label: 'ABR', dup: false }, { key: 'abrB', label: 'ABR', dup: true },
-        { key: 'mayA', label: 'MAY', dup: false }, { key: 'mayB', label: 'MAY', dup: true },
-        { key: 'junA', label: 'JUN', dup: false }, { key: 'junB', label: 'JUN', dup: true },
-        { key: 'julA', label: 'JUL', dup: false }, { key: 'julB', label: 'JUL', dup: true },
-        { key: 'agoA', label: 'AGO', dup: false }, { key: 'agoB', label: 'AGO', dup: true },
-        { key: 'sepA', label: 'SEP', dup: false }, { key: 'sepB', label: 'SEP', dup: true },
-        { key: 'octA', label: 'OCT', dup: false }, { key: 'octB', label: 'OCT', dup: true },
-        { key: 'novA', label: 'NOV', dup: false }, { key: 'novB', label: 'NOV', dup: true },
-        { key: 'dicA', label: 'DIC', dup: false }, { key: 'dicB', label: 'DIC', dup: true }
-      ];
-
-      const dash = '–';
-
-      // ===== Filas según Excel "Mex Serv Membresía 2026" =====
-      const SERVM_ROWS = [
-        { tipo: 'section', nombre: 'Ingresos Serv Membresía' },
-        { tipo: 'ing', cuenta: '406-001-000-00', nombre: 'Encuesta de Sueldos y Prestaciones' },
-        { tipo: 'ing', cuenta: '406-002-000-00', nombre: 'Digital Training' },
-        { tipo: 'total', nombre: 'Suma de Ingresos Serv Membresía' },
-
-        { tipo: 'sep' },
-
-        { tipo: 'section', nombre: 'Gastos Serv Membresía' },
-        { tipo: 'gto', cuenta: '601-002-003-00', nombre: 'Encuesta de Sueldos y Prestaciones' },
-        { tipo: 'gto', cuenta: '601-003-001-00', nombre: 'Digital Training' },
-        { tipo: 'total', nombre: 'Suma de Gastos Serv Membresía' },
-
-        { tipo: 'sep' },
-
-        { tipo: 'res', nombre: 'Resultado Serv Membresía' }
-      ];
-
-      // ===== Render =====
-      let ocultarCuentas = (localStorage.getItem(STORAGE_KEY) === '1');
-
-      function renderHead() {
-        const year = yearSelect.value || new Date().getFullYear();
-        const suf  = String(year).slice(-2);
-
-        const monthTh = SERVM_MONTHS.map(m =>
-          `<th class="${m.dup ? 'servm-dup' : ''}"><span>${m.label.toLowerCase()}-${suf}</span></th>`
-        ).join('');
-
-        if (ocultarCuentas) {
-          tableHead.innerHTML = `
-            <tr>
-              <th>SERVICIOS A LA MEMBRESÍA</th>
-              ${monthTh}
-              <th><span>${year}</span>Total</th>
-            </tr>
-          `;
-        } else {
-          tableHead.innerHTML = `
-            <tr>
-              <th class="servm-account-col-h">Cuenta</th>
-              <th>SERVICIOS A LA MEMBRESÍA</th>
-              ${monthTh}
-              <th><span>${year}</span>Total</th>
-            </tr>
-          `;
-        }
-      }
-
-      function renderBody() {
-        const TOTAL_COLS = ocultarCuentas
-          ? (1 + SERVM_MONTHS.length + 1)      // descripción + meses + total
-          : (2 + SERVM_MONTHS.length + 1);     // cuenta + descripción + meses + total
-
-        const parts = [];
-
-        SERVM_ROWS.forEach(row => {
-          if (row.tipo === 'sep') {
-            parts.push(
-              `<tr><td colspan="${TOTAL_COLS}" style="background:transparent;border:none;height:.35rem;"></td></tr>`
-            );
-            return;
-          }
-
-          if (row.tipo === 'section') {
-            parts.push(
-              `<tr>
-                 <td colspan="${TOTAL_COLS}" class="servm-section-row">${row.nombre}</td>
-               </tr>`
-            );
-            return;
-          }
-
-          const cells = SERVM_MONTHS
-            .map(m => `<td class="${m.dup ? 'servm-dup' : ''}">${dash}</td>`)
-            .join('');
-
-          if (row.tipo === 'total' || row.tipo === 'res') {
-            const kind = row.tipo === 'res' ? 'resultado-final' : 'total';
-            const labelColspan = ocultarCuentas ? 1 : 2;
-
-            parts.push(`
-              <tr data-kind="${kind}">
-                <td colspan="${labelColspan}">${row.nombre}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-            return;
-          }
-
-          // Fila normal
-          if (ocultarCuentas) {
-            parts.push(`
-              <tr data-tipo="${row.tipo}">
-                <td class="servm-desc-col">${row.nombre || ''}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-          } else {
-            parts.push(`
-              <tr data-tipo="${row.tipo}">
-                <td class="servm-account-col">${row.cuenta || '—'}</td>
-                <td class="servm-desc-col">${row.nombre || ''}</td>
-                ${cells}
-                <td>${dash}</td>
-              </tr>
-            `);
-          }
-        });
-
-        tableBody.innerHTML = parts.join('');
-      }
-
-      function updateToggleButton() {
-        toggleBtn.textContent = ocultarCuentas ? 'Mostrar cuentas' : 'Ocultar cuentas';
-        toggleBtn.setAttribute('aria-pressed', ocultarCuentas ? 'true' : 'false');
-      }
-
-      function renderAll() {
-        updateStatusTime();
-        renderHead();
-        renderBody();
-        updateToggleButton();
-      }
-
-      // ===== Eventos =====
-      yearSelect.addEventListener('change', renderAll);
-
-      toggleBtn.addEventListener('click', () => {
-        ocultarCuentas = !ocultarCuentas;
-        localStorage.setItem(STORAGE_KEY, ocultarCuentas ? '1' : '0');
-        renderAll();
-      });
-
-      // Primera pinta
-      renderAll();
-    })();
-  </script>
-
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/T&IC.html
+++ b/vistas/T&IC.html
@@ -1,443 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>T&IC</title>
+  <title>T&amp;IC - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
-
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
-    :root{
-      --tic-color-primary:#2f5496;
-      --tic-color-secondary:#8497b0;
-      --tic-color-background:#f2f2f2;
-      --tic-color-text:#2f5496;
-      --tic-color-dup:#fff7d6;
-
-      --bs-primary:#2f5496;
-      --bs-primary-rgb:47,84,150;
-      --bs-success:#2f5496;
-      --bs-success-rgb:47,84,150;
-      --bs-success-bg-subtle:rgba(47,84,150,0.16);
-      --bs-success-border-subtle:rgba(47,84,150,0.35);
+    :root {
+      --color-primary: #2f5496;
+      --color-secondary: #8497b0;
+      --color-background: #f2f2f2;
+      --color-text: #2f5496;
     }
 
-    html,body{
-      margin:0;
-      padding:0;
-      min-height:100%;
+    body {
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: var(--color-text);
+      min-height: 100vh;
+      padding-top: 70px;
     }
 
-    body{
-      background:var(--tic-color-background);
-      font-family:'Manrope','Segoe UI',Tahoma,sans-serif;
-      color:var(--tic-color-text);
-      min-height:100vh;
-      padding-top:20px;
+    .header-card {
+      background: var(--color-primary);
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      color: #fff;
     }
 
-    .tic-container{
-      max-width:1440px;
+    .table-card,
+    .workflow-card {
+      background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .tic-panel{
-      background:#fff;
-      border-radius:20px;
-      border:1px solid rgba(47,84,150,.12);
-      box-shadow:0 24px 60px rgba(47,84,150,.12);
-      padding:1.75rem;
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .tic-hero{
-      display:flex;
-      justify-content:space-between;
-      align-items:flex-start;
-      gap:1rem;
-      flex-wrap:wrap;
+    .table thead th {
+      border: none;
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    .tic-title{
-      color:var(--tic-color-primary);
-      font-weight:800;
-      margin:0;
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
     }
 
-    .tic-subtitle{
-      display:block;
-      font-weight:600;
-      color:rgba(47,84,150,.8);
-      margin-top:.15rem;
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
     }
 
-    .tic-status{
-      display:block;
-      font-size:.85rem;
-      margin-top:.25rem;
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
     }
 
-    .tic-controls{
-      display:flex;
-      align-items:flex-end;
-      gap:.75rem;
-      flex-wrap:wrap;
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
     }
 
-    .tic-controls label{
-      font-size:.8rem;
-      font-weight:700;
-      letter-spacing:.08em;
-      text-transform:uppercase;
-      color:rgba(47,84,150,.8);
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
     }
 
-    .tic-toggle-btn{
-      border-radius:10px;
-      padding:.55rem 1rem;
-      border:1px solid rgba(47,84,150,.25);
-      background:#fff;
-      color:var(--tic-color-text);
-      font-weight:700;
-      font-size:.9rem;
-      white-space:nowrap;
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
+      font-weight: 700;
+      color: var(--color-primary);
     }
 
-    .tic-toggle-btn:hover,
-    .tic-toggle-btn:focus{
-      background:rgba(47,84,150,.06);
-      outline:none;
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
     }
 
-    /* ===== Tabla ===== */
-    .tic-table-wrapper{
-      margin-top:1rem;
-    }
-
-    .tic-table-responsive{
-      overflow-x:auto;
-    }
-
-    .tic-table{
-      width:100%;
-      min-width:1800px;
-      border-collapse:collapse;
-      font-size:.9rem;
-      background:#fff;
-    }
-
-    .tic-table th,
-    .tic-table td{
-      border:1px solid rgba(47,84,150,.14);
-      padding:.5rem .6rem;
-      text-align:right;
-      white-space:nowrap;
-      background:#fff;
-    }
-
-    .tic-table thead th{
-      background:var(--tic-color-primary);
-      color:#fff;
-      text-transform:uppercase;
-      letter-spacing:.05em;
-      font-size:.78rem;
-      position:sticky;
-      top:0;
-      z-index:1;
-    }
-
-    .tic-table thead th span{
-      display:block;
-      color:#d9d9d9;
-      font-weight:800;
-    }
-
-    .tic-account-col-h,
-    .tic-account-col{
-      text-align:left;
-      min-width:140px;
-      background:#f7f9fc;
-    }
-
-    .tic-account-col{
-      font-family:'Courier New',monospace;
-      font-weight:600;
-    }
-
-    .tic-desc-col{
-      text-align:left;
-      min-width:220px;
-      font-weight:600;
-      color:var(--tic-color-text);
-      background:#f7f9fc;
-    }
-
-    .tic-month-head-alt{
-      background:#325f9f;
-    }
-
-    .tic-month-head-dup{
-      background:var(--tic-color-dup);
-      color:#374151;
-    }
-
-    .tic-cell-dup{
-      background:var(--tic-color-dup);
-    }
-
-    tr[data-tic-kind="total"],
-    tr[data-tic-kind="resultado"]{
-      background:#f2f2f2;
-      font-weight:800;
-    }
-
-    tr[data-tic-kind="resultado-final"]{
-      background:#eef8ff;
-      font-weight:900;
-    }
-
-    .tic-spacer-row td{
-      background:transparent!important;
-      border:none!important;
-      height:.4rem;
-      padding:0;
-    }
-
-    /* Ocultar cuentas sólo visualmente */
-    body.tic-ocultar-cuentas .tic-account-col,
-    body.tic-ocultar-cuentas .tic-account-col-h{
-      display:none;
-    }
-
-    @media (max-width:992px){
-      .tic-panel{
-        padding:1.25rem;
-      }
-      .tic-hero{
-        align-items:stretch;
-      }
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
-  <div class="container-xxl tic-container py-4">
-    <section class="tic-panel">
-      <div class="tic-hero mb-3">
-        <div>
-          <h1 class="tic-title h3 mb-1">T&amp;IC</h1>
-          <span id="ticChapterSubtitle" class="tic-subtitle">Capítulo —</span>
-          <span id="ticStatus" class="tic-status text-success"></span>
-        </div>
-        <div class="tic-controls">
-          <div>
-            <label for="ticYearSelect" class="mb-1">Ejercicio</label>
-            <select id="ticYearSelect" class="form-select form-select-sm">
-              <option value="2024">2024</option>
-              <option value="2025">2025</option>
-              <option value="2026" selected>2026</option>
-            </select>
-          </div>
-          <button id="ticToggleAccounts" type="button" class="tic-toggle-btn">
-            Ocultar cuentas
-          </button>
-        </div>
-      </div>
 
-      <div class="tic-table-wrapper">
-        <div class="tic-table-responsive">
-          <table class="tic-table" id="ticTable">
-            <thead></thead>
-            <tbody></tbody>
-          </table>
+<body data-modulo="T&amp;IC" data-modulo-alias="T&amp;IC">
+  <div class="container py-4 py-lg-5">
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">T&amp;IC</h1>
+                <p class="mb-0 text-white-50">Innovación y tecnología aplicadas a la operación.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-    </section>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
+            </div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
   </div>
 
   <script src="js/sesion.js"></script>
-  <script>
-    (function(){
-      const els = {
-        subtitle: document.getElementById('ticChapterSubtitle'),
-        status: document.getElementById('ticStatus'),
-        yearSelect: document.getElementById('ticYearSelect'),
-        toggleAccounts: document.getElementById('ticToggleAccounts'),
-        head: document.querySelector('#ticTable thead'),
-        body: document.querySelector('#ticTable tbody')
-      };
-
-      // Capítulo desde Sesion (igual que en otras vistas)
-      try{
-        const emp = (typeof Sesion!=='undefined' && Sesion.obtenerEmpresaActiva && Sesion.obtenerEmpresaActiva()) || null;
-        const ciudad = emp?.etiqueta || emp?.nombre || emp?.id || '—';
-        els.subtitle.textContent = 'Capítulo ' + ciudad;
-        if(emp?.etiqueta){
-          document.title = 'T&IC – ' + emp.etiqueta;
-        }
-      }catch{}
-
-      function tickStatus(){
-        if(!els.status) return;
-        els.status.textContent = 'Vista ' + new Date().toLocaleTimeString('es-MX') + '.';
-      }
-      tickStatus();
-
-      // Meses (12 * 2 columnas como en el Excel: A normal, B duplicado amarillo)
-      const BASE_MONTHS = [
-        { code:'ene', label:'ENE' },
-        { code:'feb', label:'FEB' },
-        { code:'mar', label:'MAR' },
-        { code:'abr', label:'ABR' },
-        { code:'may', label:'MAY' },
-        { code:'jun', label:'JUN' },
-        { code:'jul', label:'JUL' },
-        { code:'ago', label:'AGO' },
-        { code:'sep', label:'SEP' },
-        { code:'oct', label:'OCT' },
-        { code:'nov', label:'NOV' },
-        { code:'dic', label:'DIC' }
-      ];
-
-      const TIC_COLUMNS = BASE_MONTHS.flatMap(m => ([
-        { key: m.code + '_a', label: m.label, dup:false },
-        { key: m.code + '_b', label: m.label, dup:true }
-      ]));
-
-      const TOTAL_COLUMNS_COUNT = 2 + TIC_COLUMNS.length + 1; // cuenta + desc + meses + total
-
-      // Definición de filas basada en el Excel
-      const TIC_ROWS = [
-        // Ingresos
-        { kind:'normal', group:'ingresos', code:'405-001-000-00', label:'Ingresos 1' },
-        { kind:'normal', group:'ingresos', code:'405-002-000-00', label:'Ingresos 2' },
-        { kind:'total',  group:'ingresos', code:null,             label:'Suma de Ingresos T&IC' },
-
-        { kind:'spacer' },
-
-        // Gastos
-        { kind:'normal', group:'gastos', code:'703-002-000-00', label:'Gastos 1' },
-        { kind:'normal', group:'gastos', code:'703-003-000-00', label:'Gastos 2' },
-        { kind:'total',  group:'gastos', code:null,             label:'Suma de Gastos T&IC' },
-
-        { kind:'spacer' },
-
-        // Resultado
-        { kind:'resultado-final', group:'resultado', code:null, label:'Resultado T&IC' }
-      ];
-
-      function renderHead(){
-        const year = els.yearSelect.value || new Date().getFullYear();
-        const suf = String(year).slice(-2);
-
-        const monthTh = TIC_COLUMNS.map(col => {
-          const cls = col.dup ? 'tic-month-head-dup' : 'tic-month-head-alt';
-          const spanId = 'tic-head-' + col.key + '-' + year;
-          return `<th class="${cls}"><span id="${spanId}">${col.label.toLowerCase()}-${suf}</span></th>`;
-        }).join('');
-
-        const totalHeadId = 'tic-head-total-' + year;
-
-        els.head.innerHTML = `
-          <tr>
-            <th class="tic-account-col-h"><span id="tic-head-cuenta">Cuenta</span></th>
-            <th class="tic-desc-col"><span id="tic-head-area">T&amp;IC</span></th>
-            ${monthTh}
-            <th><span id="${totalHeadId}">${year}</span><span>Total</span></th>
-          </tr>
-        `;
-      }
-
-      const dash = '–';
-
-      function buildMonthCells(rowKey){
-        return TIC_COLUMNS.map(col => {
-          const cellId = `tic-${rowKey}-${col.key}`;
-          const cls = col.dup ? 'tic-cell-dup' : '';
-          return `<td class="${cls}"><span id="${cellId}">${dash}</span></td>`;
-        }).join('');
-      }
-
-      function renderBody(){
-        const parts = [];
-
-        TIC_ROWS.forEach((row, idx) => {
-          if(row.kind === 'spacer'){
-            parts.push(`<tr class="tic-spacer-row"><td colspan="${TOTAL_COLUMNS_COUNT}"></td></tr>`);
-            return;
-          }
-
-          const baseKey = row.code ? row.code.replace(/[^0-9A-Za-z]/g,'_') : row.group + '_' + row.kind + '_' + idx;
-          const monthCells = buildMonthCells(baseKey);
-          const totalId = `tic-${baseKey}-total`;
-
-          if(row.kind === 'normal'){
-            const accId = `tic-cta-${baseKey}`;
-            const descId = `tic-desc-${baseKey}`;
-            parts.push(`
-              <tr data-tic-kind="normal" data-tic-group="${row.group}">
-                <td class="tic-account-col"><span id="${accId}">${row.code}</span></td>
-                <td class="tic-desc-col"><span id="${descId}">${row.label}</span></td>
-                ${monthCells}
-                <td><span id="${totalId}">${dash}</span></td>
-              </tr>
-            `);
-            return;
-          }
-
-          if(row.kind === 'total'){
-            const descId = `tic-label-${baseKey}`;
-            const rowKind = 'total';
-            parts.push(`
-              <tr data-tic-kind="${rowKind}" data-tic-group="${row.group}">
-                <td class="tic-account-col"><span id="tic-empty-${baseKey}"></span></td>
-                <td class="tic-desc-col"><span id="${descId}">${row.label}</span></td>
-                ${monthCells}
-                <td><span id="${totalId}">${dash}</span></td>
-              </tr>
-            `);
-            return;
-          }
-
-          if(row.kind === 'resultado-final'){
-            const descId = `tic-label-${baseKey}`;
-            const rowKind = 'resultado-final';
-            parts.push(`
-              <tr data-tic-kind="${rowKind}" data-tic-group="${row.group}">
-                <td class="tic-account-col"><span id="tic-empty-${baseKey}"></span></td>
-                <td class="tic-desc-col"><span id="${descId}">${row.label}</span></td>
-                ${monthCells}
-                <td><span id="${totalId}">${dash}</span></td>
-              </tr>
-            `);
-            return;
-          }
-        });
-
-        els.body.innerHTML = parts.join('');
-      }
-
-      function applyToggle(ocultar){
-        document.body.classList.toggle('tic-ocultar-cuentas', !!ocultar);
-        els.toggleAccounts.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
-        els.toggleAccounts.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
-      }
-
-      // Eventos
-      els.yearSelect.addEventListener('change', () => {
-        renderHead();
-        tickStatus();
-      });
-
-      els.toggleAccounts.addEventListener('click', () => {
-        const ocultar = !document.body.classList.contains('tic-ocultar-cuentas');
-        applyToggle(ocultar);
-      });
-
-      // Primera pinta
-      renderHead();
-      renderBody();
-      applyToggle(false);
-    })();
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/VPE.html
+++ b/vistas/VPE.html
@@ -1,116 +1,233 @@
 <!DOCTYPE html>
 <html lang="es">
+
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>VPE</title>
+  <title>VPE - Presupuestos</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="css/estilos.css" />
   <style>
     :root {
-       --color-primary: #2f5496;
+      --color-primary: #2f5496;
       --color-secondary: #8497b0;
       --color-background: #f2f2f2;
       --color-text: #2f5496;
-      --bs-primary: #2f5496;
-      --bs-primary-rgb: 47, 84, 150;
-      --bs-success: #2f5496;
-      --bs-success-rgb: 47, 84, 150;
-      --bs-success-bg-subtle: rgba(47, 84, 150, 0.16);
-      --bs-success-border-subtle: rgba(47, 84, 150, 0.35);
     }
 
     body {
-      background: var(--color-background);
-      font-family: 'Manrope', 'Segoe UI', Tahoma, sans-serif;
+      background-color: var(--color-background);
+      font-family: 'Manrope', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       color: var(--color-text);
       min-height: 100vh;
-      padding-top: 60px;
+      padding-top: 70px;
     }
 
     .header-card {
       background: var(--color-primary);
-      color: #fff;
-      border-radius: 18px;
+      border-radius: 16px;
       border: 1px solid rgba(47, 84, 150, 0.1);
-      box-shadow: 0 18px 42px rgba(47, 84, 150, 0.18);
+      color: #fff;
     }
 
-    .module-card {
-      border-radius: 20px;
-      border: 1px solid rgba(47, 84, 150, 0.08);
-      box-shadow: 0 22px 48px rgba(47, 84, 150, 0.16);
+    .table-card,
+    .workflow-card {
       background: #fff;
+      border-radius: 16px;
+      border: 1px solid rgba(47, 84, 150, 0.1);
+      overflow: hidden;
     }
 
-    .module-card .card-body {
-      padding: clamp(1.5rem, 2vw, 2.5rem);
+    .table thead {
+      background-color: #d9d9d9;
     }
 
-    .pill-accent {
-      background: rgba(255, 255, 255, 0.18);
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      padding: 0.35rem 0.9rem;
-      border-radius: 999px;
-      font-weight: 700;
-      letter-spacing: 0.08em;
-    }
-
-    .module-grid {
-      min-height: 180px;
-    }
-
-    .module-card article {
+    .table thead th {
       border: none;
-      border-radius: 18px;
-      background: linear-gradient(145deg, #ffffff 0%, #f2f2f2 100%);
+      font-weight: 600;
+      color: #2f5496;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.06em;
+      padding-top: 1rem;
+      padding-bottom: 1rem;
     }
 
-    .module-card .card h3 {
-      color: var(--color-primary);
+    .table tbody tr:hover {
+      background-color: rgba(47, 84, 150, 0.05);
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid #d9d9d9;
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+
+    .account-column {
+      text-align: left;
+      font-family: 'Courier New', monospace;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .account-column-header {
+      text-align: left;
+      white-space: nowrap;
+    }
+
+    body.ocultar-cuentas .account-column,
+    body.ocultar-cuentas .account-column-header {
+      display: none;
+    }
+
+    .workflow-card .card-header {
+      background: rgba(47, 84, 150, 0.08);
       font-weight: 700;
+      color: var(--color-primary);
+    }
+
+    .workflow-card .list-group-item {
+      border: none;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      font-size: 0.9rem;
+    }
+
+    .workflow-card .list-group-item:last-child {
+      border-bottom: none;
     }
   </style>
 </head>
-<body>
+
+<body data-modulo="VPE" data-modulo-alias="VPE">
   <div class="container py-4 py-lg-5">
     <div class="row mb-4">
       <div class="col-12">
-        <div class="card header-card">
-          <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
-            <div>
-              <h1 class="h3 fw-bold mb-1">VPE</h1>
-              <p class="mb-0">Vinculación con el sector público y posicionamiento estratégico.</p>
+        <div class="card header-card fade-in">
+          <div class="card-body text-center text-lg-start">
+            <div class="d-flex flex-column flex-lg-row align-items-center justify-content-between gap-3">
+              <div>
+                <h1 class="fw-bold display-6 mb-2">VPE</h1>
+                <p class="mb-0 text-white-50">Planeación financiera de la vicepresidencia ejecutiva.</p>
+                <p class="mb-0 text-white-50">Ejercicio <span class="anio text-light" id="yearLabel"></span> · <span
+                    id="empresaLabel">—</span></p>
+              </div>
             </div>
-            <span class="pill-accent">Datos dinámicos</span>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="row g-4">
+    <div class="row mb-4">
       <div class="col-12">
-        <div class="card module-card">
-          <div class="card-body">
-            <div id="moduleLoader" class="d-flex align-items-center gap-2 mb-3 visually-hidden">
-              <div class="spinner-border text-success" role="status" aria-hidden="true"></div>
-              <span class="fw-semibold text-success">Actualizando información…</span>
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-outline" id="toggleAccountColumnBtn">
+                  <i class="bi bi-eye-slash"></i>
+                  <span>Ocultar cuentas</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-outline d-none" id="loadBudgetBtn">
+                  <i class="bi bi-upload"></i>
+                  <span>Cargar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="reviewBudgetBtn">
+                  <i class="bi bi-clipboard-check"></i>
+                  <span>Revisar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="authorizeBudgetBtn">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-primary d-none" id="saveBudgetBtn">
+                  <i class="bi bi-floppy"></i>
+                  <span>Guardar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-primario d-none" id="approveBudgetBtn">
+                  <i class="bi bi-check-circle"></i>
+                  <span>Aprobar</span>
+                </button>
+              </div>
             </div>
-            <div id="moduleStatus" class="alert alert-info">Preparando información…</div>
-            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 module-grid" id="moduleDynamicList"></div>
+            <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-12">
+        <input type="text" id="accountSearch" class="search-input" placeholder="Buscar cuenta o descripción..." />
+      </div>
+    </div>
+
+    <div class="row g-4 align-items-start">
+      <div class="col-12 col-xl-9">
+        <div class="table-card fade-in">
+          <div id="presupuestoStatus" class="alert alert-info visually-hidden" role="status"></div>
+          <div class="table-responsive">
+            <table class="table align-middle mb-0" id="tablaPresupuestos">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-start account-column-header">Cuenta</th>
+                  <th scope="col" class="text-start">Descripción</th>
+                  <th scope="col" class="text-end">Ene</th>
+                  <th scope="col" class="text-end">Feb</th>
+                  <th scope="col" class="text-end">Mar</th>
+                  <th scope="col" class="text-end">Abr</th>
+                  <th scope="col" class="text-end">May</th>
+                  <th scope="col" class="text-end">Jun</th>
+                  <th scope="col" class="text-end">Jul</th>
+                  <th scope="col" class="text-end">Ago</th>
+                  <th scope="col" class="text-end">Sep</th>
+                  <th scope="col" class="text-end">Oct</th>
+                  <th scope="col" class="text-end">Nov</th>
+                  <th scope="col" class="text-end">Dic</th>
+                  <th scope="col" class="text-end">Anual <span class="anio" id="yearColumn"></span></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-3">
+        <div class="card workflow-card h-100">
+          <div class="card-header">Flujo de autorización</div>
+          <ul class="list-group list-group-flush" id="workflowHistory"></ul>
         </div>
       </div>
     </div>
   </div>
 
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="actionToast" class="toast align-items-center text-bg-success border-0" role="alert"
+      aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+          aria-label="Cerrar"></button>
+      </div>
+    </div>
+  </div>
+
   <script src="js/sesion.js"></script>
-  <script src="js/modulo-generico.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      initGenericModule('vpe');
-    });
-  </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/presupuesto-vista.js"></script>
+  <script>
+    initVistaPresupuesto();
+  </script>
 </body>
+
 </html>

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -167,6 +167,12 @@
       gap: 1rem;
     }
 
+    .top-bar-right {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
     .sidebar-toggle-btn {
       border: none;
       background: rgba(47, 84, 150, 0.15);
@@ -212,6 +218,98 @@
 
     .company-selector select {
       min-width: 200px;
+    }
+
+    .notification-bell {
+      position: relative;
+    }
+
+    .notification-bell__button {
+      border: none;
+      background: rgba(47, 84, 150, 0.1);
+      color: var(--color-primario);
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    .notification-bell__button:hover,
+    .notification-bell__button:focus {
+      background: rgba(47, 84, 150, 0.2);
+      color: #fff;
+    }
+
+    .notification-bell__badge {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      background: #dc3545;
+      color: #fff;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      padding: 0 0.35rem;
+      font-weight: 700;
+    }
+
+    .notification-panel {
+      position: absolute;
+      top: calc(100% + 0.5rem);
+      right: 0;
+      width: min(320px, 80vw);
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 15px 40px rgba(0, 0, 0, 0.15);
+      border: 1px solid rgba(47, 84, 150, 0.15);
+      padding: 1rem;
+      z-index: 1200;
+    }
+
+    .notification-panel__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.75rem;
+    }
+
+    .notification-panel__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      max-height: 360px;
+      overflow-y: auto;
+    }
+
+    .notification-panel__item {
+      border: 1px solid rgba(47, 84, 150, 0.15);
+      border-radius: 12px;
+      padding: 0.65rem 0.75rem;
+      background: #fff;
+      display: flex;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .notification-panel__item--new {
+      border-color: var(--color-primario);
+      box-shadow: 0 12px 30px rgba(47, 84, 150, 0.15);
+    }
+
+    .notification-panel__title {
+      font-weight: 700;
+      margin-bottom: 0.25rem;
+      color: var(--color-primario);
+    }
+
+    .notification-panel__message {
+      font-size: 0.9rem;
+      color: rgba(47, 84, 150, 0.8);
     }
 
     .top-bar .badge {
@@ -380,6 +478,11 @@
       .top-bar-left {
         justify-content: space-between;
         width: 100%;
+      }
+
+      .top-bar-right {
+        width: 100%;
+        justify-content: space-between;
       }
 
       .company-selector {

--- a/vistas/css/estilos.css
+++ b/vistas/css/estilos.css
@@ -1,7 +1,12 @@
 :root {
   --btn-primario-bg: #2f5496;
-  --btn-primario-bg-hover: #8497b0;
+  --btn-primario-bg-hover: #203763;
   --btn-primario-text: #ffffff;
+  --btn-secundario-bg: #f4f6fb;
+  --btn-secundario-border: #d7def0;
+  --btn-alerta-bg: #fef4e6;
+  --btn-alerta-border: #f3c994;
+  --texto-acento: #2f5496;
 }
 
 .btn-primario {
@@ -37,4 +42,95 @@
   font-weight: 700;
   color: var(--btn-primario-bg, #2f5496);
   font-variant-numeric: tabular-nums;
+}
+
+.btn-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.45rem 0.95rem;
+  line-height: 1.2;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-chip i {
+  font-size: 1rem;
+}
+
+.btn-chip:hover,
+.btn-chip:focus {
+  transform: translateY(-1px);
+}
+
+.btn-chip-primary {
+  background-color: var(--btn-primario-bg);
+  border-color: var(--btn-primario-bg);
+  color: #fff;
+}
+
+.btn-chip-outline {
+  background-color: var(--btn-secundario-bg);
+  border: 1px solid var(--btn-secundario-border);
+  color: var(--texto-acento);
+}
+
+.btn-chip-warning {
+  background-color: var(--btn-alerta-bg);
+  border: 1px solid var(--btn-alerta-border);
+  color: #8d5a12;
+}
+
+.btn-chip-success {
+  background: rgba(41, 196, 142, 0.12);
+  border: 1px solid rgba(41, 196, 142, 0.45);
+  color: #11805d;
+}
+
+.btn-chip-ghost {
+  background: transparent;
+  border: 1px dashed var(--btn-secundario-border);
+  color: var(--texto-acento);
+}
+
+.workflow-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 700;
+  background: rgba(47, 84, 150, 0.1);
+  color: var(--texto-acento);
+}
+
+.workflow-badge[data-estado='revisado'] {
+  background: rgba(255, 193, 7, 0.15);
+  color: #7c5205;
+}
+
+.workflow-badge[data-estado='autorizado'],
+.workflow-badge[data-estado='aprobado'] {
+  background: rgba(25, 135, 84, 0.15);
+  color: #0f5132;
+}
+
+.workflow-meta {
+  font-size: 0.8rem;
+  color: rgba(47, 84, 150, 0.7);
+}
+
+.toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.toolbar-actions .btn {
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.35rem 0.9rem;
 }

--- a/vistas/js/presupuesto-vista.js
+++ b/vistas/js/presupuesto-vista.js
@@ -1,0 +1,548 @@
+(() => {
+  const API_BASE = 'http://localhost:3000/api';
+  const MESES = [
+    { etiqueta: 'Ene', clave: 'ene' },
+    { etiqueta: 'Feb', clave: 'feb' },
+    { etiqueta: 'Mar', clave: 'mar' },
+    { etiqueta: 'Abr', clave: 'abr' },
+    { etiqueta: 'May', clave: 'may' },
+    { etiqueta: 'Jun', clave: 'jun' },
+    { etiqueta: 'Jul', clave: 'jul' },
+    { etiqueta: 'Ago', clave: 'ago' },
+    { etiqueta: 'Sep', clave: 'sep' },
+    { etiqueta: 'Oct', clave: 'oct' },
+    { etiqueta: 'Nov', clave: 'nov' },
+    { etiqueta: 'Dic', clave: 'dic' }
+  ];
+
+  const WORKFLOW_ETIQUETAS = {
+    'sin-cargar': {
+      texto: 'Sin cargar',
+      descripcion: 'Carga el presupuesto estimado para comenzar.'
+    },
+    borrador: {
+      texto: 'Cargado',
+      descripcion: 'Pendiente de revisión.'
+    },
+    revisado: {
+      texto: 'Revisado',
+      descripcion: 'Listo para autorizar.'
+    },
+    autorizado: {
+      texto: 'Autorizado',
+      descripcion: 'Disponible para guardar el CSV oficial.'
+    },
+    aprobado: {
+      texto: 'Aprobado',
+      descripcion: 'Presupuesto final aprobado.'
+    }
+  };
+
+  const TRANSICIONES = {
+    cargar: {
+      destino: 'borrador',
+      permiso: 'Cargar y guardar',
+      habilita: (estado) => ['sin-cargar', 'borrador'].includes(estado)
+    },
+    revisar: {
+      destino: 'revisado',
+      permiso: 'Revisar',
+      habilita: (estado) => estado === 'borrador'
+    },
+    autorizar: {
+      destino: 'autorizado',
+      permiso: 'Aprobar',
+      habilita: (estado) => estado === 'revisado'
+    },
+    aprobar: {
+      destino: 'aprobado',
+      permiso: 'Aprobar',
+      habilita: (estado) => estado === 'autorizado'
+    }
+  };
+
+  const ACCOUNT_COLUMN_STORAGE_KEY = 'presupuestos_ocultar_cuentas';
+
+  const formatoNumero = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  const obtenerConfigDesdeDataset = () => {
+    const dataset = document.body?.dataset || {};
+    return {
+      modulo: dataset.modulo || 'Presupuestos',
+      titulo: dataset.moduloAlias || dataset.modulo || 'Presupuestos'
+    };
+  };
+
+  const actualizarTexto = (elemento, texto) => {
+    if (!elemento) return;
+    elemento.textContent = texto;
+  };
+
+  const obtenerPermisosActuales = (sesion, modulo) => {
+    const empresa = Sesion.obtenerEmpresaActiva(sesion);
+    if (!empresa) {
+      return { empresa: null, permisos: null };
+    }
+    const permisos = Sesion.obtenerPermisosModulo(modulo, empresa.id, sesion) || {};
+    return { empresa, permisos };
+  };
+
+  const initVistaPresupuesto = (config = {}) => {
+    const sesion = Sesion.requerirSesion();
+    if (!sesion) {
+      return;
+    }
+
+    const opciones = { ...obtenerConfigDesdeDataset(), ...config };
+    const anio = new Date().getFullYear();
+
+    const elementos = {
+      tablaBody: document.querySelector('#tablaPresupuestos tbody'),
+      tabla: document.getElementById('tablaPresupuestos'),
+      accountSearchInput: document.getElementById('accountSearch'),
+      saveBudgetBtn: document.getElementById('saveBudgetBtn'),
+      loadBudgetBtn: document.getElementById('loadBudgetBtn'),
+      reviewBudgetBtn: document.getElementById('reviewBudgetBtn'),
+      authorizeBudgetBtn: document.getElementById('authorizeBudgetBtn'),
+      approveBudgetBtn: document.getElementById('approveBudgetBtn'),
+      toggleAccountColumnBtn: document.getElementById('toggleAccountColumnBtn'),
+      budgetFileInput: document.getElementById('budgetFileInput'),
+      toastElement: document.getElementById('actionToast'),
+      toastBody: document.getElementById('actionToastBody'),
+      presupuestoStatus: document.getElementById('presupuestoStatus'),
+      yearLabel: document.getElementById('yearLabel'),
+      yearColumn: document.getElementById('yearColumn'),
+      empresaLabel: document.getElementById('empresaLabel'),
+      workflowBadge: document.getElementById('workflowBadge'),
+      workflowMeta: document.getElementById('workflowMeta'),
+      workflowHistory: document.getElementById('workflowHistory')
+    };
+
+    const toastInstance = window.bootstrap?.Toast.getOrCreateInstance(elementos.toastElement, { delay: 3000 });
+
+    if (elementos.yearLabel) elementos.yearLabel.textContent = anio;
+    if (elementos.yearColumn) elementos.yearColumn.textContent = anio;
+
+    const estado = {
+      cuentas: [],
+      filtro: '',
+      workflow: {
+        estado: 'sin-cargar',
+        actualizadoPor: '',
+        actualizadoEn: ''
+      }
+    };
+
+    const showToast = (mensaje, clase = 'text-bg-success') => {
+      if (!elementos.toastElement || !toastInstance || !elementos.toastBody) return;
+      elementos.toastElement.className = `toast align-items-center ${clase} border-0`;
+      elementos.toastBody.textContent = mensaje;
+      toastInstance.show();
+    };
+
+    const mostrarEstado = (mensaje, tipo = 'info') => {
+      if (!elementos.presupuestoStatus) return;
+      elementos.presupuestoStatus.textContent = mensaje;
+      elementos.presupuestoStatus.className = `alert alert-${tipo} mb-3`;
+    };
+
+    const limpiarEstado = () => {
+      if (!elementos.presupuestoStatus) return;
+      elementos.presupuestoStatus.textContent = '';
+      elementos.presupuestoStatus.className = 'alert alert-info visually-hidden';
+    };
+
+    const actualizarEncabezadoEmpresa = (empresa = null) => {
+      const etiqueta = empresa?.etiqueta || empresa?.nombre || '—';
+      actualizarTexto(elementos.empresaLabel, etiqueta);
+    };
+
+    const actualizarBadgeWorkflow = () => {
+      if (!elementos.workflowBadge) return;
+      const info = WORKFLOW_ETIQUETAS[estado.workflow.estado] || WORKFLOW_ETIQUETAS['sin-cargar'];
+      elementos.workflowBadge.dataset.estado = estado.workflow.estado;
+      elementos.workflowBadge.textContent = info.texto;
+      if (elementos.workflowMeta) {
+        const descripcion = info.descripcion || '';
+        const fecha = estado.workflow.actualizadoEn
+          ? new Date(estado.workflow.actualizadoEn).toLocaleString('es-MX')
+          : '';
+        const detalle = [descripcion, fecha ? `Último cambio: ${fecha}` : '']
+          .filter(Boolean)
+          .join(' · ');
+        elementos.workflowMeta.textContent = detalle;
+      }
+    };
+
+    const renderizarHistorial = () => {
+      if (!elementos.workflowHistory) return;
+      const items = (estado.workflow.historial || []).map((registro) => {
+        const fecha = registro.fecha ? new Date(registro.fecha).toLocaleString('es-MX') : '';
+        return `
+          <li class="list-group-item d-flex justify-content-between align-items-start">
+            <div>
+              <strong>${registro.estado}</strong>
+              <div class="small text-muted">${registro.usuario || '—'}</div>
+            </div>
+            <small class="text-muted">${fecha}</small>
+          </li>`;
+      });
+      elementos.workflowHistory.innerHTML = items.join('') || '<li class="list-group-item text-muted">Aún no hay movimientos.</li>';
+    };
+
+    const renderizarTabla = () => {
+      if (!elementos.tablaBody) {
+        return;
+      }
+      elementos.tablaBody.innerHTML = '';
+      const filtro = estado.filtro;
+      const filtradas = !filtro
+        ? estado.cuentas
+        : estado.cuentas.filter((cuenta) => {
+            const cadena = `${cuenta.numCta} ${cuenta.descripcion}`.toLowerCase();
+            return cadena.includes(filtro);
+          });
+
+      filtradas.forEach((cuenta) => {
+        const fila = document.createElement('tr');
+        const celdaCuenta = document.createElement('td');
+        celdaCuenta.textContent = cuenta.numCta || '—';
+        celdaCuenta.className = 'account-column';
+        fila.appendChild(celdaCuenta);
+
+        const celdaNombre = document.createElement('td');
+        celdaNombre.textContent = cuenta.descripcion || '—';
+        fila.appendChild(celdaNombre);
+
+        MESES.forEach(({ clave }) => {
+          const celda = document.createElement('td');
+          celda.className = 'budget-value text-end';
+          celda.textContent = formatoNumero.format(cuenta[clave] ?? 0);
+          fila.appendChild(celda);
+        });
+
+        const celdaAnual = document.createElement('td');
+        celdaAnual.className = 'budget-value text-end';
+        celdaAnual.textContent = formatoNumero.format(cuenta.anual ?? 0);
+        fila.appendChild(celdaAnual);
+        elementos.tablaBody.appendChild(fila);
+      });
+    };
+
+    const aplicarVisibilidadCuentas = (ocultar) => {
+      document.body.classList.toggle('ocultar-cuentas', Boolean(ocultar));
+      if (elementos.toggleAccountColumnBtn) {
+        const icono = elementos.toggleAccountColumnBtn.querySelector('i');
+        const texto = elementos.toggleAccountColumnBtn.querySelector('span');
+        if (icono) {
+          icono.className = ocultar ? 'bi bi-eye' : 'bi bi-eye-slash';
+        }
+        if (texto) {
+          texto.textContent = ocultar ? 'Mostrar cuentas' : 'Ocultar cuentas';
+        }
+        elementos.toggleAccountColumnBtn.setAttribute('aria-pressed', ocultar ? 'true' : 'false');
+      }
+    };
+
+    const inicializarControlCuentas = () => {
+      const esAdminGlobal = Sesion.esAdminGlobal(sesion);
+      const preferencia = localStorage.getItem(ACCOUNT_COLUMN_STORAGE_KEY);
+      const debeOcultar = preferencia ? preferencia === '1' : !esAdminGlobal;
+      aplicarVisibilidadCuentas(debeOcultar);
+      if (!elementos.toggleAccountColumnBtn) {
+        return;
+      }
+      if (!esAdminGlobal) {
+        elementos.toggleAccountColumnBtn.classList.add('d-none');
+        elementos.toggleAccountColumnBtn.setAttribute('disabled', 'true');
+        return;
+      }
+      elementos.toggleAccountColumnBtn.classList.remove('d-none');
+      elementos.toggleAccountColumnBtn.addEventListener('click', () => {
+        const ocultar = !document.body.classList.contains('ocultar-cuentas');
+        localStorage.setItem(ACCOUNT_COLUMN_STORAGE_KEY, ocultar ? '1' : '0');
+        aplicarVisibilidadCuentas(ocultar);
+      });
+    };
+
+    const cargarPresupuestos = async () => {
+      const { empresa } = obtenerPermisosActuales(sesion, opciones.modulo);
+      if (!empresa) {
+        actualizarEncabezadoEmpresa(null);
+        estado.cuentas = [];
+        renderizarTabla();
+        mostrarEstado('Selecciona una empresa desde el panel principal para visualizar sus presupuestos.', 'warning');
+        return;
+      }
+      actualizarEncabezadoEmpresa(empresa);
+      mostrarEstado('Cargando presupuestos…', 'info');
+      try {
+        const respuesta = await fetch(`${API_BASE}/presupuestos?anio=${anio}`, {
+          headers: Sesion.headersAutenticacion()
+        });
+        const datos = await respuesta.json();
+        if (!respuesta.ok) {
+          throw new Error(datos.mensaje || 'No fue posible obtener los presupuestos.');
+        }
+        if (datos.empresa) {
+          actualizarEncabezadoEmpresa(datos.empresa);
+        }
+        const normalizarNumero = (valor) => {
+          const numerico = Number(valor);
+          return Number.isFinite(numerico) ? numerico : 0;
+        };
+        const obtenerNaturaleza = (valor) => (valor || '').toString().trim().toUpperCase();
+        const esAcreedora = (naturaleza) => ['A', 'C'].includes(naturaleza);
+
+        estado.cuentas = Array.isArray(datos.cuentas)
+          ? datos.cuentas.map((cuenta) => {
+              const naturaleza = obtenerNaturaleza(cuenta.naturaleza || cuenta.NATURALEZA);
+              const factor = esAcreedora(naturaleza) ? -1 : 1;
+              const normalizada = {
+                numCta: cuenta.numCta || cuenta.num_cta || cuenta.CUENTA || '',
+                descripcion: cuenta.descripcion || cuenta.nombre || cuenta.DESCRIPCION || '',
+                naturaleza
+              };
+              MESES.forEach(({ clave }) => {
+                normalizada[clave] = normalizarNumero(cuenta[clave]) * factor;
+              });
+              normalizada.anual = normalizarNumero(cuenta.anual) * factor;
+              return normalizada;
+            })
+          : [];
+        estado.filtro = '';
+        if (elementos.accountSearchInput) {
+          elementos.accountSearchInput.value = '';
+        }
+        limpiarEstado();
+        renderizarTabla();
+      } catch (error) {
+        estado.cuentas = [];
+        renderizarTabla();
+        mostrarEstado(error.message || 'Ocurrió un problema al cargar la información.', 'danger');
+      }
+    };
+
+    const convertirTablaACsv = () => {
+      const encabezados = ['Cuenta', 'Descripción', ...MESES.map((mes) => mes.etiqueta), `Anual ${anio}`];
+      const filas = estado.cuentas.map((cuenta) => {
+        const periodos = MESES.map(({ clave }) => cuenta[clave] ?? 0);
+        const anual = cuenta.anual ?? 0;
+        return [
+          cuenta.numCta || '',
+          cuenta.descripcion || '',
+          ...periodos.map((valor) => Number(valor).toFixed(2)),
+          Number(anual).toFixed(2)
+        ];
+      });
+      const csv = [encabezados.join(',')];
+      filas.forEach((fila) => csv.push(fila.join(',')));
+      return csv.join('\n');
+    };
+
+    const actualizarDesdeCsv = (texto) => {
+      const lineas = texto.split(/\r?\n/).filter((linea) => linea.trim().length > 0);
+      if (lineas.length <= 1) {
+        return false;
+      }
+      const mapaCuentas = new Map(estado.cuentas.map((cuenta) => [cuenta.numCta, cuenta]));
+      for (let i = 1; i < lineas.length; i += 1) {
+        const columnas = lineas[i].split(',');
+        if (columnas.length < MESES.length + 2) {
+          continue;
+        }
+        const cuenta = mapaCuentas.get(columnas[0].trim());
+        if (!cuenta) {
+          continue;
+        }
+        MESES.forEach((mes, indice) => {
+          const columna = columnas[indice + 2] || '0';
+          const numerico = Number(columna.replace(/[^0-9+\-.,]/g, '').replace(',', '.'));
+          cuenta[mes.clave] = Number.isFinite(numerico) ? numerico : 0;
+        });
+        cuenta.anual = MESES.reduce((acumulado, mes) => acumulado + (cuenta[mes.clave] ?? 0), 0);
+      }
+      renderizarTabla();
+      return true;
+    };
+
+    const obtenerWorkflow = async () => {
+      try {
+        const params = new URLSearchParams({ anio: String(anio), modulo: opciones.modulo });
+        const respuesta = await fetch(`${API_BASE}/presupuestos/estado?${params.toString()}`, {
+          headers: Sesion.headersAutenticacion()
+        });
+        const datos = await respuesta.json();
+        if (!respuesta.ok) {
+          throw new Error(datos.mensaje || 'No fue posible obtener el flujo de autorización.');
+        }
+        estado.workflow = {
+          estado: datos.estado || 'sin-cargar',
+          actualizadoEn: datos.actualizadoEn || '',
+          actualizadoPor: datos.actualizadoPor || '',
+          historial: datos.historial || []
+        };
+        actualizarBadgeWorkflow();
+        renderizarHistorial();
+        actualizarDisponibilidadAcciones();
+      } catch (error) {
+        console.warn('No fue posible obtener el estado del presupuesto', error);
+        showToast(error.message || 'No fue posible consultar el flujo de autorización.', 'text-bg-warning');
+      }
+    };
+
+    const ejecutarAccionWorkflow = async (accion) => {
+      const transicion = TRANSICIONES[accion];
+      if (!transicion) {
+        return;
+      }
+      try {
+        const respuesta = await fetch(`${API_BASE}/presupuestos/estado`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...Sesion.headersAutenticacion()
+          },
+          body: JSON.stringify({
+            modulo: opciones.modulo,
+            anio,
+            accion
+          })
+        });
+        const datos = await respuesta.json();
+        if (!respuesta.ok) {
+          throw new Error(datos.mensaje || 'No fue posible actualizar el estado.');
+        }
+        estado.workflow = {
+          estado: datos.estado,
+          actualizadoEn: datos.actualizadoEn,
+          actualizadoPor: datos.actualizadoPor,
+          historial: datos.historial || []
+        };
+        actualizarBadgeWorkflow();
+        renderizarHistorial();
+        actualizarDisponibilidadAcciones();
+        showToast(datos.mensaje || 'Acción registrada correctamente.');
+      } catch (error) {
+        showToast(error.message || 'No fue posible aplicar la acción solicitada.', 'text-bg-danger');
+      }
+    };
+
+    const actualizarDisponibilidadAcciones = () => {
+      const { permisos } = obtenerPermisosActuales(sesion, opciones.modulo);
+      const estadoActual = estado.workflow.estado;
+      const puedeCargar = Boolean(permisos?.['Cargar y guardar']);
+      const puedeRevisar = Boolean(permisos?.Revisar);
+      const puedeAprobar = Boolean(permisos?.Aprobar);
+
+      if (elementos.loadBudgetBtn) {
+        elementos.loadBudgetBtn.classList.toggle('d-none', !puedeCargar);
+        elementos.loadBudgetBtn.disabled = !puedeCargar || !TRANSICIONES.cargar.habilita(estadoActual);
+      }
+      if (elementos.reviewBudgetBtn) {
+        elementos.reviewBudgetBtn.classList.toggle('d-none', !puedeRevisar);
+        elementos.reviewBudgetBtn.disabled = !puedeRevisar || !TRANSICIONES.revisar.habilita(estadoActual);
+      }
+      if (elementos.authorizeBudgetBtn) {
+        elementos.authorizeBudgetBtn.classList.toggle('d-none', !puedeAprobar);
+        elementos.authorizeBudgetBtn.disabled = !puedeAprobar || !TRANSICIONES.autorizar.habilita(estadoActual);
+      }
+      if (elementos.approveBudgetBtn) {
+        elementos.approveBudgetBtn.classList.toggle('d-none', !puedeAprobar);
+        elementos.approveBudgetBtn.disabled = !puedeAprobar || !TRANSICIONES.aprobar.habilita(estadoActual);
+      }
+      if (elementos.saveBudgetBtn) {
+        const habilitado = puedeCargar && ['autorizado', 'aprobado'].includes(estadoActual);
+        elementos.saveBudgetBtn.classList.toggle('d-none', !puedeCargar);
+        elementos.saveBudgetBtn.disabled = !habilitado;
+      }
+    };
+
+    if (elementos.accountSearchInput) {
+      elementos.accountSearchInput.addEventListener('input', (event) => {
+        estado.filtro = event.target.value.trim().toLowerCase();
+        renderizarTabla();
+      });
+    }
+
+    const nombreArchivoModulo = opciones.modulo.replace(/[^a-zA-Z0-9_-]+/g, '-');
+
+    if (elementos.saveBudgetBtn) {
+      elementos.saveBudgetBtn.addEventListener('click', () => {
+        const csvContent = convertirTablaACsv();
+        const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+        const downloadLink = document.createElement('a');
+        const url = URL.createObjectURL(blob);
+        downloadLink.href = url;
+        downloadLink.download = `presupuesto_${nombreArchivoModulo}_${anio}.csv`;
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+        URL.revokeObjectURL(url);
+        showToast('Presupuesto exportado correctamente.');
+      });
+    }
+
+    if (elementos.loadBudgetBtn && elementos.budgetFileInput) {
+      elementos.loadBudgetBtn.addEventListener('click', () => {
+        elementos.budgetFileInput.click();
+      });
+
+      elementos.budgetFileInput.addEventListener('change', (event) => {
+        const file = event.target.files?.[0];
+        if (!file) {
+          return;
+        }
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const exito = actualizarDesdeCsv(e.target?.result || '');
+          if (exito) {
+            showToast('Presupuesto cargado correctamente.', 'text-bg-info');
+            ejecutarAccionWorkflow('cargar');
+          } else {
+            showToast('El archivo seleccionado no contiene datos válidos.', 'text-bg-warning');
+          }
+        };
+        reader.onerror = () => {
+          showToast('No se pudo leer el archivo seleccionado.', 'text-bg-danger');
+        };
+        reader.readAsText(file);
+        event.target.value = '';
+      });
+    }
+
+    if (elementos.reviewBudgetBtn) {
+      elementos.reviewBudgetBtn.addEventListener('click', () => ejecutarAccionWorkflow('revisar'));
+    }
+
+    if (elementos.authorizeBudgetBtn) {
+      elementos.authorizeBudgetBtn.addEventListener('click', () => ejecutarAccionWorkflow('autorizar'));
+    }
+
+    if (elementos.approveBudgetBtn) {
+      elementos.approveBudgetBtn.addEventListener('click', () => ejecutarAccionWorkflow('aprobar'));
+    }
+
+    inicializarControlCuentas();
+    actualizarDisponibilidadAcciones();
+
+    const inicializarDatos = () => {
+      actualizarEncabezadoEmpresa();
+      cargarPresupuestos();
+      obtenerWorkflow();
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', inicializarDatos, { once: true });
+    } else {
+      inicializarDatos();
+    }
+
+    window.addEventListener(Sesion.EVENTO_EMPRESA, () => {
+      cargarPresupuestos();
+      obtenerWorkflow();
+    });
+  };
+
+  window.initVistaPresupuesto = initVistaPresupuesto;
+})();

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -250,7 +250,114 @@ const SidebarGroup = ({ group, modules, selectedModule, onSelect, open, onToggle
   );
 };
 
-const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout, empresaActiva, onChangeEmpresa }) => {
+const NotificationBell = ({ notifications = [], onRefresh, onMarkAsRead }) => {
+  const [open, setOpen] = useState(false);
+  const bellRef = React.useRef(null);
+  const unread = notifications.filter((item) => !item.leidaEn).length;
+
+  useEffect(() => {
+    const handleClick = (event) => {
+      if (!open) return;
+      if (bellRef.current && !bellRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const toggle = () => setOpen((prev) => !prev);
+  const marcarLeida = (id) => {
+    if (onMarkAsRead) {
+      onMarkAsRead(id);
+    }
+  };
+
+  const renderFecha = (valor) => {
+    if (!valor) return '';
+    try {
+      return new Date(valor).toLocaleString('es-MX');
+    } catch (e) {
+      return valor;
+    }
+  };
+
+  return (
+    <div className={`notification-bell${open ? ' notification-bell--open' : ''}`} ref={bellRef}>
+      <button
+        type="button"
+        className="notification-bell__button"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-label="Notificaciones"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="currentColor"
+          className="notification-bell__icon"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <path d="M8 16a2 2 0 0 0 1.985-1.75H6.015A2 2 0 0 0 8 16m6-6c0-3.071-1.639-5.64-4.5-6.32V3a1.5 1.5 0 0 0-3 0v.68C3.64 4.36 2 6.929 2 10v2l-1 1v1h14v-1l-1-1z" />
+        </svg>
+        {unread > 0 && <span className="notification-bell__badge">{unread}</span>}
+      </button>
+      {open && (
+        <div className="notification-panel" role="dialog" aria-label="Notificaciones recientes">
+          <div className="notification-panel__header">
+            <strong>Notificaciones</strong>
+            <button type="button" className="btn btn-link btn-sm p-0" onClick={onRefresh}>
+              Actualizar
+            </button>
+          </div>
+          <div className="notification-panel__body">
+            {notifications.length === 0 ? (
+              <p className="text-muted small mb-0">Sin notificaciones pendientes.</p>
+            ) : (
+              <ul className="notification-panel__list">
+                {notifications.map((item) => (
+                  <li
+                    key={item.id}
+                    className={`notification-panel__item${!item.leidaEn ? ' notification-panel__item--new' : ''}`}
+                  >
+                    <div>
+                      <p className="notification-panel__title mb-1">{item.titulo}</p>
+                      <p className="notification-panel__message mb-1">{item.mensaje}</p>
+                      <small className="text-muted">{renderFecha(item.creadaEn)}</small>
+                    </div>
+                    {!item.leidaEn && (
+                      <button
+                        type="button"
+                        className="btn btn-link btn-sm p-0"
+                        onClick={() => marcarLeida(item.id)}
+                      >
+                        Marcar como leída
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const DashboardLayout = ({
+  sesion,
+  selectedModuleId,
+  onSelectModule,
+  onLogout,
+  empresaActiva,
+  onChangeEmpresa,
+  notifications = [],
+  onRefreshNotifications,
+  onMarkNotification
+}) => {
   const puedeAdministrar = useMemo(() => Sesion.puedeAdministrarUsuarios(sesion), [sesion]);
 
   const empresasDisponibles = useMemo(() => Sesion.obtenerEmpresasDisponibles(sesion), [sesion]);
@@ -332,6 +439,16 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout, e
   };
 
   const layoutClassName = `app-layout${sidebarOculta ? ' sidebar-hidden' : ''}`;
+  const manejarActualizarNotificaciones = () => {
+    if (onRefreshNotifications) {
+      onRefreshNotifications();
+    }
+  };
+  const manejarMarcarNotificacion = (id) => {
+    if (onMarkNotification) {
+      onMarkNotification(id);
+    }
+  };
 
   return (
     <div className={layoutClassName}>
@@ -382,22 +499,29 @@ const DashboardLayout = ({ sesion, selectedModuleId, onSelectModule, onLogout, e
               )}
             </div>
           </div>
-          <div className="company-selector">
-            <label htmlFor="companyFilter" className="fw-semibold mb-0">Empresa:</label>
-            <select
-              id="companyFilter"
-              className="form-select form-select-sm"
-              value={empresaActualId}
-              onChange={manejarCambioEmpresa}
-              disabled={!puedeCambiarEmpresa || empresasDisponibles.length === 0}
-            >
-              {empresasDisponibles.length === 0 && <option value="">Sin empresas disponibles</option>}
-              {empresasDisponibles.map((empresa) => (
-                <option key={empresa.id} value={empresa.id}>
-                  {empresa.etiqueta ? `${empresa.etiqueta} — ${empresa.nombre}` : empresa.nombre}
-                </option>
-              ))}
-            </select>
+          <div className="top-bar-right d-flex align-items-center gap-3">
+            <NotificationBell
+              notifications={notifications}
+              onRefresh={manejarActualizarNotificaciones}
+              onMarkAsRead={manejarMarcarNotificacion}
+            />
+            <div className="company-selector">
+              <label htmlFor="companyFilter" className="fw-semibold mb-0">Empresa:</label>
+              <select
+                id="companyFilter"
+                className="form-select form-select-sm"
+                value={empresaActualId}
+                onChange={manejarCambioEmpresa}
+                disabled={!puedeCambiarEmpresa || empresasDisponibles.length === 0}
+              >
+                {empresasDisponibles.length === 0 && <option value="">Sin empresas disponibles</option>}
+                {empresasDisponibles.map((empresa) => (
+                  <option key={empresa.id} value={empresa.id}>
+                    {empresa.etiqueta ? `${empresa.etiqueta} — ${empresa.nombre}` : empresa.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
         </div>
         <div className="content-wrapper">
@@ -425,6 +549,7 @@ const App = () => {
   const [sesion, setSesion] = useState(() => Sesion.obtener());
   const [empresaActiva, setEmpresaActiva] = useState(() => Sesion.obtenerEmpresaActiva());
   const [moduloSeleccionado, setModuloSeleccionado] = useState(null);
+  const [notificaciones, setNotificaciones] = useState([]);
 
   const seleccionarModulo = useCallback((moduloId) => {
     setModuloSeleccionado(moduloId);
@@ -441,6 +566,7 @@ const App = () => {
     setSesion(null);
     setEmpresaActiva(null);
     setModuloSeleccionado(null);
+    setNotificaciones([]);
   };
 
   const manejarCambioEmpresa = useCallback((empresaId) => {
@@ -448,6 +574,53 @@ const App = () => {
     setEmpresaActiva(nuevaEmpresa);
     setSesion(Sesion.obtener());
   }, []);
+
+  const cargarNotificaciones = useCallback(async () => {
+    const sesionActual = Sesion.obtener();
+    if (!sesionActual) {
+      setNotificaciones([]);
+      return;
+    }
+    try {
+      const respuesta = await fetch(`${API_BASE}/notificaciones?limite=10`, {
+        headers: Sesion.headersAutenticacion()
+      });
+      const datos = await respuesta.json();
+      if (!respuesta.ok) {
+        throw new Error(datos.mensaje || 'No fue posible obtener las notificaciones.');
+      }
+      setNotificaciones(datos.notificaciones || []);
+    } catch (error) {
+      console.warn('Error al cargar notificaciones', error);
+    }
+  }, []);
+
+  const marcarNotificacion = useCallback(async (id) => {
+    if (!id) return;
+    try {
+      const respuesta = await fetch(`${API_BASE}/notificaciones/${id}/leida`, {
+        method: 'PATCH',
+        headers: Sesion.headersAutenticacion()
+      });
+      if (!respuesta.ok) {
+        const datos = await respuesta.json();
+        throw new Error(datos.mensaje || 'No fue posible actualizar la notificación.');
+      }
+      cargarNotificaciones();
+    } catch (error) {
+      console.warn('Error al marcar notificación como leída', error);
+    }
+  }, [cargarNotificaciones]);
+
+  useEffect(() => {
+    if (!sesion) {
+      setNotificaciones([]);
+      return;
+    }
+    cargarNotificaciones();
+    const intervalo = setInterval(cargarNotificaciones, 60000);
+    return () => clearInterval(intervalo);
+  }, [sesion, empresaActiva, cargarNotificaciones]);
 
   useEffect(() => {
     if (!sesion) {
@@ -475,6 +648,9 @@ const App = () => {
       onLogout={manejarLogout}
       empresaActiva={empresaActiva}
       onChangeEmpresa={manejarCambioEmpresa}
+      notifications={notificaciones}
+      onRefreshNotifications={cargarNotificaciones}
+      onMarkNotification={marcarNotificacion}
     />
   );
 };

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -185,6 +185,31 @@
     return headers;
   };
 
+  const obtenerPermisosModulo = (modulo, empresaId, sesionActual) => {
+    const sesionEvaluada = sesionActual || obtener();
+    const moduloNormalizado = (modulo || '').toString();
+    if (!sesionEvaluada || !sesionEvaluada.usuario || !moduloNormalizado) {
+      return null;
+    }
+    const empresa = empresaId || obtenerEmpresaActiva(sesionEvaluada)?.id;
+    if (!empresa) {
+      return null;
+    }
+    return sesionEvaluada.usuario?.permisosPorEmpresa?.[empresa]?.[moduloNormalizado] || null;
+  };
+
+  const tienePermisoModulo = (modulo, accion, empresaId, sesionActual) => {
+    const permisos = obtenerPermisosModulo(modulo, empresaId, sesionActual);
+    if (!permisos) {
+      return false;
+    }
+    const accionNormalizada = (accion || '').toString();
+    if (!accionNormalizada) {
+      return false;
+    }
+    return Boolean(permisos[accionNormalizada]);
+  };
+
   window.Sesion = {
     obtener,
     guardar,
@@ -199,6 +224,8 @@
     obtenerEmpresaActiva,
     establecerEmpresaActiva,
     puedeCambiarEmpresa,
-    EVENTO_EMPRESA
+    EVENTO_EMPRESA,
+    obtenerPermisosModulo,
+    tienePermisoModulo
   };
 })();


### PR DESCRIPTION
## Summary
- replace all divisional budget views with the new reusable layout and controller so every area shares the same controls, search, and workflow metadata
- add workflow state management endpoints, persistence, and notification delivery (UI toast list + optional SMTP) to enforce cargar → revisar → autorizar → aprobar transitions per module
- refresh the dashboard shell with a live notification bell and new styling while keeping permissions-aware buttons for creating, revising, authorizing, loading, and saving budgets

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691761f15d98832db75d95c1fca93a4e)