### PR TITLE
Organiza summary y resumen por capítulo

### DIFF
--- a/info IMPORTANTE/cuentas_summary_resumen_por_capitulo.md
+++ b/info IMPORTANTE/cuentas_summary_resumen_por_capitulo.md
@@ -1,0 +1,262 @@
+# CUENTAS SUMMARY y RESUMEN por capítulo
+
+## CIUDAD DE MÉXICO
+
+### SUMMARY
+| CAPITULO         | SECCIÓN Principal   | SECCION Secundaria     |                CUENTA | NOMBRE                                      |
+|:-----------------|:--------------------|:-----------------------|----------------------:|:--------------------------------------------|
+| CIUDAD DE MÉXICO | CDMX Expense        | Committees             | 702000000000000000001 | Servicio a la membresia                     |
+| CIUDAD DE MÉXICO | CDMX Expense        | Committees             | 704000000000000000001 | Portafolio Económico                        |
+| CIUDAD DE MÉXICO | CDMX Expense        | Events                 | 701000000000000000001 | Costo Eventos                               |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801001000000000000002 | Desarrollo de Negocios                      |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801002000000000000002 | Relaciones Externas                         |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801003000000000000002 | Servicios a las membresia                   |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801004000000000000002 | Vicepresidencia                             |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801005000000000000002 | Finanzas                                    |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801006000000000000002 | Administración                              |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801007000000000000002 | Sistemas                                    |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801008000000000000002 | Empleos                                     |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801009000000000000002 | Servicios Generakes (Almacén)               |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801010000000000000002 | Eventos                                     |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801011000000000000002 | Comites                                     |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801012000000000000002 | Renta de Salas                              |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos administrativos | 801013000000000000002 | Comunicación                                |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 513000000000000000001 | Nomina Vicepresidencia                      |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 514000000000000000001 | Nomina Administración y Finanzas            |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 515000000000000000001 | Nomina Servicios a la Membresia             |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 516000000000000000001 | Nomina Comites y Relaciones Externas        |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 517000000000000000001 | Nomina Desarrollo de Negocios               |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 518000000000000000001 | Nomina Eventos y Mercadotecnia              |
+| CIUDAD DE MÉXICO | CDMX Expense        | Gastos de Nomina       | 519000000000000000001 | Nomina Comunicación                         |
+| CIUDAD DE MÉXICO | CDMX Expense        | Membership             | 705000000000000000001 | Gastos Promoción                            |
+| CIUDAD DE MÉXICO | CDMX Expense        | Other                  | 901000000000000000001 | Gastos Generales                            |
+| CIUDAD DE MÉXICO | CDMX Expense        | Services to Members    | 601000000000000000001 | Costo  directo de publicaciones             |
+| CIUDAD DE MÉXICO | CDMX Income         | Committees             | 403000000000000000001 | Patrocinios por Comites                     |
+| CIUDAD DE MÉXICO | CDMX Income         | Committees             | 417000000000000000001 | Committees                                  |
+| CIUDAD DE MÉXICO | CDMX Income         | Events                 | 407000000000000000001 | Eventos                                     |
+| CIUDAD DE MÉXICO | CDMX Income         | Events                 | 408000000000000000001 | Patrocinios                                 |
+| CIUDAD DE MÉXICO | CDMX Income         | Membership             | 401000000000000000001 | Cuotas Netas                                |
+| CIUDAD DE MÉXICO | CDMX Income         | Membership             | 402000000000000000001 | Ingresos socios nuevos                      |
+| CIUDAD DE MÉXICO | CDMX Income         | Membership             | 412000000000000000001 | Economex                                    |
+| CIUDAD DE MÉXICO | CDMX Income         | Services to Members    | 406000000000000000001 | Bolsa de Trabajo                            |
+| CIUDAD DE MÉXICO | CDMX Income         | Services to Members    | 409000000000000000001 | Venta Publicaciones                         |
+| CIUDAD DE MÉXICO | Guadalajara Expense | Guadalajara Expense    | 950001002000000000003 | Gastos Guadalajara                          |
+| CIUDAD DE MÉXICO | Guadalajara Income  | Guadalajara Income     | 450001000000000000002 | Guadalajara Income                          |
+| CIUDAD DE MÉXICO | Monterrey Expense   | Monterrey Expense      | 950002002000000000003 | Gastos Monterrey                            |
+| CIUDAD DE MÉXICO | Monterrey Income    | Monterrey Income       | 450002000000000000002 | Monterrey Income                            |
+| CIUDAD DE MÉXICO | Other Income        | México  Other Income   | 413000000000000000001 | Otros Ingresos                              |
+| CIUDAD DE MÉXICO | Other Income        | México  Other Income   | 414000000000000000001 | Intereses Bancos                            |
+| CIUDAD DE MÉXICO | Other Income        | México  Other Income   | 416000000000000000001 | Utilidad Cambiaria Inversiones              |
+| CIUDAD DE MÉXICO | Other Income        | México  Other Income   | 418000000000000000001 | Plusvalia/Minusvalia Portafolio Inversiones |
+
+### RESUMEN
+| CAPITULO         | SECCIÓN Principal   | SECCION Secundaria     | CUENTA         | NOMBRE                                      |
+|:-----------------|:--------------------|:-----------------------|:---------------|:--------------------------------------------|
+| CIUDAD DE MÉXICO | EXPENSE             | Committees             | 521-000-000-00 | Comisiones EWDP y Economex                  |
+| CIUDAD DE MÉXICO | EXPENSE             | Committees             | 702-000-000-00 | Costo Comités                               |
+| CIUDAD DE MÉXICO | EXPENSE             | Committees             | 704-000-000-00 | Costo Economex                              |
+| CIUDAD DE MÉXICO | EXPENSE             | Events                 | 701-000-000-00 | Costo Eventos                               |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-001-000-00 | Desarrollo de Negocios                      |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-002-000-00 | Relaciones Externas                         |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-003-000-00 | Servicios a las membresia                   |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-004-000-00 | Vicepresidencia                             |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-005-000-00 | Finanzas                                    |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-006-000-00 | Administración                              |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-007-000-00 | Sistemas                                    |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-008-000-00 | Empleos                                     |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-009-000-00 | Servicios Generales (Almacén)               |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-010-000-00 | Eventos                                     |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-011-000-00 | Comites                                     |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-012-000-00 | Renta de Salas                              |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Administrativos | 801-013-000-00 | Comunicación                                |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Corporativos    | 903-000-000-00 | Gastos Corporativos                         |
+| CIUDAD DE MÉXICO | EXPENSE             | Gastos Generales       | 901-000-000-00 | Gastos Generales                            |
+| CIUDAD DE MÉXICO | EXPENSE             | Guadalajara Expense    | 950-001-000-00 | Guadalajara Expense                         |
+| CIUDAD DE MÉXICO | EXPENSE             | Membership             | 520-000-000-00 | Comsiones por venta de membresía            |
+| CIUDAD DE MÉXICO | EXPENSE             | Membership             | 705-000-000-00 | Gastos Promoción                            |
+| CIUDAD DE MÉXICO | EXPENSE             | Monterrey Expense      | 950-002-000-00 | Monterrey Expense                           |
+| CIUDAD DE MÉXICO | EXPENSE             | Northwest Expense      | 950-003-000-00 | Northwest Expense                           |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 513-000-000-00 | Nomina Vicepresidencia                      |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 514-000-000-00 | Nomina Administración y Finanzas            |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 515-000-000-00 | Nomina Servicios a la Membresia             |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 516-000-000-00 | Nomina Comites y Relaciones Externas        |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 517-000-000-00 | Nomina Desarrollo de Negocios               |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 518-000-000-00 | Nomina Eventos y Mercadotecnia              |
+| CIUDAD DE MÉXICO | EXPENSE             | Nómina                 | 519-000-000-00 | Nomina Comunicación                         |
+| CIUDAD DE MÉXICO | EXPENSE             | Services to Members    | 601-002-003-00 | Costo Venta Publicaciones                   |
+| CIUDAD DE MÉXICO | EXPENSE             | Services to Members    | 601-003-001-00 | Costo Digital Training                      |
+| CIUDAD DE MÉXICO | EXPENSE             | T&IC                   | 703-000-000-00 | Costo Trade & Investment Center             |
+| CIUDAD DE MÉXICO | INCOME              | Committees             | 412-000-000-00 | Economex                                    |
+| CIUDAD DE MÉXICO | INCOME              | Committees             | 417-000-000-00 | Comités                                     |
+| CIUDAD DE MÉXICO | INCOME              | Events                 | 407-000-000-00 | Eventos                                     |
+| CIUDAD DE MÉXICO | INCOME              | Events                 | 408-000-000-00 | Patrocinios                                 |
+| CIUDAD DE MÉXICO | INCOME              | Guadalajara Income     | 450-001-000-00 | Guadalajara Income                          |
+| CIUDAD DE MÉXICO | INCOME              | Membership             | 401-000-000-00 | Cuotas Netas                                |
+| CIUDAD DE MÉXICO | INCOME              | Membership             | 402-000-000-00 | Ingresos socios nuevos                      |
+| CIUDAD DE MÉXICO | INCOME              | Monterrey Income       | 450-002-000-00 | Monterrey Income                            |
+| CIUDAD DE MÉXICO | INCOME              | Northwest Income       | 450-003-000-00 | Northwest Income                            |
+| CIUDAD DE MÉXICO | INCOME              | Services to Members    | 406-001-000-00 | Venta Publicaciones                         |
+| CIUDAD DE MÉXICO | INCOME              | Services to Members    | 406-002-000-00 | Digital Training                            |
+| CIUDAD DE MÉXICO | INCOME              | Services to Members    | 409-000-000-00 | Visas                                       |
+| CIUDAD DE MÉXICO | INCOME              | T&IC                   | 405-000-000-00 | Trade & Investment Center                   |
+| CIUDAD DE MÉXICO | MORE                | Member Centricity      | 902-000-000-00 | Member Centricity                           |
+| CIUDAD DE MÉXICO | MORE                | Other                  | 413-000-000-00 | Otros Ingresos                              |
+| CIUDAD DE MÉXICO | MORE                | Other                  | 414-000-000-00 | Intereses Bancos                            |
+| CIUDAD DE MÉXICO | MORE                | Other                  | 416-000-000-00 | Utilidad Cambiaria Inversiones              |
+| CIUDAD DE MÉXICO | MORE                | Other                  | 418-000-000-00 | Plusvalia/Minusvalia Portafolio Inversiones |
+
+## GUADALAJARA
+
+### SUMMARY
+| CAPITULO    | SECCIÓN Principal   | SECCION Secundaria     |                CUENTA | NOMBRE                             |
+|:------------|:--------------------|:-----------------------|----------------------:|:-----------------------------------|
+| GUADALAJARA | Guadalajara Expense | CARGOS ADMINISTRATIVOS | 903016000000000000002 | CARGOS ADMINISTRATIVOS             |
+| GUADALAJARA | Guadalajara Expense | Events and Committees  | 502000000000000000001 | Costo comités                      |
+| GUADALAJARA | Guadalajara Expense | Events and Committees  | 701000000000000000001 | Costo Eventos                      |
+| GUADALAJARA | Guadalajara Expense | G&A                    | 501000000000000000001 | Nómina Guadalajara                 |
+| GUADALAJARA | Guadalajara Expense | G&A                    | 801000000000000000001 | Gasto de local                     |
+| GUADALAJARA | Guadalajara Expense | G&A                    | 901000000000000000001 | Gastos de Administracion           |
+| GUADALAJARA | Guadalajara Expense | Gastos Corporativos    | 903000000000000000001 | Gastos Corporativos                |
+| GUADALAJARA | Guadalajara Expense | Other                  | 904000000000000000001 | Gastos extraordinarios             |
+| GUADALAJARA | Guadalajara Expense | Services to Members    | 601000000000000000001 | Gastos directos de publicación     |
+| GUADALAJARA | Guadalajara Expense | Services to Members    | 702000000000000000001 | Costo de publicidad                |
+| GUADALAJARA | Guadalajara Expense | Services to Members    | 902000000000000000001 | Gtos promoción y juntas de trabajo |
+| GUADALAJARA | Guadalajara Income  | Events and Committees  | 404000000000000000001 | Comités                            |
+| GUADALAJARA | Guadalajara Income  | Events and Committees  | 405000000000000000001 | Eventos                            |
+| GUADALAJARA | Guadalajara Income  | Membership             | 400000000000000000001 | Cuotas Netas                       |
+| GUADALAJARA | Guadalajara Income  | Membership             | 401000000000000000001 | Ingresos socios nuevos             |
+| GUADALAJARA | Guadalajara Income  | Services to Members    | 403000000000000000001 | Venta Publicaciones                |
+| GUADALAJARA | Guadalajara Income  | Services to Members    | 406000000000000000001 | Bolsa de Trabajo                   |
+| GUADALAJARA | Guadalajara Income  | Services to Members    | 407000000000000000001 | Publicidad                         |
+| GUADALAJARA | Guadalajara Income  | Services to Members    | 408000000000000000001 | Visas                              |
+| GUADALAJARA | Guadalajara Income  | Services to Members    | 409000000000000000001 | Información comercial              |
+| GUADALAJARA | Other               | Other                  | 402000000000000000001 | Otros ingresos                     |
+| GUADALAJARA | Other               | Other                  | 410000000000000000001 | Utilidad cambiaria                 |
+
+### RESUMEN
+| CAPITULO    | SECCIÓN Principal   | SECCION Secundaria     | CUENTA         | NOMBRE                             |
+|:------------|:--------------------|:-----------------------|:---------------|:-----------------------------------|
+| GUADALAJARA | EXPENSE             | Cargos Administrativos | 903-016-000-00 | Cargos Administrativos             |
+| GUADALAJARA | EXPENSE             | Commitees              | 502-000-000-00 | Costo comités                      |
+| GUADALAJARA | EXPENSE             | Commitees              | 504-000-000-00 | Comisiones EWDP                    |
+| GUADALAJARA | EXPENSE             | Events                 | 701-000-000-00 | Costo Eventos                      |
+| GUADALAJARA | EXPENSE             | Gastos Corporativos    | 903-000-000-00 | Gastos Corporativos                |
+| GUADALAJARA | EXPENSE             | Gastos G&A             | 801-000-000-00 | Gasto de Administración            |
+| GUADALAJARA | EXPENSE             | Gastos G&A             | 901-000-000-00 | Gastos Generales                   |
+| GUADALAJARA | EXPENSE             | Membership             | 503-000-000-00 | Comisiones por venta de membresías |
+| GUADALAJARA | EXPENSE             | Membership             | 702-000-000-00 | Gastos Promoción                   |
+| GUADALAJARA | EXPENSE             | Nómina                 | 501-000-000-00 | Nómina                             |
+| GUADALAJARA | EXPENSE             | Services to Members    | 601-000-000-00 | Gastos Venta Publicaciones         |
+| GUADALAJARA | EXPENSE             | T&IC                   | 703-000-000-00 | Costo Trade & Investment Center    |
+| GUADALAJARA | INCOME              | Commitees              | 404-000-000-00 | Comités                            |
+| GUADALAJARA | INCOME              | Events                 | 405-000-000-00 | Eventos                            |
+| GUADALAJARA | INCOME              | Events                 | 406-000-000-00 | Patrocinios                        |
+| GUADALAJARA | INCOME              | Membership             | 400-000-000-00 | Cuotas Netas                       |
+| GUADALAJARA | INCOME              | Membership             | 401-000-000-00 | Ingresos socios nuevos             |
+| GUADALAJARA | INCOME              | Services to Members    | 403-000-000-00 | Venta Publicaciones                |
+| GUADALAJARA | INCOME              | Services to Members    | 408-000-000-00 | Visas                              |
+| GUADALAJARA | INCOME              | T&IC                   | 407-000-000-00 | Trade & Investment Center          |
+| GUADALAJARA | OPERATING RESULTS   | Member Centricity      | 904-000-000-00 | Member Centricity                  |
+| GUADALAJARA | OPERATING RESULTS   | Other                  | 402-000-000-00 | Otros ingresos                     |
+| GUADALAJARA | OPERATING RESULTS   | Other                  | 410-000-000-00 | Utilidad cambiaria                 |
+
+## NORESTE
+
+### SUMMARY
+| CAPITULO   | SECCIÓN Principal   | SECCION Secundaria     |                CUENTA | NOMBRE                            |
+|:-----------|:--------------------|:-----------------------|----------------------:|:----------------------------------|
+| NORESTE    | Monterrey Expense   | CARGOS ADMINISTRATIVOS | 810000000000000000001 | no deducibles                     |
+| NORESTE    | Monterrey Expense   | CARGOS ADMINISTRATIVOS | 900001000000000000002 | CARGOS ADMINISTRATIVOS            |
+| NORESTE    | Monterrey Expense   | Events and Committees  | 701000000000000000001 | Gastos Junta de Comité            |
+| NORESTE    | Monterrey Expense   | Events and Committees  | 702000000000000000001 | Gastos Junta de Consejo           |
+| NORESTE    | Monterrey Expense   | Events and Committees  | 703000000000000000001 | Juntas de Comité Extraordinarias  |
+| NORESTE    | Monterrey Expense   | Events and Committees  | 705000000000000000001 | Eventos                           |
+| NORESTE    | Monterrey Expense   | G&A                    | 501000000000000000001 | Nómina                            |
+| NORESTE    | Monterrey Expense   | G&A                    | 704000000000000000001 | Cuotas club de industriales       |
+| NORESTE    | Monterrey Expense   | G&A                    | 800000000000000000001 | Gastos administrativos            |
+| NORESTE    | Monterrey Expense   | G&A                    | 801000000000000000001 | Comisiones bancarias              |
+| NORESTE    | Monterrey Expense   | G&A                    | 802000000000000000001 | Gastos Generales                  |
+| NORESTE    | Monterrey Expense   | Gastos Corporativos    | 900000000000000000001 | Gastos Corporativos               |
+| NORESTE    | Monterrey Expense   | Membership             | 707000000000000000001 | Cuotas                            |
+| NORESTE    | Monterrey Expense   | Membership             | 707000000000000000001 | Comsiones por venta de membresía  |
+| NORESTE    | Monterrey Expense   | Membership             | 707000000000000000001 | Paquete Anual                     |
+| NORESTE    | Monterrey Expense   | Other expenses         | 808000000000000000001 | Other                             |
+| NORESTE    | Monterrey Expense   | Services to Members    | 600000000000000000001 | Costo de publicaciones            |
+| NORESTE    | Monterrey Expense   | Services to Members    | 706000000000000000001 | Visas                             |
+| NORESTE    | Monterrey Expense   | Services to Members    | 800007000000000000002 | Becarios                          |
+| NORESTE    | Monterrey Expense   | Services to Members    | 901002000000000000002 | Campaña Institucional             |
+| NORESTE    | Monterrey Expense   | Services to Members    | 901002000000000000002 | Sistema de proveedores confiables |
+| NORESTE    | Monterrey Income    | Events and Committees  | 407000000000000000001 | Comités                           |
+| NORESTE    | Monterrey Income    | Events and Committees  | 408000000000000000001 | Eventos                           |
+| NORESTE    | Monterrey Income    | Events and Committees  | 414000000000000000001 | Eventos especiales                |
+| NORESTE    | Monterrey Income    | Membership             | 400000000000000000001 | Cuotas Netas                      |
+| NORESTE    | Monterrey Income    | Membership             | 401000000000000000001 | Ingresos socios nuevos            |
+| NORESTE    | Monterrey Income    | Services to Members    | 404000000000000000001 | Venta de publicidad               |
+| NORESTE    | Monterrey Income    | Services to Members    | 405000000000000000001 | Infocenter                        |
+| NORESTE    | Monterrey Income    | Services to Members    | 406000000000000000001 | Bolsa de trabajo                  |
+| NORESTE    | Monterrey Income    | Services to Members    | 410000000000000000001 | Venta de publicaciones            |
+| NORESTE    | Monterrey Income    | Services to Members    | 412000000000000000001 | Visas                             |
+| NORESTE    | Other               | Other                  | 403000000000000000001 | Otros ingresos                    |
+| NORESTE    | Other               | Other                  | 409000000000000000001 | Utilidad cambiaria                |
+| NORESTE    | Other               | Other                  | 413000000000000000001 | Rendimientos bancarios            |
+
+### RESUMEN
+| CAPITULO   | SECCIÓN Principal   | SECCION Secundaria     | CUENTA         | NOMBRE                           |
+|:-----------|:--------------------|:-----------------------|:---------------|:---------------------------------|
+| NORESTE    | EXPENSE             | Gastos G&A             | 802-000-000-00 | Gastos Generales                 |
+| NORESTE    | EXPENSE             | Gastos G&A             | 803-000-000-00 | Gastos administrativos           |
+| NORESTE    | EXPENSE             | Cargos Administrativos | 900-001-000-00 | Cargos Administrativos           |
+| NORESTE    | EXPENSE             | Committees             | 504-000-000-00 | Comisiones EWDP                  |
+| NORESTE    | EXPENSE             | Committees             | 701-000-000-00 | Costo Comités                    |
+| NORESTE    | EXPENSE             | Events                 | 705-000-000-00 | Eventos                          |
+| NORESTE    | EXPENSE             | Gastos Corporativos    | 900-000-000-00 | Gastos Corporativos              |
+| NORESTE    | EXPENSE             | Membership             | 502-000-000-00 | Comsiones por venta de membresía |
+| NORESTE    | EXPENSE             | Membership             | 708-000-000-00 | Gastos de Promoción              |
+| NORESTE    | EXPENSE             | Nómina                 | 501-000-000-00 | Nómina                           |
+| NORESTE    | EXPENSE             | Services to Members    | 600-000-000-00 | Costo de publicaciones           |
+| NORESTE    | EXPENSE             | Services to Members    | 706-000-000-00 | Visas                            |
+| NORESTE    | EXPENSE             | T&IC                   | 602-000-000-00 | Costo Trade&Investment Center    |
+| NORESTE    | INCOME              | Committees             | 408-000-000-00 | Comités                          |
+| NORESTE    | INCOME              | Events                 | 406-000-000-00 | Eventos                          |
+| NORESTE    | INCOME              | Events                 | 414-000-000-00 | Patrocinios                      |
+| NORESTE    | INCOME              | Membership             | 400-000-000-00 | Cuotas Netas                     |
+| NORESTE    | INCOME              | Membership             | 401-000-000-00 | Ingresos socios nuevos           |
+| NORESTE    | INCOME              | Services to Members    | 410-000-000-00 | Venta de publicaciones           |
+| NORESTE    | INCOME              | Services to Members    | 412-000-000-00 | Visas                            |
+| NORESTE    | INCOME              | T&IC                   | 405-000-000-00 | Trade & Investment Center        |
+| NORESTE    | OPERATING RESULTS   | Member Centricity      | 901-000-000-00 | Member Centricity                |
+| NORESTE    | OPERATING RESULTS   | Other                  | 403-000-000-00 | Otros ingresos                   |
+| NORESTE    | OPERATING RESULTS   | Other                  | 409-000-000-00 | Utilidad cambiaria               |
+| NORESTE    | OPERATING RESULTS   | Other                  | 413-000-000-00 | Rendimientos bancarios           |
+| NORESTE    | OPERATING RESULTS   | Other                  | 804-000-000-00 | Pérdida cambiaria                |
+
+## NOROESTE
+
+### SUMMARY
+No hay filas de SUMMARY para este capítulo.
+
+### RESUMEN
+| CAPITULO   | SECCIÓN Principal   | SECCION Secundaria     | CUENTA         | NOMBRE                             |
+|:-----------|:--------------------|:-----------------------|:---------------|:-----------------------------------|
+| NOROESTE   | EXPENSE             | Gastos G&A             | 801-000-000-00 | Gastos de Administracion           |
+| NOROESTE   | EXPENSE             | Gastos G&A             | 901-000-000-00 | Gastos Generales                   |
+| NOROESTE   | EXPENSE             | Cargos Administrativos | 903-001-000-00 | Cargos Administrativos             |
+| NOROESTE   | EXPENSE             | Committees             | 504-000-000-00 | Comisiones EWDP                    |
+| NOROESTE   | EXPENSE             | Committees             | 701-000-000-00 | Costo comités                      |
+| NOROESTE   | EXPENSE             | Events                 | 702-000-000-00 | Costo Eventos                      |
+| NOROESTE   | EXPENSE             | Gastos Corporativos    | 903-000-000-00 | Gtos. Corporativos                 |
+| NOROESTE   | EXPENSE             | Membership             | 503-000-000-00 | Comisiones por venta de membresías |
+| NOROESTE   | EXPENSE             | Membership             | 605-000-000-00 | Gastos Promoción                   |
+| NOROESTE   | EXPENSE             | Nómina                 | 501-000-000-00 | Nómina                             |
+| NOROESTE   | EXPENSE             | Services to Members    | 601-000-000-00 | Gastos Venta Publicaciones         |
+| NOROESTE   | EXPENSE             | T&IC                   | 703-000-000-00 | Costo Trade & Investment Center    |
+| NOROESTE   | INCOME              | Committees             | 403-000-000-00 | Comités                            |
+| NOROESTE   | INCOME              | Events                 | 404-000-000-00 | Eventos                            |
+| NOROESTE   | INCOME              | Events                 | 406-000-000-00 | Patrocinios                        |
+| NOROESTE   | INCOME              | Membership             | 400-000-000-00 | Cuotas Netas                       |
+| NOROESTE   | INCOME              | Membership             | 401-000-000-00 | Cuotas de Inscripción              |
+| NOROESTE   | INCOME              | Services to Members    | 402-001-000-00 | Venta Publicaciones                |
+| NOROESTE   | INCOME              | T&IC                   | 407-000-000-00 | Trade & Investment Center          |
+| NOROESTE   | OPERATING RESULTS   | Other                  | 405-000-000-00 | Otros ingresos                     |
+| NOROESTE   | OPERATING RESULTS   | Other                  | 410-000-000-00 | Utilidad cambiaria                 |
+| NOROESTE   | OPERATING RESULTS   | Other                  | 902-000-000-00 | Perdida cambiaria                  |


### PR DESCRIPTION
## Summary
- Regenerate `cuentas_summary_resumen_por_capitulo.md` to list SUMMARY and RESUMEN cuentas agrupadas por capítulo con el mismo formato que planeación.
- Incluye nota explícita para NOROESTE al no existir filas en la hoja SUMMARY mientras mantiene su mapa RESUMEN.

## Testing
- Not run (data-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693086ff3bcc832da2e4727c0c5cf4cb)