### PR TITLE
Strengthen budget draft approval workflow

### DIFF
--- a/src/routes/borradores.js
+++ b/src/routes/borradores.js
@@ -9,8 +9,12 @@ const {
   enviarRevision,
   autorizarBorrador,
   rechazarBorrador,
-  obtenerBorradorPorId
+  obtenerBorradorPorId,
+  marcarRevisado,
+  guardarAutorizado,
+  ESTADOS
 } = require('../services/borradoresService');
+const { notificarWorkflowPresupuesto } = require('../services/notificacionesService');
 
 const router = express.Router();
 
@@ -98,6 +102,12 @@ const esquemaBorradorId = Joi.object({
 const esquemaRechazo = esquemaBorradorId.keys({
   motivo: Joi.string().trim().required()
 });
+
+const esquemaRevision = esquemaBorradorId.keys({
+  cancelar: Joi.boolean().default(false)
+});
+
+const esquemaFinalizar = esquemaBorradorId;
 
 router.use(cargarUsuarioActual);
 
@@ -192,6 +202,18 @@ router.post('/enviar', async (req, res) => {
 
   try {
     const resultado = await enviarRevision(value.borradorId, req.esAdmin ? 'ADMIN_GLOBAL' : 'USUARIO');
+    notificarWorkflowPresupuesto({
+      empresaId: empresa.id,
+      modulo: borrador.modulo,
+      anio: borrador.anio,
+      accion: resultado.autoAutorizado ? 'autorizar' : 'enviar',
+      estado: resultado.borrador?.estado,
+      ejecutor: {
+        id: req.usuarioActual.id,
+        usuario: req.usuarioActual.usuario,
+        nombre: `${req.usuarioActual.nombres || ''} ${req.usuarioActual.apellidos || ''}`.trim() || req.usuarioActual.usuario
+      }
+    }).catch((notifError) => console.warn('No se enviaron todas las notificaciones de borradores.', notifError));
     return res.json({
       mensaje: resultado.autoAutorizado ? 'Borrador autorizado automáticamente.' : 'Borrador enviado a revisión.',
       ...resultado
@@ -225,6 +247,18 @@ router.post('/autorizar', async (req, res) => {
 
   try {
     const aprobado = await autorizarBorrador(value.borradorId);
+    notificarWorkflowPresupuesto({
+      empresaId: empresa.id,
+      modulo: borrador.modulo,
+      anio: borrador.anio,
+      accion: 'autorizar',
+      estado: aprobado.estado,
+      ejecutor: {
+        id: req.usuarioActual.id,
+        usuario: req.usuarioActual.usuario,
+        nombre: `${req.usuarioActual.nombres || ''} ${req.usuarioActual.apellidos || ''}`.trim() || req.usuarioActual.usuario
+      }
+    }).catch((notifError) => console.warn('No se enviaron todas las notificaciones de borradores.', notifError));
     return res.json({ mensaje: 'Borrador autorizado.', borrador: aprobado });
   } catch (errorAutorizar) {
     console.error('Error al autorizar borrador:', errorAutorizar);
@@ -255,10 +289,110 @@ router.post('/rechazar', (req, res) => {
 
   try {
     const rechazado = rechazarBorrador(value.borradorId, value.motivo);
+    notificarWorkflowPresupuesto({
+      empresaId: empresa.id,
+      modulo: borrador.modulo,
+      anio: borrador.anio,
+      accion: 'rechazar',
+      estado: rechazado.estado,
+      ejecutor: {
+        id: req.usuarioActual.id,
+        usuario: req.usuarioActual.usuario,
+        nombre: `${req.usuarioActual.nombres || ''} ${req.usuarioActual.apellidos || ''}`.trim() || req.usuarioActual.usuario
+      }
+    }).catch((notifError) => console.warn('No se enviaron todas las notificaciones de borradores.', notifError));
     return res.json({ mensaje: 'Borrador rechazado.', borrador: rechazado });
   } catch (errorRechazar) {
     console.error('Error al rechazar borrador:', errorRechazar);
     return res.status(500).json({ mensaje: 'No fue posible rechazar el borrador.' });
+  }
+});
+
+router.post('/revisar', (req, res) => {
+  const { value, error } = esquemaRevision.validate(req.body, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({
+      mensaje: 'Verifica los datos proporcionados.',
+      detalles: error.details.map((detalle) => detalle.message)
+    });
+  }
+
+  const borrador = obtenerBorradorPorId(value.borradorId);
+  if (!borrador) {
+    return res.status(404).json({ mensaje: 'Borrador no encontrado.' });
+  }
+  const empresa = obtenerEmpresaPorId(borrador.empresaId);
+  if (!empresa) {
+    return res.status(404).json({ mensaje: 'Empresa asociada al borrador no existe.' });
+  }
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, empresa.id, borrador.modulo, 'Revisar')) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para revisar borradores.' });
+  }
+
+  try {
+    const resultado = marcarRevisado(value.borradorId, value.cancelar);
+    notificarWorkflowPresupuesto({
+      empresaId: empresa.id,
+      modulo: borrador.modulo,
+      anio: borrador.anio,
+      accion: value.cancelar ? 'revisar-cancelar' : 'revisar',
+      estado: resultado.estado,
+      ejecutor: {
+        id: req.usuarioActual.id,
+        usuario: req.usuarioActual.usuario,
+        nombre: `${req.usuarioActual.nombres || ''} ${req.usuarioActual.apellidos || ''}`.trim() || req.usuarioActual.usuario
+      }
+    }).catch((notifError) => console.warn('No se enviaron todas las notificaciones de borradores.', notifError));
+    const mensaje = value.cancelar ? 'Revisión cancelada y devuelta a edición.' : 'Borrador marcado como revisado.';
+    return res.json({ mensaje, borrador: resultado });
+  } catch (errorRevision) {
+    console.error('Error al marcar revisión:', errorRevision);
+    return res.status(500).json({ mensaje: 'No fue posible actualizar la revisión.' });
+  }
+});
+
+router.post('/finalizar', async (req, res) => {
+  const { value, error } = esquemaFinalizar.validate(req.body, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({
+      mensaje: 'Verifica los datos proporcionados.',
+      detalles: error.details.map((detalle) => detalle.message)
+    });
+  }
+
+  const borrador = obtenerBorradorPorId(value.borradorId);
+  if (!borrador) {
+    return res.status(404).json({ mensaje: 'Borrador no encontrado.' });
+  }
+  const empresa = obtenerEmpresaPorId(borrador.empresaId);
+  if (!empresa) {
+    return res.status(404).json({ mensaje: 'Empresa asociada al borrador no existe.' });
+  }
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, empresa.id, borrador.modulo, 'Cargar y guardar')) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para guardar en base de datos.' });
+  }
+  if (borrador.estado !== ESTADOS.APROBADO) {
+    return res.status(409).json({ mensaje: 'El borrador debe estar autorizado para guardar en base de datos.' });
+  }
+
+  try {
+    const guardado = await guardarAutorizado(value.borradorId);
+    notificarWorkflowPresupuesto({
+      empresaId: empresa.id,
+      modulo: borrador.modulo,
+      anio: borrador.anio,
+      accion: 'guardar',
+      estado: guardado.estado,
+      ejecutor: {
+        id: req.usuarioActual.id,
+        usuario: req.usuarioActual.usuario,
+        nombre: `${req.usuarioActual.nombres || ''} ${req.usuarioActual.apellidos || ''}`.trim() || req.usuarioActual.usuario
+      }
+    }).catch((notifError) => console.warn('No se enviaron todas las notificaciones de borradores.', notifError));
+    return res.json({ mensaje: 'Presupuesto guardado en base de datos.', borrador: guardado });
+  } catch (errorFinal) {
+    console.error('Error al guardar borrador autorizado:', errorFinal);
+    return res.status(500).json({ mensaje: 'No fue posible guardar en la base de datos.' });
   }
 });
 

--- a/src/routes/saldos.js
+++ b/src/routes/saldos.js
@@ -128,8 +128,12 @@ router.get('/cuentas', async (req, res) => {
 
   const { value, error } = Joi.object({
     empresaId: Joi.string().required(),
-    anio: Joi.number().integer().min(2000).max(2100).required()
-  }).validate(req.query, { abortEarly: false });
+    anio: Joi.number().integer().min(2000).max(2100).required(),
+    cuentas: Joi.alternatives().try(
+      Joi.array().items(Joi.string().trim()).min(1),
+      Joi.string().trim()
+    ).optional()
+  }).validate(req.query, { abortEarly: false, allowUnknown: true });
 
   if (error) {
     return res.status(400).json({ mensaje:'Parámetros inválidos', detalles: error.details.map(d=>d.message) });
@@ -149,9 +153,16 @@ router.get('/cuentas', async (req, res) => {
     if (!puede(mapa, empresa.id)) return res.status(403).json({ mensaje: 'Sin permiso para esta empresa.' });
   }
 
+  const cuentas = Array.isArray(value.cuentas)
+    ? value.cuentas
+    : (value.cuentas || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
   try {
-    const cuentas = await obtenerCuentasPorAnio(empresa.id, value.anio);
-    res.json({ cuentas });
+    const cuentasEncontradas = await obtenerCuentasPorAnio(empresa.id, value.anio, cuentas);
+    res.json({ cuentas: cuentasEncontradas });
   } catch (e) {
     console.error('Error /api/saldos/cuentas:', e);
     res.status(500).json({ mensaje: 'No fue posible obtener cuentas.' });

--- a/src/services/borradoresService.js
+++ b/src/services/borradoresService.js
@@ -1,5 +1,14 @@
 const { db, registrarPresupuestoGuardado } = require('../db/sqlite');
 
+const ESTADOS = {
+  EDITANDO: 'EDITANDO',
+  PENDIENTE: 'PENDIENTE',
+  REVISADO: 'REVISADO',
+  RECHAZADO: 'RECHAZADO',
+  APROBADO: 'APROBADO',
+  GUARDADO: 'GUARDADO'
+};
+
 const mapData = (texto) => {
   if (!texto) return null;
   try {
@@ -151,8 +160,9 @@ const obtenerBorrador = ({ empresaId, modulo, anio }) => {
   const fila = db.prepare(`
     SELECT *
     FROM PLAN_BORRADORES
-    WHERE empresaId = ? AND modulo = ? AND anio = ? AND estado IN ('EDITANDO', 'PENDIENTE')
-    ORDER BY id DESC
+    WHERE empresaId = ? AND modulo = ? AND anio = ?
+      AND estado IN ('${ESTADOS.EDITANDO}', '${ESTADOS.PENDIENTE}', '${ESTADOS.RECHAZADO}', '${ESTADOS.REVISADO}', '${ESTADOS.APROBADO}')
+    ORDER BY fechaEnvio DESC NULLS LAST, id DESC
     LIMIT 1
   `).get(empresaId, modulo, anio);
   return mapearFila(fila);
@@ -170,7 +180,7 @@ const guardarBorrador = (contexto, datos) => {
   if (existente) {
     db.prepare(`
       UPDATE PLAN_BORRADORES
-      SET data = ?, estado = 'EDITANDO', fechaEnvio = NULL, comentarios = NULL, usuarioId = ?
+      SET data = ?, estado = '${ESTADOS.EDITANDO}', fechaEnvio = NULL, comentarios = NULL, usuarioId = ?
       WHERE id = ?
     `).run(contenido, cfg.usuarioId, existente.id);
     return obtenerBorradorPorId(existente.id);
@@ -178,7 +188,7 @@ const guardarBorrador = (contexto, datos) => {
 
   const resultado = db.prepare(`
     INSERT INTO PLAN_BORRADORES (empresaId, anio, modulo, usuarioId, data, estado, comentarios)
-    VALUES (?, ?, ?, ?, ?, 'EDITANDO', ?)
+    VALUES (?, ?, ?, ?, ?, '${ESTADOS.EDITANDO}', ?)
   `).run(cfg.empresaId, cfg.anio, cfg.modulo, cfg.usuarioId, contenido, cfg.comentarios);
 
   return obtenerBorradorPorId(resultado.lastInsertRowid);
@@ -191,17 +201,35 @@ const enviarRevision = async (borradorId, usuarioRol) => {
   }
 
   if (usuarioRol === 'ADMIN_GLOBAL') {
-    const autorizado = await autorizarBorrador(borradorId);
-    return { autoAutorizado: true, borrador: autorizado };
+    db.prepare(`
+      UPDATE PLAN_BORRADORES
+      SET estado = '${ESTADOS.APROBADO}', fechaEnvio = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `).run(borradorId);
+    return { autoAutorizado: true, borrador: obtenerBorradorPorId(borradorId) };
   }
 
   db.prepare(`
     UPDATE PLAN_BORRADORES
-    SET estado = 'PENDIENTE', fechaEnvio = CURRENT_TIMESTAMP
+    SET estado = '${ESTADOS.PENDIENTE}', fechaEnvio = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(borradorId);
 
   return { autoAutorizado: false, borrador: obtenerBorradorPorId(borradorId) };
+};
+
+const marcarRevisado = (borradorId, cancelar = false) => {
+  const borrador = obtenerBorradorPorId(borradorId);
+  if (!borrador) {
+    throw new Error('Borrador no encontrado.');
+  }
+  const destino = cancelar ? ESTADOS.EDITANDO : ESTADOS.REVISADO;
+  db.prepare(`
+    UPDATE PLAN_BORRADORES
+    SET estado = ?, comentarios = NULL
+    WHERE id = ?
+  `).run(destino, borradorId);
+  return obtenerBorradorPorId(borradorId);
 };
 
 const autorizarBorrador = async (borradorId) => {
@@ -210,14 +238,13 @@ const autorizarBorrador = async (borradorId) => {
     throw new Error('Borrador no encontrado.');
   }
 
-  const finalizador = obtenerFinalizador(borrador.modulo);
-  if (finalizador) {
-    await finalizador(borrador);
+  if (![ESTADOS.REVISADO, ESTADOS.APROBADO].includes(borrador.estado)) {
+    throw new Error('El borrador debe estar revisado antes de autorizar.');
   }
 
   db.prepare(`
     UPDATE PLAN_BORRADORES
-    SET estado = 'APROBADO', fechaEnvio = CURRENT_TIMESTAMP
+    SET estado = '${ESTADOS.APROBADO}', fechaEnvio = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(borradorId);
 
@@ -232,10 +259,30 @@ const rechazarBorrador = (borradorId, motivo) => {
 
   db.prepare(`
     UPDATE PLAN_BORRADORES
-    SET estado = 'RECHAZADO', comentarios = ?, fechaEnvio = CURRENT_TIMESTAMP
+    SET estado = '${ESTADOS.RECHAZADO}', comentarios = ?, fechaEnvio = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(motivo || null, borradorId);
 
+  return obtenerBorradorPorId(borradorId);
+};
+
+const guardarAutorizado = async (borradorId) => {
+  const borrador = obtenerBorradorPorId(borradorId);
+  if (!borrador) {
+    throw new Error('Borrador no encontrado.');
+  }
+  if (borrador.estado !== ESTADOS.APROBADO) {
+    throw new Error('El borrador debe estar autorizado antes de guardar.');
+  }
+  const finalizador = obtenerFinalizador(borrador.modulo);
+  if (finalizador) {
+    await finalizador(borrador);
+  }
+  db.prepare(`
+    UPDATE PLAN_BORRADORES
+    SET estado = '${ESTADOS.GUARDADO}', fechaEnvio = CURRENT_TIMESTAMP
+    WHERE id = ?
+  `).run(borradorId);
   return obtenerBorradorPorId(borradorId);
 };
 
@@ -245,5 +292,8 @@ module.exports = {
   enviarRevision,
   autorizarBorrador,
   rechazarBorrador,
-  obtenerBorradorPorId
+  obtenerBorradorPorId,
+  marcarRevisado,
+  guardarAutorizado,
+  ESTADOS
 };

--- a/src/services/notificacionesService.js
+++ b/src/services/notificacionesService.js
@@ -146,8 +146,11 @@ const construirMensajeCorreo = ({ titulo, mensaje, enlace }) => {
 
 const MAPA_DESTINATARIOS = {
   cargar: { permiso: 'Revisar', asunto: 'listo para revisión' },
+  enviar: { permiso: 'Revisar', asunto: 'enviado para revisión' },
   revisar: { permiso: 'Aprobar', asunto: 'requiere autorización' },
+  'revisar-cancelar': { permiso: 'Cargar y guardar', asunto: 'regresado a edición' },
   autorizar: { permiso: 'Cargar y guardar', asunto: 'autorizado y listo para guardar' },
+  rechazar: { permiso: 'Cargar y guardar', asunto: 'rechazado, requiere ajustes' },
   aprobar: { permiso: 'Cargar y guardar', asunto: 'aprobado y cerrado' },
   guardar: { permiso: 'Cargar y guardar', asunto: 'guardado y listo para operación' }
 };

--- a/src/services/reportes/planeacionReportesEngine.js
+++ b/src/services/reportes/planeacionReportesEngine.js
@@ -1,164 +1,175 @@
 const path = require('path');
-const { obtenerSaldosPorCuentas } = require('../saldosService');
-const { cargarCsv, construirMapaCabeceras, buscarValor, resolverRuta, normalizarTexto } = require('../../utils/csvLoader');
-const { obtenerEmpresaPorId } = require('../../config/empresas');
+const fs = require('fs');
+const { obtenerDatosPlaneacion } = require('../planeacionCuentasService');
+const { MESES } = require('../saldosService');
 
 const DEFAULT_BASE_PATH = path.join(__dirname, '..', '..', '..', 'info IMPORTANTE');
+const DEFINICIONES_FILE = path.join(DEFAULT_BASE_PATH, 'CUENTAS SUMMARY y RESUMEN.json');
 
-const REPORT_CONFIG = {
-  SUMMARY: {
-    mapFiles: {
-      empresa1: 'SUMMARY Ciudad de México.csv',
-      empresa2: 'SUMMARY GUADALAJARA.csv',
-      empresa3: 'SUMMARY NOROESTE.csv',
-      empresa4: 'SUMMARY NOROESTE.csv'
-    },
-    aliases: {
-      CUENTA: ['CUENTA', 'Cuentas', 'CODIGO'],
-      DESCRIPCION: ['DESCRIPCION', 'Descripción', 'NOMBRE'],
-      SECCION: ['Sección', 'SECCION', 'CATEGORIA'],
-      CAPITULO: ['SECCIÓN MAYOR', 'CAPITULO', 'CHAPTER']
-    }
-  },
-  RESUMEN: {
-    mapFiles: {
-      empresa1: 'Resumen Guadalajara.csv', // Ajustar según corresponda si hay más archivos
-      empresa2: 'Resumen Guadalajara.csv',
-      empresa3: 'Resumen Guadalajara.csv',
-      empresa4: 'Resumen Guadalajara.csv'
-    },
-    aliases: {
-      CUENTA: ['CUENTA', 'CODIGO'],
-      DESCRIPCION: ['DESCRIPCION', 'NOMBRE'],
-      GRUPO: ['GRUPO', 'SECCION']
-    }
-  }
+const NORMALIZAR_CLAVE = (valor = '') => valor.toString().trim().toUpperCase();
+
+const cargarDefiniciones = () => {
+  const contenido = fs.readFileSync(DEFINICIONES_FILE, 'utf8');
+  return JSON.parse(contenido);
 };
 
-const normalizeKey = (valor) => {
-  if (valor == null) return '';
-  return valor.toString().trim().toUpperCase();
+const obtenerMesActualClave = () => {
+  const ahora = new Date();
+  const indice = Math.min(Math.max(ahora.getMonth(), 0), 11);
+  return MESES[indice]?.clave || 'dic';
 };
 
-const getReportPath = (tipo, empresaId) => {
-  const config = REPORT_CONFIG[tipo];
-  if (!config) return null;
-  const filename = config.mapFiles[empresaId];
-  if (!filename) return null;
-  return path.join(DEFAULT_BASE_PATH, filename);
-};
-
-const parseRows = (rows, aliases) => {
-  return rows.map((fila) => {
-    const headers = construirMapaCabeceras(fila);
-    const cuenta = buscarValor(fila, headers, aliases.CUENTA);
-    const descripcion = buscarValor(fila, headers, aliases.DESCRIPCION);
-    const seccion = buscarValor(fila, headers, aliases.SECCION) || buscarValor(fila, headers, aliases.GRUPO);
-    const capitulo = buscarValor(fila, headers, aliases.CAPITULO) || 'GENERAL';
-    
-    if (!cuenta) return null;
-
-    return {
-      cuenta: normalizeKey(cuenta),
-      descripcion: descripcion || '',
-      seccion: seccion || 'OTROS',
-      capitulo: capitulo
-    };
-  }).filter(Boolean);
-};
-
-const isExpense = (label) => {
-  const text = normalizeKey(label);
-  return text.includes('EXPENSE') || text.includes('GASTO') || text.includes('COSTO');
-};
-
-const buildHierarchy = (items, saldosMap) => {
-  const root = {
-    label: 'Reporte',
-    total: 0,
-    children: []
+const calcularTotales = (cuentas, claveMes, planeacionActual, planeacionPrevio) => {
+  const acumulados = {
+    actualMonth: 0,
+    planMonth: 0,
+    prevMonth: 0,
+    actualYTD: 0,
+    planYTD: 0,
+    prevYTD: 0
   };
 
-  const chapters = new Map();
-
-  items.forEach(item => {
-    const saldo = saldosMap.get(item.cuenta);
-    const valor = Number(saldo?.dic_acum ?? saldo?.anual ?? 0);
-    
-    // Agrupar por Capítulo (ej. CDMX Income)
-    if (!chapters.has(item.capitulo)) {
-      chapters.set(item.capitulo, {
-        label: item.capitulo,
-        total: 0,
-        children: [], // Secciones
-        sectionsMap: new Map(),
-        type: isExpense(item.capitulo) ? 'expense' : 'income'
-      });
+  const sumaHastaMes = (registro, incluirPrevio) => {
+    let total = 0;
+    for (const { clave } of MESES) {
+      total += Number(registro?.presupuesto?.[clave] ?? 0);
+      if (clave === claveMes) break;
     }
-    const chapterNode = chapters.get(item.capitulo);
+    if (incluirPrevio) return total;
+    return total;
+  };
 
-    // Agrupar por Sección (ej. Membership)
-    if (!chapterNode.sectionsMap.has(item.seccion)) {
-      chapterNode.sectionsMap.set(item.seccion, {
-        label: item.seccion,
-        total: 0,
-        cuentas: []
-      });
-      chapterNode.children.push(chapterNode.sectionsMap.get(item.seccion));
+  const claveAcum = `${claveMes}_acum`;
+
+  cuentas.forEach((cuenta) => {
+    const actual = planeacionActual.find((p) => p.cuenta === cuenta);
+    const previo = planeacionPrevio.find((p) => p.cuenta === cuenta);
+
+    acumulados.actualMonth += Number(actual?.real?.[claveMes] ?? 0);
+    acumulados.planMonth += Number(actual?.presupuesto?.[claveMes] ?? 0);
+    acumulados.prevMonth += Number(previo?.real?.[claveMes] ?? 0);
+
+    acumulados.actualYTD += Number(actual?.real?.[claveAcum] ?? 0);
+    acumulados.planYTD += sumaHastaMes(actual, false);
+    acumulados.prevYTD += Number(previo?.real?.[claveAcum] ?? 0);
+  });
+
+  return acumulados;
+};
+
+const construirNodoSeccion = ({ seccion, cuentas, definicion, claveMes, planeacionActual, planeacionPrevio }) => {
+  const totales = calcularTotales(cuentas, claveMes, planeacionActual, planeacionPrevio);
+  return {
+    label: seccion,
+    cuentas: cuentas.map((cuentaId) => {
+      const actual = planeacionActual.find((p) => p.cuenta === cuentaId) || {};
+      const previo = planeacionPrevio.find((p) => p.cuenta === cuentaId) || {};
+      return {
+        cuenta: cuentaId,
+        descripcion: definicion.get(cuentaId)?.descripcion || '',
+        actualMonth: Number(actual.real?.[claveMes] ?? 0),
+        planMonth: Number(actual.presupuesto?.[claveMes] ?? 0),
+        prevMonth: Number(previo.real?.[claveMes] ?? 0),
+        actualYTD: Number(actual.real?.[`${claveMes}_acum`] ?? 0),
+        planYTD: MESES.reduce((acc, { clave }) => {
+          if (acc.detener) return acc;
+          const nuevo = acc.total + Number(actual.presupuesto?.[clave] ?? 0);
+          if (clave === claveMes) return { total: nuevo, detener: true };
+          return { total: nuevo, detener: false };
+        }, { total: 0, detener: false }).total,
+        prevYTD: Number(previo.real?.[`${claveMes}_acum`] ?? 0)
+      };
+    }),
+    totalActualMonth: totales.actualMonth,
+    totalPlanMonth: totales.planMonth,
+    totalPrevMonth: totales.prevMonth,
+    totalActualYTD: totales.actualYTD,
+    totalPlanYTD: totales.planYTD,
+    totalPrevYTD: totales.prevYTD,
+    total: totales.actualYTD
+  };
+};
+
+const construirReporte = (definiciones, claveMes, planeacionActual, planeacionPrevio) => {
+  const definicionCuentas = new Map();
+  const agrupado = new Map();
+
+  definiciones.forEach((item) => {
+    const capitulo = item['SECCIÓN Principal'] || item['SECCION Principal'] || item['SECCION'] || item['SECCIÓN'];
+    const seccion = item['SECCION Secundaria'] || item['Sección'] || item['SECCION'];
+    const cuenta = NORMALIZAR_CLAVE(item.CUENTA);
+    if (!capitulo || !seccion || !cuenta) return;
+
+    definicionCuentas.set(cuenta, { descripcion: item.NOMBRE || '' });
+    if (!agrupado.has(capitulo)) {
+      agrupado.set(capitulo, new Map());
     }
-    const sectionNode = chapterNode.sectionsMap.get(item.seccion);
+    const secciones = agrupado.get(capitulo);
+    if (!secciones.has(seccion)) {
+      secciones.set(seccion, []);
+    }
+    secciones.get(seccion).push(cuenta);
+  });
 
-    // Agregar cuenta
-    sectionNode.cuentas.push({
-      cuenta: item.cuenta,
-      descripcion: item.descripcion,
-      valor: valor
+  const resumen = [];
+
+  agrupado.forEach((secciones, capitulo) => {
+    const children = [];
+    secciones.forEach((cuentas, seccion) => {
+      children.push(construirNodoSeccion({ seccion, cuentas, definicion: definicionCuentas, claveMes, planeacionActual, planeacionPrevio }));
     });
-    
-    sectionNode.total += valor;
-    chapterNode.total += valor;
+
+    const totalesCapitulo = children.reduce((acc, nodo) => {
+      acc.actualMonth += nodo.totalActualMonth;
+      acc.planMonth += nodo.totalPlanMonth;
+      acc.prevMonth += nodo.totalPrevMonth;
+      acc.actualYTD += nodo.totalActualYTD;
+      acc.planYTD += nodo.totalPlanYTD;
+      acc.prevYTD += nodo.totalPrevYTD;
+      return acc;
+    }, { actualMonth: 0, planMonth: 0, prevMonth: 0, actualYTD: 0, planYTD: 0, prevYTD: 0 });
+
+    resumen.push({
+      key: NORMALIZAR_CLAVE(capitulo),
+      label: capitulo,
+      children,
+      totalActualMonth: totalesCapitulo.actualMonth,
+      totalPlanMonth: totalesCapitulo.planMonth,
+      totalPrevMonth: totalesCapitulo.prevMonth,
+      totalActualYTD: totalesCapitulo.actualYTD,
+      totalPlanYTD: totalesCapitulo.planYTD,
+      totalPrevYTD: totalesCapitulo.prevYTD,
+      total: totalesCapitulo.actualYTD
+    });
   });
 
-  // Convertir mapa a array y calcular resultados operativos si es necesario
-  // Aquí podríamos implementar la lógica de Income - Expense si los capítulos están relacionados
-  // Por ahora devolvemos la lista de capítulos como nodos de primer nivel
-  
-  root.children = Array.from(chapters.values()).map(chap => {
-    delete chap.sectionsMap; // Limpiar propiedad auxiliar
-    return chap;
-  });
-  
-  // Calcular total global (simple suma por ahora)
-  root.total = root.children.reduce((acc, curr) => {
-    return acc + (curr.type === 'expense' ? -curr.total : curr.total);
-  }, 0);
-
-  return root.children;
+  return resumen;
 };
 
 async function generarReporte(tipoReporte, empresaId, anio) {
-  const config = REPORT_CONFIG[tipoReporte];
-  if (!config) throw new Error(`Tipo de reporte no soportado: ${tipoReporte}`);
+  const definiciones = cargarDefiniciones();
+  const lista = definiciones[tipoReporte];
+  if (!Array.isArray(lista) || !lista.length) {
+    throw new Error(`No hay definiciones para ${tipoReporte}`);
+  }
 
-  const filePath = getReportPath(tipoReporte, empresaId);
-  if (!filePath) throw new Error(`No hay configuración para ${tipoReporte} en empresa ${empresaId}`);
+  const cuentas = lista.map((item) => NORMALIZAR_CLAVE(item.CUENTA)).filter(Boolean);
+  const claveMes = obtenerMesActualClave();
 
-  const rawRows = await cargarCsv(filePath);
-  const items = parseRows(rawRows, config.aliases);
-  
-  const cuentas = items.map(i => i.cuenta);
-  const saldos = await obtenerSaldosPorCuentas(empresaId, anio, cuentas);
-  
-  const saldosMap = new Map();
-  saldos.forEach(s => saldosMap.set(normalizeKey(s.numCta), s));
+  const [planeacionActual, planeacionPrevio] = await Promise.all([
+    obtenerDatosPlaneacion({ empresaId, anio, cuentas }),
+    obtenerDatosPlaneacion({ empresaId, anio: Number(anio) - 1, cuentas })
+  ]);
 
-  const resumen = buildHierarchy(items, saldosMap);
-
-  return {
-    empresa: empresaId,
+  const resumen = construirReporte(lista, claveMes, planeacionActual, planeacionPrevio);
+  const payload = {
+    empresaId,
+    reportKey: tipoReporte,
     anio,
     resumen
   };
+
+  return payload;
 }
 
 module.exports = {

--- a/src/services/saldosService.js
+++ b/src/services/saldosService.js
@@ -129,7 +129,7 @@ async function obtenerAniosDisponibles(empresaId) {
   return listarAniosSaldos(empresaId);
 }
 
-async function obtenerCuentasPorAnio(empresaId, anio) {
+async function obtenerCuentasPorAnio(empresaId, anio, filtroCuentas = []) {
   if (!empresaId) throw new Error('Empresa obligatoria');
   const ejercicio = Number(anio);
   if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
@@ -139,6 +139,12 @@ async function obtenerCuentasPorAnio(empresaId, anio) {
   const tCtas = construirNombreTabla('CUENTAS', ejercicio);
   const tSal = construirNombreTabla('SALDOS', ejercicio);
 
+  const filtros = Array.isArray(filtroCuentas)
+    ? filtroCuentas.filter(Boolean)
+    : [];
+
+  const parametros = [ejercicio];
+  const whereCuentas = filtros.length ? ` AND c.num_cta IN (${filtros.map(() => '?').join(',')})` : '';
   const sql = `
     SELECT DISTINCT
       c.num_cta AS cuenta,
@@ -147,10 +153,11 @@ async function obtenerCuentasPorAnio(empresaId, anio) {
     FROM ${tCtas} c
     INNER JOIN ${tSal} s ON s.num_cta = c.num_cta AND s.ejercicio = ?
     WHERE c.status = 'A'
+      ${whereCuentas}
     ORDER BY c.num_cta
   `;
 
-  const rows = await ejecutarConsulta(empresaId, sql, [ejercicio]);
+  const rows = await ejecutarConsulta(empresaId, sql, parametros.concat(filtros));
   return rows.map(row => ({
     cuenta: String(row.cuenta).trim(),
     nombre: String(row.nombre || '').trim(),

--- a/vistas/Comités.html
+++ b/vistas/Comités.html
@@ -304,6 +304,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Comunicación.html
+++ b/vistas/Comunicación.html
@@ -309,6 +309,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Dirección.html
+++ b/vistas/Dirección.html
@@ -309,6 +309,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Eventos.html
+++ b/vistas/Eventos.html
@@ -317,6 +317,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Finanzas.html
+++ b/vistas/Finanzas.html
@@ -355,12 +355,13 @@
                   </button>
                   <button id="btnEnviarCambios" class="btn btn-primary btn-sm d-none">Enviar edición</button>
                   <button id="btnCancelarEdicion" class="btn btn-secondary btn-sm d-none">Cancelar</button>
-                  <button id="btnVerBorrador" class="btn btn-info btn-sm d-none">Ver edición</button>
-                  <div id="panelRevision" class="d-none">
-                    <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
-                    <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
-                  </div>
+                <button id="btnVerBorrador" class="btn btn-info btn-sm d-none">Ver edición</button>
+                <div id="panelRevision" class="d-none">
+                  <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
+                  <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
+              </div>
               </div>
               <input
                 type="file"

--- a/vistas/Gtos_Corporativos.html
+++ b/vistas/Gtos_Corporativos.html
@@ -310,6 +310,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Membresía.html
+++ b/vistas/Membresía.html
@@ -312,6 +312,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Presupuestos.html
+++ b/vistas/Presupuestos.html
@@ -295,6 +295,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/RH.html
+++ b/vistas/RH.html
@@ -317,6 +317,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/Serv_Membresía.html
+++ b/vistas/Serv_Membresía.html
@@ -312,6 +312,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/T&IC.html
+++ b/vistas/T&IC.html
@@ -312,6 +312,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/VPE.html
+++ b/vistas/VPE.html
@@ -312,6 +312,7 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
+                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
             </div>
             <input type="file" id="budgetFileInput" accept=".csv,text/csv" class="d-none" />

--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -5,6 +5,14 @@
   const EVENTO_CONTEXTO = 'planeacion:contexto-actualizado';
   const EVENTO_EDICION = 'modulo-planeacion:presupuesto-editado';
   const STYLE_ID = 'flujo-autorizacion-style';
+  const ESTADOS = {
+    EDITANDO: 'EDITANDO',
+    PENDIENTE: 'PENDIENTE',
+    REVISADO: 'REVISADO',
+    RECHAZADO: 'RECHAZADO',
+    APROBADO: 'APROBADO',
+    GUARDADO: 'GUARDADO'
+  };
 
   const colocarEstilo = () => {
     if (document.getElementById(STYLE_ID)) {
@@ -70,6 +78,7 @@
         'btnEnviarCambios',
         'btnCancelarEdicion',
         'btnVerBorrador',
+        'btnGuardarAutorizado',
         'btnAutorizar',
         'btnRechazar',
         'panelRevision'
@@ -94,6 +103,9 @@
       }
       if (this.buttons.btnRechazar) {
         this.buttons.btnRechazar.addEventListener('click', () => this._handleRechazar());
+      }
+      if (this.buttons.btnGuardarAutorizado) {
+        this.buttons.btnGuardarAutorizado.addEventListener('click', () => this._handleGuardarFinal());
       }
     }
 
@@ -211,6 +223,9 @@
     }
 
     async _handleEnviar() {
+      if (!this.borradorActual?.id || this.hayCambios) {
+        await this._handleGuardar();
+      }
       if (!this.borradorActual?.id) {
         this._mostrarToast('No hay borrador guardado para enviar.', 'warning');
         return;
@@ -246,6 +261,10 @@
         this._mostrarToast('No hay borrador pendiente.', 'warning');
         return;
       }
+      const estado = this.borradorActual?.estado;
+      if (estado === ESTADOS.PENDIENTE) {
+        return this._handleRevision(false);
+      }
       try {
         const respuesta = await fetch(`${API_BASE}/borradores/autorizar`, {
           method: 'POST',
@@ -274,6 +293,12 @@
         this._mostrarToast('No hay borrador pendiente.', 'warning');
         return;
       }
+      if (this.borradorActual?.estado === ESTADOS.REVISADO) {
+        const cancelar = window.confirm('¿Cancelar revisión y regresar a edición?');
+        if (cancelar) {
+          return this._handleRevision(true);
+        }
+      }
       const motivo = window.prompt('Indica el motivo para rechazar este borrador:');
       if (!motivo) {
         return;
@@ -298,6 +323,62 @@
       } catch (error) {
         console.error('Error al rechazar borrador', error);
         this._mostrarToast(error.message || 'No fue posible rechazar.', 'danger');
+      }
+    }
+
+    async _handleRevision(cancelar) {
+      if (!this.borradorActual?.id) {
+        this._mostrarToast('No hay borrador para revisar.', 'warning');
+        return;
+      }
+      try {
+        const respuesta = await fetch(`${API_BASE}/borradores/revisar`, {
+          method: 'POST',
+          headers: this._construirHeaders(),
+          body: JSON.stringify({ borradorId: this.borradorActual.id, cancelar: Boolean(cancelar) })
+        });
+        const datos = await respuesta.json().catch(() => ({}));
+        if (!respuesta.ok) {
+          throw new Error(datos.mensaje || 'No fue posible actualizar la revisión.');
+        }
+        this.borradorActual = datos.borrador || null;
+        this.borradorGuardado = Boolean(this.borradorActual);
+        this.hayCambios = false;
+        this.verBorradorVisible = false;
+        FlujoAutorizacion.limpiarBorrador(this.tableElement);
+        this._actualizarBotones();
+        this._mostrarToast(datos.mensaje || 'Revisión registrada.');
+      } catch (error) {
+        console.error('Error al marcar revisión', error);
+        this._mostrarToast(error.message || 'No fue posible actualizar la revisión.', 'danger');
+      }
+    }
+
+    async _handleGuardarFinal() {
+      if (!this.borradorActual?.id) {
+        this._mostrarToast('No hay borrador autorizado para guardar.', 'warning');
+        return;
+      }
+      try {
+        const respuesta = await fetch(`${API_BASE}/borradores/finalizar`, {
+          method: 'POST',
+          headers: this._construirHeaders(),
+          body: JSON.stringify({ borradorId: this.borradorActual.id })
+        });
+        const datos = await respuesta.json().catch(() => ({}));
+        if (!respuesta.ok) {
+          throw new Error(datos.mensaje || 'No fue posible guardar en base de datos.');
+        }
+        this.borradorActual = datos.borrador || null;
+        this.borradorGuardado = Boolean(this.borradorActual);
+        this.hayCambios = false;
+        this.verBorradorVisible = false;
+        FlujoAutorizacion.limpiarBorrador(this.tableElement);
+        this._actualizarBotones();
+        this._mostrarToast(datos.mensaje || 'Información guardada en la base de datos.');
+      } catch (error) {
+        console.error('Error al guardar autorizado', error);
+        this._mostrarToast(error.message || 'No fue posible guardar en la base de datos.', 'danger');
       }
     }
 
@@ -345,7 +426,16 @@
 
     _actualizarBotones() {
       const estado = this.borradorActual?.estado || null;
-      const { btnGuardarBorrador, btnEnviarCambios, btnCancelarEdicion, btnVerBorrador, panelRevision } = this.buttons;
+      const {
+        btnGuardarBorrador,
+        btnEnviarCambios,
+        btnCancelarEdicion,
+        btnVerBorrador,
+        panelRevision,
+        btnAutorizar,
+        btnRechazar,
+        btnGuardarAutorizado
+      } = this.buttons;
 
       if (btnGuardarBorrador) {
         btnGuardarBorrador.disabled = !this.hayCambios;
@@ -353,9 +443,8 @@
       }
 
       if (btnEnviarCambios) {
-        const puedeEnviar = Boolean(this.borradorActual)
-          && ['EDITANDO', 'RECHAZADO'].includes(estado)
-          && !this.hayCambios;
+        const puedeEnviar = [ESTADOS.EDITANDO, ESTADOS.RECHAZADO, null].includes(estado)
+          && (this.hayCambios || Boolean(this.borradorActual));
         btnEnviarCambios.classList.toggle('d-none', !puedeEnviar);
       }
 
@@ -370,7 +459,22 @@
       }
 
       if (panelRevision) {
-        panelRevision.classList.toggle('d-none', estado !== 'PENDIENTE');
+        const visible = [ESTADOS.PENDIENTE, ESTADOS.REVISADO, ESTADOS.APROBADO].includes(estado);
+        panelRevision.classList.toggle('d-none', !visible);
+      }
+
+      if (btnAutorizar) {
+        const enRevision = estado === ESTADOS.PENDIENTE;
+        btnAutorizar.textContent = enRevision ? 'Marcar revisado' : 'Autorizar';
+        btnAutorizar.classList.toggle('d-none', ![ESTADOS.PENDIENTE, ESTADOS.REVISADO].includes(estado));
+      }
+
+      if (btnRechazar) {
+        btnRechazar.classList.toggle('d-none', ![ESTADOS.PENDIENTE, ESTADOS.REVISADO, ESTADOS.APROBADO].includes(estado));
+      }
+
+      if (btnGuardarAutorizado) {
+        btnGuardarAutorizado.classList.toggle('d-none', estado !== ESTADOS.APROBADO);
       }
     }
 


### PR DESCRIPTION
## Summary
- add explicit draft review/authorization states with endpoints to review, cancel review, authorize, and finalize authorized drafts into the database
- expand workflow notifications to cover the new transitions and keep admins’ auto-authorization path intact
- update all budget module views with improved authorization controls and a final save button for authorized drafts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe8572af8832db7bb2a76aa4164aa)