### PR TITLE
Update authorization workflow messaging

### DIFF
--- a/vistas/Finanzas.html
+++ b/vistas/Finanzas.html
@@ -359,7 +359,6 @@
                   <button id="btnAutorizar" class="btn btn-success btn-sm">Autorizar</button>
                   <button id="btnRechazar" class="btn btn-danger btn-sm">Rechazar</button>
                 </div>
-                <button id="btnGuardarAutorizado" class="btn btn-primary btn-sm d-none">Guardar en base de datos</button>
               </div>
               </div>
               </div>

--- a/vistas/RESUMEN.html
+++ b/vistas/RESUMEN.html
@@ -360,14 +360,6 @@
                   </button>
                   <button
                     type="button"
-                    class="btn btn-chip btn-primario d-none"
-                    id="btnGuardarAutorizado"
-                  >
-                    <i class="bi bi-save"></i>
-                    <span>Guardar</span>
-                  </button>
-                  <button
-                    type="button"
                     class="btn btn-chip btn-outline-secondary d-none"
                     id="btnVerBorrador"
                   >

--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -69,7 +69,6 @@
         verBorrador: 'btnVerBorrador',
         autorizar: 'btnAutorizar',
         rechazar: 'btnRechazar',
-        guardarAutorizado: 'btnGuardarAutorizado',
         panelRevision: 'panelRevision'
       };
       this._conectarEventos();
@@ -105,9 +104,6 @@
       }
       if (this.buttons.rechazar) {
         this.buttons.rechazar.addEventListener('click', () => this._handleRechazar());
-      }
-      if (this.buttons.guardarAutorizado) {
-        this.buttons.guardarAutorizado.addEventListener('click', () => this._handleGuardarFinal());
       }
     }
 
@@ -366,45 +362,6 @@
       }
     }
 
-    async _handleGuardarFinal() {
-      try {
-        if (!this.borradorActual?.id && this.hayCambios) {
-          await this._handleGuardar();
-        }
-        if (!this.borradorActual?.id) {
-          this._mostrarToast('No hay borrador autorizado para guardar.', 'warning');
-          return;
-        }
-        if (this.esAdminGlobal && this.borradorActual?.estado !== ESTADOS.APROBADO) {
-          await this._handleEnviar();
-        }
-        if (this.borradorActual?.estado !== ESTADOS.APROBADO) {
-          this._mostrarToast('El borrador debe estar autorizado antes de guardar.', 'warning');
-          return;
-        }
-
-        const respuesta = await fetch(`${API_BASE}/borradores/finalizar`, {
-          method: 'POST',
-          headers: this._construirHeaders(),
-          body: JSON.stringify({ borradorId: this.borradorActual.id })
-        });
-        const datos = await respuesta.json().catch(() => ({}));
-        if (!respuesta.ok) {
-          throw new Error(datos.mensaje || 'No fue posible guardar en base de datos.');
-        }
-        this.borradorActual = datos.borrador || null;
-        this.borradorGuardado = Boolean(this.borradorActual);
-        this.hayCambios = false;
-        this.verBorradorVisible = true;
-        FlujoAutorizacion.pintarBorrador(this.tableElement, this.borradorActual);
-        this._actualizarBotones();
-        this._mostrarToast(datos.mensaje || 'Información guardada en la base de datos.');
-      } catch (error) {
-        console.error('Error al guardar autorizado', error);
-        this._mostrarToast(error.message || 'No fue posible guardar en la base de datos.', 'danger');
-      }
-    }
-
     _handleCancelarEdicion() {
       this.hayCambios = false;
       this.verBorradorVisible = false;
@@ -456,8 +413,7 @@
         verBorrador,
         panelRevision,
         autorizar,
-        rechazar,
-        guardarAutorizado
+        rechazar
       } = this.buttons;
 
       const enEdicion = [ESTADOS.EDITANDO, ESTADOS.RECHAZADO, null].includes(estado);
@@ -499,13 +455,6 @@
         rechazar.classList.toggle('d-none', this.esAdminGlobal || ![ESTADOS.PENDIENTE, ESTADOS.REVISADO, ESTADOS.APROBADO].includes(estado));
       }
 
-      if (guardarAutorizado) {
-        const autorizado = estado === ESTADOS.APROBADO && this.borradorActual?.id;
-        const adminListo = this.esAdminGlobal && (this.borradorActual?.id || this.hayCambios);
-        const mostrarGuardarFinal = autorizado || adminListo;
-        guardarAutorizado.classList.toggle('d-none', !mostrarGuardarFinal);
-        guardarAutorizado.disabled = !mostrarGuardarFinal;
-      }
     }
 
     static pintarBorrador(tabla, datosBorrador) {

--- a/vistas/js/planeacion-modulo-vista.js
+++ b/vistas/js/planeacion-modulo-vista.js
@@ -72,7 +72,7 @@
     borrador: { texto: 'Borrador', descripcion: 'Edición local en curso.' },
     revisado: { texto: 'Revisado', descripcion: 'Listo para autorizar o volver a editar.' },
     autorizado: { texto: 'Autorizado', descripcion: 'Listo para guardar en base de datos.' },
-    guardado: { texto: 'Guardado', descripcion: 'Presupuesto comprometido en la base de datos.' }
+    guardado: { texto: 'Guardado', descripcion: 'Movimiento de guardado en el flujo de autorización.' }
   };
 
   const TRANSICIONES = {


### PR DESCRIPTION
## Summary
- remove the extra "Guardar en base de datos" action from Finanzas and resumen authorization controls
- simplify the authorization flow script by dropping the unused final-save button handling
- adjust the guardado workflow description to describe the authorization step rather than a database commit

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305e5d2958832dba045f554d8fc02c)