### PR TITLE
Fix Summary header column alignment

### DIFF
--- a/excels/SUMMARY_EMPRESA01_2022_report.md
+++ b/excels/SUMMARY_EMPRESA01_2022_report.md
@@ -1,0 +1,58 @@
+# Resumen técnico de SUMMARY EMPRESA01_2022.xlsx
+
+## Estructura del libro
+| Hoja | Filas | Columnas |
+| --- | ---: | ---: |
+| SALDOS18 | 3,148 | 46 |
+| ACUM18 | 5,000 | 27 |
+| SALDOS19 | 3,163 | 46 |
+| ACUM19 | 5,000 | 27 |
+| SALDOS20 | 3,179 | 47 |
+| ACUM20 | 5,000 | 27 |
+| SALDOS21 | 3,187 | 46 |
+| ACUM21 | 7,539 | 27 |
+| SALDOS22 | 3,187 | 46 |
+| ACUM22 | 7,539 | 27 |
+| SUMMARY_E01 | 110 | 20 |
+
+## SALDOS22
+Balances calculados sumando cargos y abonos mensuales para estimar el saldo final por cuenta y naturaleza.
+| Naturaleza | Inicial | Cargos | Abonos | Saldo final |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 383,960,091.90 | 40,934,469.26 | 35,880,512.52 | 389,014,048.64 |
+| 1 | 378,921,323.41 | 24,654,423.30 | 28,303,841.08 | 375,271,905.63 |
+| Total | 762,881,415.32 | 65,588,892.56 | 64,184,353.60 | 764,285,954.28 |
+
+Principales saldos finales:
+| # | Cuenta | Saldo final |
+| ---: | --- | ---: |
+| 1 | 300000000000000000001 (PATRIMONIO) | 105,275,865.56 |
+| 2 | 110000000000000000001 (PROPIEDADES Y EQUIPO) | 47,442,032.13 |
+| 3 | 100000000000000000001 (CAJA BANCOS) | 45,618,069.57 |
+| 4 | 100016000000000000002 (CASA DE BOLSA INTERACCIONES/BANORTE IXE) | 44,061,731.38 |
+| 5 | 107000000000000000001 (BONOS, VALORES, INVERSIONES BCOS.) | 41,117,205.87 |
+
+## ACUM22
+Acumulados mensuales comparados contra el presupuesto anual por naturaleza.
+| Naturaleza | YTD | Presupuesto | Variación | Variación % |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 4,668,168,583.74 | 963,634,057.01 | 3,704,534,526.73 | 384.43% |
+| 1 | 4,590,848,894.31 | 858,584,007.08 | 3,732,264,887.23 | 434.70% |
+
+Variaciones más favorables (mayor superávit sobre presupuesto):
+| Cuenta | YTD | Presupuesto | Variación |
+| --- | ---: | ---: | ---: |
+| 300000000000000000001 | 1,263,310,386.71 | 0.00 | 1,263,310,386.71 |
+| 110000000000000000001 | 569,304,385.54 | 0.00 | 569,304,385.54 |
+| 100000000000000000001 | 547,416,834.78 | 0.00 | 547,416,834.78 |
+| 100016000000000000002 | 528,740,776.56 | 0.00 | 528,740,776.56 |
+| 107000000000000000001 | 493,406,470.44 | 0.00 | 493,406,470.44 |
+
+Variaciones más desfavorables (mayor déficit sobre presupuesto):
+| Cuenta | YTD | Presupuesto | Variación |
+| --- | ---: | ---: | ---: |
+| 240004000000000000002 | -348,250,708.68 | 0.00 | -348,250,708.68 |
+| 240004001000000000003 | -341,084,924.88 | 0.00 | -341,084,924.88 |
+| 450000000000000000001 | 0.00 | 175,377,814.54 | -175,377,814.54 |
+| 401000000000000000001 | -0.00 | 167,553,745.00 | -167,553,745.00 |
+| 401001000000000000002 | -0.00 | 167,553,745.00 | -167,553,745.00 |

--- a/scripts/analyze_summary_empresa01_2022.py
+++ b/scripts/analyze_summary_empresa01_2022.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+import pandas as pd
+
+EXCEL_PATH = Path(__file__).resolve().parent.parent / "excels" / "SUMMARY EMPRESA01_2022.xlsx"
+REPORT_PATH = Path(__file__).resolve().parent.parent / "excels" / "SUMMARY_EMPRESA01_2022_report.md"
+
+def load_workbook(path: Path) -> pd.ExcelFile:
+    return pd.ExcelFile(path)
+
+def summarize_sheet_shapes(xls: pd.ExcelFile) -> str:
+    lines = ["| Hoja | Filas | Columnas |", "| --- | ---: | ---: |"]
+    for sheet in xls.sheet_names:
+        df = pd.read_excel(xls, sheet)
+        lines.append(f"| {sheet} | {len(df):,} | {df.shape[1]} |")
+    return "\n".join(lines)
+
+def summarize_saldos22(xls: pd.ExcelFile) -> tuple[str, str]:
+    saldos = pd.read_excel(xls, "SALDOS22")
+    cargo_cols = [c for c in saldos.columns if c.startswith("CARGO")]
+    abono_cols = [c for c in saldos.columns if c.startswith("ABONO")]
+
+    saldos = saldos.assign(
+        TOTAL_CARGO=saldos[cargo_cols].sum(axis=1),
+        TOTAL_ABONO=saldos[abono_cols].sum(axis=1),
+    )
+    saldos["SALDO_FINAL"] = saldos["INICIAL"] + saldos["TOTAL_CARGO"] - saldos["TOTAL_ABONO"]
+
+    grouped = saldos.groupby("NATURALEZA")[
+        ["INICIAL", "TOTAL_CARGO", "TOTAL_ABONO", "SALDO_FINAL"]
+    ].sum()
+    overall = grouped.sum()
+
+    table_lines = ["| Naturaleza | Inicial | Cargos | Abonos | Saldo final |", "| --- | ---: | ---: | ---: | ---: |"]
+    for naturaleza, row in grouped.iterrows():
+        table_lines.append(
+            f"| {int(naturaleza)} | {row['INICIAL']:,.2f} | {row['TOTAL_CARGO']:,.2f} | {row['TOTAL_ABONO']:,.2f} | {row['SALDO_FINAL']:,.2f} |"
+        )
+    table_lines.append(
+        f"| Total | {overall['INICIAL']:,.2f} | {overall['TOTAL_CARGO']:,.2f} | {overall['TOTAL_ABONO']:,.2f} | {overall['SALDO_FINAL']:,.2f} |"
+    )
+
+    top_table = ["| # | Cuenta | Saldo final |", "| ---: | --- | ---: |"]
+    for idx, row in saldos.nlargest(5, "SALDO_FINAL").iterrows():
+        top_table.append(
+            f"| {len(top_table)-1} | {row['NUM_CTA']} ({row['NOMBRE']}) | {row['SALDO_FINAL']:,.2f} |"
+        )
+
+    return "\n".join(table_lines), "\n".join(top_table)
+
+def summarize_acum22(xls: pd.ExcelFile) -> tuple[str, str, str]:
+    acum = pd.read_excel(xls, "ACUM22")
+    month_cols = [
+        "ENERO", "FEBRERO", "MARZO", "ABRIL", "MAYO", "JUNIO",
+        "JULIO", "AGOSTO", "SEPTIEMBRE", "OCTUBRE", "NOVIEMBRE", "DICIEMBRE",
+    ]
+    presup_cols = [f"PRESUP{str(i).zfill(2)}" for i in range(1, 13)]
+
+    acum = acum.assign(
+        YTD=acum[month_cols].sum(axis=1),
+        PRESUP_TOTAL=acum[presup_cols].sum(axis=1),
+    )
+    acum["VAR_ABS"] = acum["YTD"] - acum["PRESUP_TOTAL"]
+    acum["VAR_PCT"] = acum["VAR_ABS"] / acum["PRESUP_TOTAL"].replace({0: pd.NA}) * 100
+
+    grouped = acum.groupby("NATURALEZA")[["YTD", "PRESUP_TOTAL", "VAR_ABS"]].sum()
+    grouped["VAR_PCT"] = grouped["VAR_ABS"] / grouped["PRESUP_TOTAL"] * 100
+
+    table_lines = ["| Naturaleza | YTD | Presupuesto | Variación | Variación % |", "| --- | ---: | ---: | ---: | ---: |"]
+    for naturaleza, row in grouped.iterrows():
+        table_lines.append(
+            f"| {int(naturaleza)} | {row['YTD']:,.2f} | {row['PRESUP_TOTAL']:,.2f} | {row['VAR_ABS']:,.2f} | {row['VAR_PCT']:,.2f}% |"
+        )
+
+    favorable = acum.nlargest(5, "VAR_ABS")
+    unfavorable = acum.nsmallest(5, "VAR_ABS")
+
+    def variance_table(df: pd.DataFrame, title: str) -> str:
+        lines = [f"| {title} | YTD | Presupuesto | Variación |", "| --- | ---: | ---: | ---: |"]
+        for _, row in df.iterrows():
+            lines.append(
+                f"| {row['CUENTA']} | {row['YTD']:,.2f} | {row['PRESUP_TOTAL']:,.2f} | {row['VAR_ABS']:,.2f} |"
+            )
+        return "\n".join(lines)
+
+    return "\n".join(table_lines), variance_table(favorable, "Cuenta"), variance_table(unfavorable, "Cuenta")
+
+def build_report() -> None:
+    xls = load_workbook(EXCEL_PATH)
+    sheet_summary = summarize_sheet_shapes(xls)
+    saldos_table, saldos_top = summarize_saldos22(xls)
+    acum_table, acum_fav, acum_unfav = summarize_acum22(xls)
+
+    report = f"""# Resumen técnico de SUMMARY EMPRESA01_2022.xlsx
+
+## Estructura del libro
+{sheet_summary}
+
+## SALDOS22
+Balances calculados sumando cargos y abonos mensuales para estimar el saldo final por cuenta y naturaleza.
+{saldos_table}
+
+Principales saldos finales:
+{saldos_top}
+
+## ACUM22
+Acumulados mensuales comparados contra el presupuesto anual por naturaleza.
+{acum_table}
+
+Variaciones más favorables (mayor superávit sobre presupuesto):
+{acum_fav}
+
+Variaciones más desfavorables (mayor déficit sobre presupuesto):
+{acum_unfav}
+"""
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    print(f"Reporte generado en {REPORT_PATH}")
+
+if __name__ == "__main__":
+    build_report()

--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -496,45 +496,22 @@
               <table class="table align-middle mb-0" id="mainTable">
                 <thead>
                   <tr>
-                    <th class="account-column-header"></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <td colspan="1" class="ytd-head">Y&nbsp;T&nbsp;D</td>
+                    <th class="account-column-header" rowspan="2">Cuenta</th>
+                    <th colspan="5">Mes <span class="anio-seleccionado">2025</span></th>
+                    <th rowspan="2">Descripción</th>
+                    <th colspan="5" class="ytd-head">YTD <span class="anio-seleccionado">2025</span></th>
                   </tr>
                   <tr class="subhdr">
-                    <th class="account-column-header"></th>
-                    <th>Cuentas</th>
                     <th>Actual</th>
                     <th>Plan</th>
-                    <th><span class="anio-seleccionado">2025</span></th>
-                    <th>B/(W)%</th>
-                    <th></th>
-                    <th>Descripción</th>
+                    <th><span class="anio-seleccionado-anterior">2025</span></th>
+                    <th>B/(W)% vs. Plan</th>
+                    <th>B/(W)% vs. <span class="anio-seleccionado-anterior">2025</span></th>
                     <th>Actual</th>
                     <th>Plan</th>
-                    <th><span class="anio-seleccionado">2025</span></th>
-                    <th>B/(W)%</th>
-                    <th></th>
-                  </tr>
-                  <tr class="subhdr">
-                    <th class="account-column-header"></th>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td>vs. Plan</td>
-                    <td>vs. <span class="anio-seleccionado-anterior">2025</span></td>
-                    <th></th>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td>vs. Plan</td>
-                    <td>vs. <span class="anio-seleccionado-anterior">2025</span></td>
+                    <th><span class="anio-seleccionado-anterior">2025</span></th>
+                    <th>B/(W)% vs. Plan</th>
+                    <th>B/(W)% vs. <span class="anio-seleccionado-anterior">2025</span></th>
                   </tr>
                 </thead>
                 <tbody id="summaryTableBody"></tbody>

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -121,7 +121,21 @@ const MES_A_PERIODO = {
 
 // Actualiza todos los <span class="anio">...</span> en el header
 const setAllYearSpans = (anio) => {
-  document.querySelectorAll('.anio').forEach(sp => sp.textContent = anio);
+  const numero = Number(anio);
+  const textoAnio = Number.isFinite(numero) ? String(numero) : '—';
+  const textoAnterior = Number.isFinite(numero) ? String(numero - 1) : '—';
+
+  document.querySelectorAll('.anio').forEach((sp) => {
+    sp.textContent = textoAnio;
+  });
+
+  document.querySelectorAll('.anio-seleccionado').forEach((sp) => {
+    sp.textContent = textoAnio;
+  });
+
+  document.querySelectorAll('.anio-seleccionado-anterior').forEach((sp) => {
+    sp.textContent = textoAnterior;
+  });
 };
 // Actualiza todos los <span class="mes">...</span> en el header
 const setAllMonthSpans = (mesNombre) => {


### PR DESCRIPTION
## Summary
- align SUMMARY header layout with the 12 data columns (account, mes metrics, descripción, YTD metrics)
- update header year spans so monthly and YTD sections reflect the selected and prior years consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930679a1494832daa3940c060f1145a)