### PR TITLE
Fix resumen payload and account lookup filtering

### DIFF
--- a/src/routes/saldos.js
+++ b/src/routes/saldos.js
@@ -128,8 +128,12 @@ router.get('/cuentas', async (req, res) => {
 
   const { value, error } = Joi.object({
     empresaId: Joi.string().required(),
-    anio: Joi.number().integer().min(2000).max(2100).required()
-  }).validate(req.query, { abortEarly: false });
+    anio: Joi.number().integer().min(2000).max(2100).required(),
+    cuentas: Joi.alternatives().try(
+      Joi.array().items(Joi.string().trim()).min(1),
+      Joi.string().trim()
+    ).optional()
+  }).validate(req.query, { abortEarly: false, allowUnknown: true });
 
   if (error) {
     return res.status(400).json({ mensaje:'Parámetros inválidos', detalles: error.details.map(d=>d.message) });
@@ -149,9 +153,16 @@ router.get('/cuentas', async (req, res) => {
     if (!puede(mapa, empresa.id)) return res.status(403).json({ mensaje: 'Sin permiso para esta empresa.' });
   }
 
+  const cuentas = Array.isArray(value.cuentas)
+    ? value.cuentas
+    : (value.cuentas || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
   try {
-    const cuentas = await obtenerCuentasPorAnio(empresa.id, value.anio);
-    res.json({ cuentas });
+    const cuentasEncontradas = await obtenerCuentasPorAnio(empresa.id, value.anio, cuentas);
+    res.json({ cuentas: cuentasEncontradas });
   } catch (e) {
     console.error('Error /api/saldos/cuentas:', e);
     res.status(500).json({ mensaje: 'No fue posible obtener cuentas.' });

--- a/src/services/reportes/planeacionReportesEngine.js
+++ b/src/services/reportes/planeacionReportesEngine.js
@@ -1,164 +1,189 @@
 const path = require('path');
-const { obtenerSaldosPorCuentas } = require('../saldosService');
-const { cargarCsv, construirMapaCabeceras, buscarValor, resolverRuta, normalizarTexto } = require('../../utils/csvLoader');
-const { obtenerEmpresaPorId } = require('../../config/empresas');
+const fs = require('fs');
+const { obtenerDatosPlaneacion } = require('../planeacionCuentasService');
+const { MESES } = require('../saldosService');
 
 const DEFAULT_BASE_PATH = path.join(__dirname, '..', '..', '..', 'info IMPORTANTE');
+const DEFINICIONES_FILE = path.join(DEFAULT_BASE_PATH, 'CUENTAS SUMMARY y RESUMEN.json');
 
-const REPORT_CONFIG = {
-  SUMMARY: {
-    mapFiles: {
-      empresa1: 'SUMMARY Ciudad de México.csv',
-      empresa2: 'SUMMARY GUADALAJARA.csv',
-      empresa3: 'SUMMARY NOROESTE.csv',
-      empresa4: 'SUMMARY NOROESTE.csv'
-    },
-    aliases: {
-      CUENTA: ['CUENTA', 'Cuentas', 'CODIGO'],
-      DESCRIPCION: ['DESCRIPCION', 'Descripción', 'NOMBRE'],
-      SECCION: ['Sección', 'SECCION', 'CATEGORIA'],
-      CAPITULO: ['SECCIÓN MAYOR', 'CAPITULO', 'CHAPTER']
-    }
-  },
-  RESUMEN: {
-    mapFiles: {
-      empresa1: 'Resumen Guadalajara.csv', // Ajustar según corresponda si hay más archivos
-      empresa2: 'Resumen Guadalajara.csv',
-      empresa3: 'Resumen Guadalajara.csv',
-      empresa4: 'Resumen Guadalajara.csv'
-    },
-    aliases: {
-      CUENTA: ['CUENTA', 'CODIGO'],
-      DESCRIPCION: ['DESCRIPCION', 'NOMBRE'],
-      GRUPO: ['GRUPO', 'SECCION']
-    }
-  }
+const NORMALIZAR_CLAVE = (valor = '') => valor.toString().trim().toUpperCase();
+
+const cargarDefiniciones = () => {
+  const contenido = fs.readFileSync(DEFINICIONES_FILE, 'utf8');
+  return JSON.parse(contenido);
 };
 
-const normalizeKey = (valor) => {
-  if (valor == null) return '';
-  return valor.toString().trim().toUpperCase();
+const obtenerMesActualClave = () => {
+  const ahora = new Date();
+  const indice = Math.min(Math.max(ahora.getMonth(), 0), 11);
+  return MESES[indice]?.clave || 'dic';
 };
 
-const getReportPath = (tipo, empresaId) => {
-  const config = REPORT_CONFIG[tipo];
-  if (!config) return null;
-  const filename = config.mapFiles[empresaId];
-  if (!filename) return null;
-  return path.join(DEFAULT_BASE_PATH, filename);
-};
-
-const parseRows = (rows, aliases) => {
-  return rows.map((fila) => {
-    const headers = construirMapaCabeceras(fila);
-    const cuenta = buscarValor(fila, headers, aliases.CUENTA);
-    const descripcion = buscarValor(fila, headers, aliases.DESCRIPCION);
-    const seccion = buscarValor(fila, headers, aliases.SECCION) || buscarValor(fila, headers, aliases.GRUPO);
-    const capitulo = buscarValor(fila, headers, aliases.CAPITULO) || 'GENERAL';
-    
-    if (!cuenta) return null;
-
-    return {
-      cuenta: normalizeKey(cuenta),
-      descripcion: descripcion || '',
-      seccion: seccion || 'OTROS',
-      capitulo: capitulo
-    };
-  }).filter(Boolean);
-};
-
-const isExpense = (label) => {
-  const text = normalizeKey(label);
-  return text.includes('EXPENSE') || text.includes('GASTO') || text.includes('COSTO');
-};
-
-const buildHierarchy = (items, saldosMap) => {
-  const root = {
-    label: 'Reporte',
-    total: 0,
-    children: []
+const calcularTotales = (cuentas, claveMes, planeacionActual, planeacionPrevio) => {
+  const acumulados = {
+    actualMonth: 0,
+    planMonth: 0,
+    prevMonth: 0,
+    actualYTD: 0,
+    planYTD: 0,
+    prevYTD: 0
   };
 
-  const chapters = new Map();
-
-  items.forEach(item => {
-    const saldo = saldosMap.get(item.cuenta);
-    const valor = Number(saldo?.dic_acum ?? saldo?.anual ?? 0);
-    
-    // Agrupar por Capítulo (ej. CDMX Income)
-    if (!chapters.has(item.capitulo)) {
-      chapters.set(item.capitulo, {
-        label: item.capitulo,
-        total: 0,
-        children: [], // Secciones
-        sectionsMap: new Map(),
-        type: isExpense(item.capitulo) ? 'expense' : 'income'
-      });
+  const sumaHastaMes = (registro, incluirPrevio) => {
+    let total = 0;
+    for (const { clave } of MESES) {
+      total += Number(registro?.presupuesto?.[clave] ?? 0);
+      if (clave === claveMes) break;
     }
-    const chapterNode = chapters.get(item.capitulo);
+    if (incluirPrevio) return total;
+    return total;
+  };
 
-    // Agrupar por Sección (ej. Membership)
-    if (!chapterNode.sectionsMap.has(item.seccion)) {
-      chapterNode.sectionsMap.set(item.seccion, {
-        label: item.seccion,
-        total: 0,
-        cuentas: []
-      });
-      chapterNode.children.push(chapterNode.sectionsMap.get(item.seccion));
+  const claveAcum = `${claveMes}_acum`;
+
+  cuentas.forEach((cuenta) => {
+    const actual = planeacionActual.find((p) => p.cuenta === cuenta);
+    const previo = planeacionPrevio.find((p) => p.cuenta === cuenta);
+
+    acumulados.actualMonth += Number(actual?.real?.[claveMes] ?? 0);
+    acumulados.planMonth += Number(actual?.presupuesto?.[claveMes] ?? 0);
+    acumulados.prevMonth += Number(previo?.real?.[claveMes] ?? 0);
+
+    acumulados.actualYTD += Number(actual?.real?.[claveAcum] ?? 0);
+    acumulados.planYTD += sumaHastaMes(actual, false);
+    acumulados.prevYTD += Number(previo?.real?.[claveAcum] ?? 0);
+  });
+
+  return acumulados;
+};
+
+const construirNodoSeccion = ({ seccion, cuentas, definicion, claveMes, planeacionActual, planeacionPrevio }) => {
+  const totales = calcularTotales(cuentas, claveMes, planeacionActual, planeacionPrevio);
+  return {
+    label: seccion,
+    cuentas: cuentas.map((cuentaId) => {
+      const actual = planeacionActual.find((p) => p.cuenta === cuentaId) || {};
+      const previo = planeacionPrevio.find((p) => p.cuenta === cuentaId) || {};
+      return {
+        cuenta: cuentaId,
+        descripcion: definicion.get(cuentaId)?.descripcion || '',
+        actualMonth: Number(actual.real?.[claveMes] ?? 0),
+        planMonth: Number(actual.presupuesto?.[claveMes] ?? 0),
+        prevMonth: Number(previo.real?.[claveMes] ?? 0),
+        actualYTD: Number(actual.real?.[`${claveMes}_acum`] ?? 0),
+        planYTD: MESES.reduce((acc, { clave }) => {
+          if (acc.detener) return acc;
+          const nuevo = acc.total + Number(actual.presupuesto?.[clave] ?? 0);
+          if (clave === claveMes) return { total: nuevo, detener: true };
+          return { total: nuevo, detener: false };
+        }, { total: 0, detener: false }).total,
+        prevYTD: Number(previo.real?.[`${claveMes}_acum`] ?? 0)
+      };
+    }),
+    totalActualMonth: totales.actualMonth,
+    totalPlanMonth: totales.planMonth,
+    totalPrevMonth: totales.prevMonth,
+    totalActualYTD: totales.actualYTD,
+    totalPlanYTD: totales.planYTD,
+    totalPrevYTD: totales.prevYTD,
+    total: totales.actualYTD
+  };
+};
+
+const construirReporte = (definiciones, claveMes, planeacionActual, planeacionPrevio) => {
+  const definicionCuentas = new Map();
+  const agrupado = new Map();
+
+  definiciones.forEach((item) => {
+    const capitulo = item['SECCIÓN Principal'] || item['SECCION Principal'] || item['SECCION'] || item['SECCIÓN'];
+    const seccion = item['SECCION Secundaria'] || item['Sección'] || item['SECCION'];
+    const cuenta = NORMALIZAR_CLAVE(item.CUENTA);
+    if (!capitulo || !seccion || !cuenta) return;
+
+    definicionCuentas.set(cuenta, { descripcion: item.NOMBRE || '' });
+    if (!agrupado.has(capitulo)) {
+      agrupado.set(capitulo, new Map());
     }
-    const sectionNode = chapterNode.sectionsMap.get(item.seccion);
+    const secciones = agrupado.get(capitulo);
+    if (!secciones.has(seccion)) {
+      secciones.set(seccion, []);
+    }
+    secciones.get(seccion).push(cuenta);
+  });
 
-    // Agregar cuenta
-    sectionNode.cuentas.push({
-      cuenta: item.cuenta,
-      descripcion: item.descripcion,
-      valor: valor
+  const resumen = [];
+
+  agrupado.forEach((secciones, capitulo) => {
+    const children = [];
+    secciones.forEach((cuentas, seccion) => {
+      children.push(construirNodoSeccion({ seccion, cuentas, definicion: definicionCuentas, claveMes, planeacionActual, planeacionPrevio }));
     });
-    
-    sectionNode.total += valor;
-    chapterNode.total += valor;
+
+    const totalesCapitulo = children.reduce((acc, nodo) => {
+      acc.actualMonth += nodo.totalActualMonth;
+      acc.planMonth += nodo.totalPlanMonth;
+      acc.prevMonth += nodo.totalPrevMonth;
+      acc.actualYTD += nodo.totalActualYTD;
+      acc.planYTD += nodo.totalPlanYTD;
+      acc.prevYTD += nodo.totalPrevYTD;
+      return acc;
+    }, { actualMonth: 0, planMonth: 0, prevMonth: 0, actualYTD: 0, planYTD: 0, prevYTD: 0 });
+
+    resumen.push({
+      key: NORMALIZAR_CLAVE(capitulo),
+      label: capitulo,
+      children,
+      totalActualMonth: totalesCapitulo.actualMonth,
+      totalPlanMonth: totalesCapitulo.planMonth,
+      totalPrevMonth: totalesCapitulo.prevMonth,
+      totalActualYTD: totalesCapitulo.actualYTD,
+      totalPlanYTD: totalesCapitulo.planYTD,
+      totalPrevYTD: totalesCapitulo.prevYTD,
+      total: totalesCapitulo.actualYTD
+    });
   });
 
-  // Convertir mapa a array y calcular resultados operativos si es necesario
-  // Aquí podríamos implementar la lógica de Income - Expense si los capítulos están relacionados
-  // Por ahora devolvemos la lista de capítulos como nodos de primer nivel
-  
-  root.children = Array.from(chapters.values()).map(chap => {
-    delete chap.sectionsMap; // Limpiar propiedad auxiliar
-    return chap;
-  });
-  
-  // Calcular total global (simple suma por ahora)
-  root.total = root.children.reduce((acc, curr) => {
-    return acc + (curr.type === 'expense' ? -curr.total : curr.total);
-  }, 0);
-
-  return root.children;
+  return resumen;
 };
 
 async function generarReporte(tipoReporte, empresaId, anio) {
-  const config = REPORT_CONFIG[tipoReporte];
-  if (!config) throw new Error(`Tipo de reporte no soportado: ${tipoReporte}`);
+  const definiciones = cargarDefiniciones();
+  const lista = definiciones[tipoReporte];
+  if (!Array.isArray(lista) || !lista.length) {
+    throw new Error(`No hay definiciones para ${tipoReporte}`);
+  }
 
-  const filePath = getReportPath(tipoReporte, empresaId);
-  if (!filePath) throw new Error(`No hay configuración para ${tipoReporte} en empresa ${empresaId}`);
+  const cuentas = lista.map((item) => NORMALIZAR_CLAVE(item.CUENTA)).filter(Boolean);
+  const claveMes = obtenerMesActualClave();
 
-  const rawRows = await cargarCsv(filePath);
-  const items = parseRows(rawRows, config.aliases);
-  
-  const cuentas = items.map(i => i.cuenta);
-  const saldos = await obtenerSaldosPorCuentas(empresaId, anio, cuentas);
-  
-  const saldosMap = new Map();
-  saldos.forEach(s => saldosMap.set(normalizeKey(s.numCta), s));
+  const [planeacionActual, planeacionPrevio] = await Promise.all([
+    obtenerDatosPlaneacion({ empresaId, anio, cuentas }),
+    obtenerDatosPlaneacion({ empresaId, anio: Number(anio) - 1, cuentas })
+  ]);
 
-  const resumen = buildHierarchy(items, saldosMap);
-
-  return {
-    empresa: empresaId,
+  const resumen = construirReporte(lista, claveMes, planeacionActual, planeacionPrevio);
+  const payload = {
+    empresaId,
+    reportKey: tipoReporte,
     anio,
     resumen
   };
+
+  if (tipoReporte === 'RESUMEN') {
+    payload.resumen = resumen.map((capitulo) => ({
+      key: capitulo.key,
+      label: capitulo.label,
+      children: (capitulo.children || []).map((seccion) => ({
+        label: seccion.label,
+        chapter: capitulo.label,
+        amount: seccion.totalActualYTD,
+        totalPlanYTD: seccion.totalPlanYTD,
+        totalPrevYTD: seccion.totalPrevYTD
+      }))
+    }));
+  }
+
+  return payload;
 }
 
 module.exports = {

--- a/src/services/saldosService.js
+++ b/src/services/saldosService.js
@@ -129,7 +129,7 @@ async function obtenerAniosDisponibles(empresaId) {
   return listarAniosSaldos(empresaId);
 }
 
-async function obtenerCuentasPorAnio(empresaId, anio) {
+async function obtenerCuentasPorAnio(empresaId, anio, filtroCuentas = []) {
   if (!empresaId) throw new Error('Empresa obligatoria');
   const ejercicio = Number(anio);
   if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
@@ -139,6 +139,12 @@ async function obtenerCuentasPorAnio(empresaId, anio) {
   const tCtas = construirNombreTabla('CUENTAS', ejercicio);
   const tSal = construirNombreTabla('SALDOS', ejercicio);
 
+  const filtros = Array.isArray(filtroCuentas)
+    ? filtroCuentas.filter(Boolean)
+    : [];
+
+  const parametros = [ejercicio];
+  const whereCuentas = filtros.length ? ` AND c.num_cta IN (${filtros.map(() => '?').join(',')})` : '';
   const sql = `
     SELECT DISTINCT
       c.num_cta AS cuenta,
@@ -147,10 +153,11 @@ async function obtenerCuentasPorAnio(empresaId, anio) {
     FROM ${tCtas} c
     INNER JOIN ${tSal} s ON s.num_cta = c.num_cta AND s.ejercicio = ?
     WHERE c.status = 'A'
+      ${whereCuentas}
     ORDER BY c.num_cta
   `;
 
-  const rows = await ejecutarConsulta(empresaId, sql, [ejercicio]);
+  const rows = await ejecutarConsulta(empresaId, sql, parametros.concat(filtros));
   return rows.map(row => ({
     cuenta: String(row.cuenta).trim(),
     nombre: String(row.nombre || '').trim(),


### PR DESCRIPTION
## Summary
- allow /api/saldos/cuentas to accept optional account lists and filter results
- adjust planeación summary engine to return simplified RESUMEN payload matching the front-end view
- expose section totals with identifiers for chapter headers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe8572af8832db7bb2a76aa4164aa)