### PR TITLE
Handle presupuesto queries when year listing fails

### DIFF
--- a/src/routes/presupuestos.js
+++ b/src/routes/presupuestos.js
@@ -56,6 +56,33 @@ const construirNombreUsuario = (registro) => {
   return nombre || registro?.usuario || 'Usuario';
 };
 
+const esTablaPresupuestoInexistente = (error) => {
+  const codigoSql = Number(error?.sqlcode || error?.SQLCODE);
+  if (codigoSql === -204) {
+    return true;
+  }
+  const mensaje = (error?.message || '').toString().toUpperCase();
+  return (
+    mensaje.includes('TABLE') &&
+    mensaje.includes('UNKNOWN') &&
+    (mensaje.includes('PRESUP') || mensaje.includes('CUENTAS') || mensaje.includes('SALDOS'))
+  );
+};
+
+const esErrorConexionFirebird = (error) => {
+  const codigo = (error?.code || '').toString().toUpperCase();
+  if (['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'ETIMEDOUT'].includes(codigo)) {
+    return true;
+  }
+  const mensaje = (error?.message || '').toString().toUpperCase();
+  return (
+    mensaje.includes('UNABLE TO COMPLETE NETWORK REQUEST') ||
+    mensaje.includes('FAILED TO ESTABLISH A CONNECTION') ||
+    mensaje.includes('NETWORK REQUEST') ||
+    mensaje.includes('CONNECTION REJECTED')
+  );
+};
+
 const cargarUsuarioActual = (req, res, next) => {
   const usuarioEncabezado = normalizarUsuario(req.headers['x-usuario-actual']);
   if (!usuarioEncabezado) {
@@ -175,6 +202,11 @@ router.get('/anios', async (req, res) => {
     const anios = await listarAniosPresupuestos(empresa.id);
     res.json({ anios });
   } catch (error) {
+    if (esErrorConexionFirebird(error)) {
+      return res.status(503).json({
+        mensaje: 'No fue posible conectar con la base de datos de Firebird para esta empresa.'
+      });
+    }
     console.error('Error al consultar anos de presupuestos:', error);
     res.status(500).json({ mensaje: 'No fue posible obtener los ejercicios disponibles.' });
   }
@@ -198,7 +230,28 @@ router.get('/', async (req, res) => {
   }
   const anioActual = new Date().getFullYear();
   const ejercicio = value.anio || anioActual;
+  let aniosDisponibles;
   try {
+    try {
+      aniosDisponibles = await listarAniosPresupuestos(empresa.id);
+      if (
+        Array.isArray(aniosDisponibles) &&
+        aniosDisponibles.length > 0 &&
+        !aniosDisponibles.includes(ejercicio)
+      ) {
+        return res.status(404).json({
+          mensaje: 'El ejercicio solicitado no está disponible en la base de datos.',
+          disponibles: aniosDisponibles
+        });
+      }
+    } catch (errorListado) {
+      if (esErrorConexionFirebird(errorListado)) {
+        return res.status(503).json({
+          mensaje: 'No fue posible conectar con la base de datos de Firebird para esta empresa.'
+        });
+      }
+      console.warn('No fue posible listar ejercicios antes de consultar presupuestos.', errorListado);
+    }
     const cuentas = await obtenerPresupuestosMayor(empresa.id, ejercicio);
     res.json({
       empresa: serializarEmpresa(empresa),
@@ -207,6 +260,25 @@ router.get('/', async (req, res) => {
       cuentas
     });
   } catch (err) {
+    if (esErrorConexionFirebird(err)) {
+      return res.status(503).json({
+        mensaje: 'No fue posible conectar con la base de datos de Firebird para esta empresa.'
+      });
+    }
+    if (esTablaPresupuestoInexistente(err)) {
+      let disponibles = Array.isArray(aniosDisponibles) ? aniosDisponibles : [];
+      if (!Array.isArray(aniosDisponibles) || aniosDisponibles.length === 0) {
+        try {
+          disponibles = await listarAniosPresupuestos(empresa.id);
+        } catch (listarError) {
+          console.warn('No fue posible obtener los ejercicios disponibles para respuesta 404.', listarError);
+        }
+      }
+      return res.status(404).json({
+        mensaje: 'No existe información de presupuestos para el ejercicio indicado.',
+        disponibles
+      });
+    }
     console.error('Error al consultar presupuestos:', err);
     res.status(500).json({ mensaje: 'No fue posible obtener la información de presupuestos.' });
   }

--- a/src/services/presupuestosMetadataService.js
+++ b/src/services/presupuestosMetadataService.js
@@ -13,6 +13,20 @@ const construirNombreTabla = (anio) => `PRESUP${anio.toString().slice(-2).padSta
 const ANIO_MIN = 2000;
 const ANIO_MAX = 2100;
 
+const esErrorConexionFirebird = (error) => {
+  const codigo = (error?.code || '').toString().toUpperCase();
+  if (['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'ETIMEDOUT'].includes(codigo)) {
+    return true;
+  }
+  const mensaje = (error?.message || '').toString().toUpperCase();
+  return (
+    mensaje.includes('UNABLE TO COMPLETE NETWORK REQUEST') ||
+    mensaje.includes('FAILED TO ESTABLISH A CONNECTION') ||
+    mensaje.includes('NETWORK REQUEST') ||
+    mensaje.includes('CONNECTION REJECTED')
+  );
+};
+
 const extraerAnio = (nombre) => {
   const normalizado = normalizarNombre(nombre);
   const match = normalizado.match(/^PRESUP[_]?(\d{1,4})$/);
@@ -46,6 +60,9 @@ async function listarDesdeMetadata(empresaId) {
     });
     return Array.from(anios);
   } catch (error) {
+    if (esErrorConexionFirebird(error)) {
+      throw error;
+    }
     console.warn('No fue posible consultar RDB$RELATIONS para PRESUP.', error);
     return [];
   }
@@ -67,6 +84,9 @@ async function detectarPorInspeccion(empresaId) {
         }
       }
     } catch (error) {
+      if (esErrorConexionFirebird(error)) {
+        throw error;
+      }
       // Tabla inexistente o sin permisos, continuar con el siguiente ano.
     }
   }


### PR DESCRIPTION
## Summary
- allow presupuesto queries to proceed when year enumeration returns empty results while still honoring explicit available-year lists
- reuse previously fetched exercises for 404 responses and warn on pre-query listing failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303ec36c44832d874f83f1b8f780df)