### PR TITLE
Handle unavailable budget years

### DIFF
--- a/src/routes/presupuestos.js
+++ b/src/routes/presupuestos.js
@@ -199,6 +199,13 @@ router.get('/', async (req, res) => {
   const anioActual = new Date().getFullYear();
   const ejercicio = value.anio || anioActual;
   try {
+    const aniosDisponibles = await listarAniosPresupuestos(empresa.id);
+    if (Array.isArray(aniosDisponibles) && aniosDisponibles.length > 0 && !aniosDisponibles.includes(ejercicio)) {
+      return res.status(404).json({
+        mensaje: 'El ejercicio solicitado no está disponible en la base de datos.',
+        disponibles: aniosDisponibles
+      });
+    }
     const cuentas = await obtenerPresupuestosMayor(empresa.id, ejercicio);
     res.json({
       empresa: serializarEmpresa(empresa),


### PR DESCRIPTION
## Summary
- validate requested budget year against available Firebird tables before querying
- return a clear 404 response with available years when the requested year is missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303ec36c44832d874f83f1b8f780df)