### PR TITLE
Add redesigned authorization workflow dashboard

### DIFF
--- a/src/db/sqlite.js
+++ b/src/db/sqlite.js
@@ -136,6 +136,19 @@ const crearTablas = () => {
       UNIQUE(empresaId, modulo, anio)
     )
   `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS PLAN_BORRADORES_HISTORIAL (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      borradorId INTEGER NOT NULL,
+      estado TEXT NOT NULL,
+      comentario TEXT,
+      meta TEXT,
+      usuarioId TEXT,
+      fecha TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(borradorId) REFERENCES PLAN_BORRADORES(id) ON DELETE CASCADE
+    )
+  `).run();
 };
 
 const asegurarColumnasUsuarios = () => {

--- a/src/routes/borradores.js
+++ b/src/routes/borradores.js
@@ -12,6 +12,9 @@ const {
   obtenerBorradorPorId,
   marcarRevisado,
   guardarAutorizado,
+  listarBorradores,
+  obtenerHistorial,
+  eliminarBorrador,
   ESTADOS
 } = require('../services/borradoresService');
 const { notificarWorkflowPresupuesto } = require('../services/notificacionesService');
@@ -27,6 +30,18 @@ const normalizarTexto = (valor) => {
     return base.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   }
   return base;
+};
+
+const normalizarEstados = (valor) => {
+  if (!valor) return [];
+  if (Array.isArray(valor)) {
+    return valor.map((item) => item.toString().trim().toUpperCase()).filter(Boolean);
+  }
+  return valor
+    .toString()
+    .split(',')
+    .map((item) => item.trim().toUpperCase())
+    .filter(Boolean);
 };
 
 const cargarUsuarioActual = (req, res, next) => {
@@ -109,7 +124,61 @@ const esquemaRevision = esquemaBorradorId.keys({
 
 const esquemaFinalizar = esquemaBorradorId;
 
+const esquemaListado = Joi.object({
+  empresaId: Joi.string().trim(),
+  anio: Joi.number().integer().min(2000).max(2100),
+  estado: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())),
+  modulo: Joi.string().trim(),
+  busca: Joi.string().allow('')
+});
+
+const esquemaId = Joi.object({
+  id: Joi.number().integer().required()
+});
+
 router.use(cargarUsuarioActual);
+
+router.get('/', (req, res) => {
+  const { value, error } = esquemaListado.validate(req.query || {}, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Verifica los filtros proporcionados.', detalles: error.details });
+  }
+
+  const moduloCanonico = value.modulo ? obtenerModuloCanonico(value.modulo) : null;
+  if (value.modulo && !moduloCanonico) {
+    return res.status(400).json({ mensaje: 'El módulo indicado no es válido.' });
+  }
+
+  const filtros = {
+    empresaId: value.empresaId || null,
+    anio: value.anio || null,
+    estados: normalizarEstados(value.estado),
+    modulo: moduloCanonico,
+    busqueda: value.busca ? value.busca.toString().trim() : null
+  };
+
+  try {
+    const borradores = listarBorradores(filtros).filter((borrador) => {
+      if (req.esAdmin) return true;
+      return tienePermisoEnModulo(req.mapaPermisos, borrador.empresaId, borrador.modulo);
+    });
+
+    const resumen = borradores.reduce(
+      (acc, borrador) => {
+        acc.total += 1;
+        const estado = borrador.estado || 'SIN_ESTADO';
+        acc.porEstado[estado] = (acc.porEstado[estado] || 0) + 1;
+        return acc;
+      },
+      { total: 0, porEstado: {} }
+    );
+
+    return res.json({ borradores, resumen });
+  } catch (listError) {
+    console.error('Error al listar borradores:', listError);
+    return res.status(500).json({ mensaje: 'No fue posible obtener los borradores.' });
+  }
+});
 
 router.get('/estado', (req, res) => {
   const empresaId = resolverEmpresaId(req);
@@ -201,7 +270,10 @@ router.post('/enviar', async (req, res) => {
   }
 
   try {
-    const resultado = await enviarRevision(value.borradorId, req.esAdmin ? 'ADMIN_GLOBAL' : 'USUARIO');
+    const resultado = await enviarRevision(value.borradorId, {
+      rol: req.esAdmin ? 'ADMIN_GLOBAL' : 'USUARIO',
+      usuarioId: req.usuarioActual.id
+    });
     notificarWorkflowPresupuesto({
       empresaId: empresa.id,
       modulo: borrador.modulo,
@@ -246,7 +318,7 @@ router.post('/autorizar', async (req, res) => {
   }
 
   try {
-    const aprobado = await autorizarBorrador(value.borradorId);
+    const aprobado = await autorizarBorrador(value.borradorId, { usuarioId: req.usuarioActual.id });
     notificarWorkflowPresupuesto({
       empresaId: empresa.id,
       modulo: borrador.modulo,
@@ -288,7 +360,7 @@ router.post('/rechazar', (req, res) => {
   }
 
   try {
-    const rechazado = rechazarBorrador(value.borradorId, value.motivo);
+    const rechazado = rechazarBorrador(value.borradorId, value.motivo, { usuarioId: req.usuarioActual.id });
     notificarWorkflowPresupuesto({
       empresaId: empresa.id,
       modulo: borrador.modulo,
@@ -330,7 +402,7 @@ router.post('/revisar', (req, res) => {
   }
 
   try {
-    const resultado = marcarRevisado(value.borradorId, value.cancelar);
+    const resultado = marcarRevisado(value.borradorId, value.cancelar, { usuarioId: req.usuarioActual.id });
     notificarWorkflowPresupuesto({
       empresaId: empresa.id,
       modulo: borrador.modulo,
@@ -376,7 +448,7 @@ router.post('/finalizar', async (req, res) => {
   }
 
   try {
-    const guardado = await guardarAutorizado(value.borradorId);
+    const guardado = await guardarAutorizado(value.borradorId, { usuarioId: req.usuarioActual.id });
     const ejecutor = {
       id: req.usuarioActual.id,
       usuario: req.usuarioActual.usuario,
@@ -398,6 +470,79 @@ router.post('/finalizar', async (req, res) => {
   } catch (errorFinal) {
     console.error('Error al guardar borrador autorizado:', errorFinal);
     return res.status(500).json({ mensaje: 'No fue posible guardar en la base de datos.' });
+  }
+});
+
+router.get('/:id/historial', (req, res) => {
+  const { value, error } = esquemaId.validate(req.params, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Identificador de borrador inválido.' });
+  }
+
+  const borrador = obtenerBorradorPorId(value.id);
+  if (!borrador) {
+    return res.status(404).json({ mensaje: 'Borrador no encontrado.' });
+  }
+
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, borrador.empresaId, borrador.modulo)) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para ver este borrador.' });
+  }
+
+  try {
+    const historial = obtenerHistorial(value.id);
+    return res.json({ historial });
+  } catch (histError) {
+    console.error('Error al consultar historial de borrador:', histError);
+    return res.status(500).json({ mensaje: 'No fue posible obtener el historial.' });
+  }
+});
+
+router.get('/:id', (req, res) => {
+  const { value, error } = esquemaId.validate(req.params, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Identificador de borrador inválido.' });
+  }
+
+  const borrador = obtenerBorradorPorId(value.id);
+  if (!borrador) {
+    return res.status(404).json({ mensaje: 'Borrador no encontrado.' });
+  }
+
+  if (!req.esAdmin && !tienePermisoEnModulo(req.mapaPermisos, borrador.empresaId, borrador.modulo)) {
+    return res.status(403).json({ mensaje: 'No cuentas con permisos para ver este borrador.' });
+  }
+
+  try {
+    const historial = obtenerHistorial(value.id);
+    return res.json({ borrador, historial });
+  } catch (detailError) {
+    console.error('Error al consultar detalle de borrador:', detailError);
+    return res.status(500).json({ mensaje: 'No fue posible obtener el borrador.' });
+  }
+});
+
+router.delete('/:id', (req, res) => {
+  const { value, error } = esquemaId.validate(req.params, { abortEarly: false });
+  if (error) {
+    return res.status(400).json({ mensaje: 'Identificador de borrador inválido.' });
+  }
+
+  const borrador = obtenerBorradorPorId(value.id);
+  if (!borrador) {
+    return res.status(404).json({ mensaje: 'Borrador no encontrado.' });
+  }
+
+  const esPropio = String(borrador.usuarioId || '') === String(req.usuarioActual.id || '');
+  if (!req.esAdmin && !esPropio) {
+    return res.status(403).json({ mensaje: 'Solo el creador o un administrador pueden eliminar este borrador.' });
+  }
+
+  try {
+    eliminarBorrador(value.id);
+    return res.json({ mensaje: 'Borrador eliminado.' });
+  } catch (deleteError) {
+    console.error('Error al eliminar borrador:', deleteError);
+    return res.status(500).json({ mensaje: 'No fue posible eliminar el borrador.' });
   }
 });
 

--- a/src/services/borradoresService.js
+++ b/src/services/borradoresService.js
@@ -18,6 +18,16 @@ const mapData = (texto) => {
   }
 };
 
+const mapMeta = (valor) => {
+  if (!valor) return null;
+  if (typeof valor === 'object') return valor;
+  try {
+    return JSON.parse(valor);
+  } catch (error) {
+    return valor;
+  }
+};
+
 const normalizarContexto = (contexto) => {
   if (!contexto) {
     throw new Error('Contexto del borrador no proporcionado.');
@@ -48,6 +58,8 @@ const mapearFila = (fila) => {
     modulo: fila.modulo,
     anio: fila.anio,
     usuarioId: fila.usuarioId,
+    usuario: fila.usuario || null,
+    usuarioNombre: fila.usuarioNombre || null,
     data: mapData(fila.data),
     estado: fila.estado,
     fechaCreacion: fila.fechaCreacion,
@@ -56,16 +68,104 @@ const mapearFila = (fila) => {
   };
 };
 
+const mapearHistorial = (fila) => {
+  if (!fila) return null;
+  const nombre = (fila.nombre || '').trim();
+  const usuario = (fila.usuario || '').trim();
+  return {
+    id: fila.id,
+    borradorId: fila.borradorId,
+    estado: fila.estado,
+    comentario: fila.comentario || null,
+    fecha: fila.fecha,
+    usuarioId: fila.usuarioId || null,
+    usuario,
+    nombre: nombre || usuario || null,
+    meta: mapMeta(fila.meta)
+  };
+};
+
 const obtenerBorradorPorId = (id) => {
   if (!id) {
     return null;
   }
   const fila = db.prepare(`
-    SELECT *
-    FROM PLAN_BORRADORES
-    WHERE id = ?
+    SELECT b.*, u.usuario, TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS usuarioNombre
+    FROM PLAN_BORRADORES b
+    LEFT JOIN usuarios u ON u.id = b.usuarioId
+    WHERE b.id = ?
   `).get(id);
   return mapearFila(fila);
+};
+
+const registrarHistorial = (borradorId, estado, opciones = {}) => {
+  if (!borradorId || !estado) return null;
+  const meta = opciones.meta ? JSON.stringify(opciones.meta) : null;
+  return db.prepare(`
+    INSERT INTO PLAN_BORRADORES_HISTORIAL (borradorId, estado, comentario, meta, usuarioId)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(borradorId, estado, opciones.comentario || null, meta, opciones.usuarioId || null);
+};
+
+const obtenerHistorial = (borradorId) => {
+  if (!borradorId) return [];
+  const filas = db.prepare(`
+    SELECT h.*, u.usuario, TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS nombre
+    FROM PLAN_BORRADORES_HISTORIAL h
+    LEFT JOIN usuarios u ON u.id = h.usuarioId
+    WHERE h.borradorId = ?
+    ORDER BY h.fecha ASC, h.id ASC
+  `).all(borradorId);
+  return filas.map(mapearHistorial).filter(Boolean);
+};
+
+const listarBorradores = (filtros = {}) => {
+  const condiciones = [];
+  const valores = [];
+
+  if (filtros.empresaId) {
+    condiciones.push('b.empresaId = ?');
+    valores.push(filtros.empresaId);
+  }
+
+  if (filtros.anio) {
+    condiciones.push('b.anio = ?');
+    valores.push(filtros.anio);
+  }
+
+  if (Array.isArray(filtros.estados) && filtros.estados.length) {
+    const placeholders = filtros.estados.map(() => '?').join(', ');
+    condiciones.push(`b.estado IN (${placeholders})`);
+    valores.push(...filtros.estados);
+  }
+
+  if (filtros.modulo) {
+    condiciones.push('LOWER(b.modulo) = LOWER(?)');
+    valores.push(filtros.modulo);
+  }
+
+  if (filtros.busqueda) {
+    condiciones.push('(LOWER(b.comentarios) LIKE ? OR LOWER(b.modulo) LIKE ? )');
+    valores.push(`%${filtros.busqueda.toLowerCase()}%`, `%${filtros.busqueda.toLowerCase()}%`);
+  }
+
+  const whereClause = condiciones.length ? `WHERE ${condiciones.join(' AND ')}` : '';
+  const filas = db.prepare(`
+    SELECT b.*, u.usuario, TRIM(COALESCE(u.nombres, '') || ' ' || COALESCE(u.apellidos, '')) AS usuarioNombre
+    FROM PLAN_BORRADORES b
+    LEFT JOIN usuarios u ON u.id = b.usuarioId
+    ${whereClause}
+    ORDER BY b.fechaEnvio DESC NULLS LAST, b.fechaCreacion DESC
+  `).all(...valores);
+
+  return filas.map(mapearFila).filter(Boolean);
+};
+
+const eliminarBorrador = (borradorId) => {
+  if (!borradorId) return 0;
+  db.prepare('DELETE FROM PLAN_BORRADORES_HISTORIAL WHERE borradorId = ?').run(borradorId);
+  const resultado = db.prepare('DELETE FROM PLAN_BORRADORES WHERE id = ?').run(borradorId);
+  return resultado.changes || 0;
 };
 
 const persistirEnFirebird = async (borrador) => {
@@ -183,29 +283,43 @@ const guardarBorrador = (contexto, datos) => {
       SET data = ?, estado = '${ESTADOS.EDITANDO}', fechaEnvio = NULL, comentarios = NULL, usuarioId = ?
       WHERE id = ?
     `).run(contenido, cfg.usuarioId, existente.id);
-    return obtenerBorradorPorId(existente.id);
+    const actualizado = obtenerBorradorPorId(existente.id);
+    registrarHistorial(existente.id, ESTADOS.EDITANDO, {
+      comentario: 'Borrador actualizado',
+      usuarioId: cfg.usuarioId
+    });
+    return actualizado;
   }
 
   const resultado = db.prepare(`
     INSERT INTO PLAN_BORRADORES (empresaId, anio, modulo, usuarioId, data, estado, comentarios)
     VALUES (?, ?, ?, ?, ?, '${ESTADOS.EDITANDO}', ?)
   `).run(cfg.empresaId, cfg.anio, cfg.modulo, cfg.usuarioId, contenido, cfg.comentarios);
-
-  return obtenerBorradorPorId(resultado.lastInsertRowid);
+  const creado = obtenerBorradorPorId(resultado.lastInsertRowid);
+  registrarHistorial(creado.id, ESTADOS.EDITANDO, {
+    comentario: 'Borrador creado',
+    usuarioId: cfg.usuarioId
+  });
+  return creado;
 };
 
-const enviarRevision = async (borradorId, usuarioRol) => {
+const enviarRevision = async (borradorId, opciones = {}) => {
   const borrador = obtenerBorradorPorId(borradorId);
   if (!borrador) {
     throw new Error('Borrador no encontrado.');
   }
 
-  if (usuarioRol === 'ADMIN_GLOBAL') {
+  if (opciones.rol === 'ADMIN_GLOBAL') {
     db.prepare(`
       UPDATE PLAN_BORRADORES
       SET estado = '${ESTADOS.APROBADO}', fechaEnvio = CURRENT_TIMESTAMP
       WHERE id = ?
     `).run(borradorId);
+    registrarHistorial(borradorId, ESTADOS.APROBADO, {
+      comentario: 'Autorizado automáticamente',
+      usuarioId: opciones.usuarioId,
+      meta: { origen: 'envio', auto: true }
+    });
     return { autoAutorizado: true, borrador: obtenerBorradorPorId(borradorId) };
   }
 
@@ -215,10 +329,16 @@ const enviarRevision = async (borradorId, usuarioRol) => {
     WHERE id = ?
   `).run(borradorId);
 
+  registrarHistorial(borradorId, ESTADOS.PENDIENTE, {
+    comentario: 'Borrador enviado a revisión',
+    usuarioId: opciones.usuarioId,
+    meta: { origen: 'envio' }
+  });
+
   return { autoAutorizado: false, borrador: obtenerBorradorPorId(borradorId) };
 };
 
-const marcarRevisado = (borradorId, cancelar = false) => {
+const marcarRevisado = (borradorId, cancelar = false, actor = {}) => {
   const borrador = obtenerBorradorPorId(borradorId);
   if (!borrador) {
     throw new Error('Borrador no encontrado.');
@@ -229,10 +349,15 @@ const marcarRevisado = (borradorId, cancelar = false) => {
     SET estado = ?, comentarios = NULL
     WHERE id = ?
   `).run(destino, borradorId);
+  registrarHistorial(borradorId, destino, {
+    comentario: cancelar ? 'Revisión cancelada' : 'Marcado como revisado',
+    usuarioId: actor.usuarioId,
+    meta: { origen: 'revision', cancelar }
+  });
   return obtenerBorradorPorId(borradorId);
 };
 
-const autorizarBorrador = async (borradorId) => {
+const autorizarBorrador = async (borradorId, actor = {}) => {
   const borrador = obtenerBorradorPorId(borradorId);
   if (!borrador) {
     throw new Error('Borrador no encontrado.');
@@ -248,10 +373,16 @@ const autorizarBorrador = async (borradorId) => {
     WHERE id = ?
   `).run(borradorId);
 
+  registrarHistorial(borradorId, ESTADOS.APROBADO, {
+    comentario: 'Autorizado',
+    usuarioId: actor.usuarioId,
+    meta: { origen: 'autorizacion' }
+  });
+
   return obtenerBorradorPorId(borradorId);
 };
 
-const rechazarBorrador = (borradorId, motivo) => {
+const rechazarBorrador = (borradorId, motivo, actor = {}) => {
   const borrador = obtenerBorradorPorId(borradorId);
   if (!borrador) {
     throw new Error('Borrador no encontrado.');
@@ -263,10 +394,16 @@ const rechazarBorrador = (borradorId, motivo) => {
     WHERE id = ?
   `).run(motivo || null, borradorId);
 
+  registrarHistorial(borradorId, ESTADOS.RECHAZADO, {
+    comentario: motivo || 'Rechazado',
+    usuarioId: actor.usuarioId,
+    meta: { origen: 'rechazo' }
+  });
+
   return obtenerBorradorPorId(borradorId);
 };
 
-const guardarAutorizado = async (borradorId) => {
+const guardarAutorizado = async (borradorId, actor = {}) => {
   const borrador = obtenerBorradorPorId(borradorId);
   if (!borrador) {
     throw new Error('Borrador no encontrado.');
@@ -283,6 +420,11 @@ const guardarAutorizado = async (borradorId) => {
     SET estado = '${ESTADOS.GUARDADO}', fechaEnvio = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(borradorId);
+  registrarHistorial(borradorId, ESTADOS.GUARDADO, {
+    comentario: 'Guardado en base de datos',
+    usuarioId: actor.usuarioId,
+    meta: { origen: 'guardado' }
+  });
   return obtenerBorradorPorId(borradorId);
 };
 
@@ -295,5 +437,8 @@ module.exports = {
   obtenerBorradorPorId,
   marcarRevisado,
   guardarAutorizado,
+  listarBorradores,
+  obtenerHistorial,
+  eliminarBorrador,
   ESTADOS
 };

--- a/vistas/css/estilos.css
+++ b/vistas/css/estilos.css
@@ -210,3 +210,193 @@
 .workflow-drawer .list-group-item:last-child {
   border-bottom: none;
 }
+
+/* --- Gestión de flujo de autorización --- */
+.flujo-hero {
+  background: linear-gradient(135deg, rgba(10, 14, 39, 0.9), rgba(0, 217, 255, 0.16));
+  border-radius: 20px;
+  padding: 2rem;
+  color: #f8f9ff;
+  position: relative;
+  overflow: hidden;
+}
+
+.flujo-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(0, 255, 136, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(0, 217, 255, 0.2), transparent 40%);
+  pointer-events: none;
+}
+
+.flujo-hero h1 {
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.estado-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: #0a0e27;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.estado-pill[data-estado='EDITANDO'] {
+  background: linear-gradient(135deg, #ffda7a, #ffb800);
+}
+
+.estado-pill[data-estado='PENDIENTE'] {
+  background: linear-gradient(135deg, #8fd3ff, #2f8cff);
+}
+
+.estado-pill[data-estado='REVISADO'] {
+  background: linear-gradient(135deg, #d3b4ff, #7c3aed);
+}
+
+.estado-pill[data-estado='APROBADO'] {
+  background: linear-gradient(135deg, #7ee8a3, #19c37d);
+}
+
+.estado-pill[data-estado='RECHAZADO'] {
+  background: linear-gradient(135deg, #ff9bb7, #ff006e);
+}
+
+.estado-pill[data-estado='GUARDADO'] {
+  background: linear-gradient(135deg, #cdd6f4, #8497b0);
+}
+
+.tarjeta-estado {
+  border: 1px solid rgba(10, 14, 39, 0.08);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 20px 40px rgba(10, 14, 39, 0.06);
+}
+
+.tarjeta-estado h6 {
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.tarjeta-estado .numero {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 800;
+}
+
+.estado-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 0.82rem;
+}
+
+.estado-badge[data-estado='EDITANDO'] {
+  background: rgba(255, 184, 0, 0.15);
+  color: #a55c00;
+}
+
+.estado-badge[data-estado='PENDIENTE'] {
+  background: rgba(47, 140, 255, 0.16);
+  color: #0b5ed7;
+}
+
+.estado-badge[data-estado='REVISADO'] {
+  background: rgba(124, 58, 237, 0.16);
+  color: #5b21b6;
+}
+
+.estado-badge[data-estado='APROBADO'] {
+  background: rgba(25, 195, 125, 0.16);
+  color: #0f5132;
+}
+
+.estado-badge[data-estado='RECHAZADO'] {
+  background: rgba(255, 0, 110, 0.16);
+  color: #b00047;
+}
+
+.estado-badge[data-estado='GUARDADO'] {
+  background: rgba(132, 151, 176, 0.16);
+  color: #243b53;
+}
+
+.tabla-borradores tbody tr:hover {
+  background-color: rgba(47, 84, 150, 0.04);
+  cursor: pointer;
+}
+
+.tabla-borradores .subtexto {
+  color: #6c757d;
+  font-size: 0.85rem;
+}
+
+.timeline-historial {
+  position: relative;
+  padding-left: 1rem;
+}
+
+.timeline-historial::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(10, 14, 39, 0.2), rgba(10, 14, 39, 0));
+}
+
+.timeline-item {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -2px;
+  top: 6px;
+  width: 10px;
+  height: 10px;
+  background: #0a0e27;
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(47, 84, 150, 0.12);
+}
+
+.timeline-item .fecha {
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.resaltado {
+  background: linear-gradient(90deg, rgba(255, 239, 213, 0.8), rgba(255, 250, 235, 0.7));
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.acciones-flujo .btn {
+  border-radius: 12px;
+  font-weight: 700;
+}
+
+.badge-legend {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: 12px;
+  padding: 0.35rem 0.65rem;
+  color: #fff;
+  font-weight: 700;
+}

--- a/vistas/flujo-autorizacion.html
+++ b/vistas/flujo-autorizacion.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestión de autorizaciones</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/estilos.css">
+  <style>
+    body {
+      background: #f5f6fa;
+      font-family: 'Manrope', system-ui, -apple-system, sans-serif;
+      color: #0a0e27;
+    }
+  </style>
+</head>
+<body>
+  <div class="container py-4">
+    <div class="flujo-hero mb-4">
+      <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3">
+        <div>
+          <div class="d-flex align-items-center gap-3 mb-2">
+            <span class="badge text-bg-light text-uppercase fw-bold">Versión 2.0</span>
+            <span class="badge-legend"><i class="bi bi-cloud-arrow-down"></i> Persistencia automática</span>
+            <span class="badge-legend"><i class="bi bi-shield-check"></i> Roles y permisos</span>
+          </div>
+          <h1 class="mb-2">Gestión centralizada de autorizaciones</h1>
+          <p class="mb-0 text-white-50">Panel dedicado para revisar, aprobar o rechazar borradores de presupuestos con timeline de auditoría y acciones contextualizadas.</p>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+          <span class="estado-pill" data-estado="EDITANDO"><i class="bi bi-pencil-square"></i> Editando</span>
+          <span class="estado-pill" data-estado="PENDIENTE"><i class="bi bi-send-check"></i> Pendiente</span>
+          <span class="estado-pill" data-estado="REVISADO"><i class="bi bi-search-heart"></i> Revisado</span>
+          <span class="estado-pill" data-estado="APROBADO"><i class="bi bi-check-circle"></i> Aprobado</span>
+          <span class="estado-pill" data-estado="RECHAZADO"><i class="bi bi-x-octagon"></i> Rechazado</span>
+          <span class="estado-pill" data-estado="GUARDADO"><i class="bi bi-database-check"></i> Guardado</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="card border-0 shadow-sm mb-3">
+      <div class="card-body">
+        <div class="row g-3 align-items-end">
+          <div class="col-md-4">
+            <label class="form-label fw-semibold text-muted">Empresa</label>
+            <select id="filtroEmpresa" class="form-select"></select>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label fw-semibold text-muted">Ejercicio</label>
+            <select id="filtroAnio" class="form-select"></select>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label fw-semibold text-muted">Estados</label>
+            <div class="d-flex flex-wrap gap-2" id="filtroEstados">
+              <!-- chips dinámicos -->
+            </div>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label fw-semibold text-muted">Búsqueda</label>
+            <input id="filtroBusqueda" type="search" class="form-control" placeholder="Módulo o comentario" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row g-3 mb-3" id="tarjetasResumen">
+      <div class="col-md-4">
+        <div class="tarjeta-estado h-100">
+          <div class="d-flex align-items-center justify-content-between">
+            <div>
+              <p class="text-muted mb-1">Borradores activos</p>
+              <div class="numero" id="totalBorradores">0</div>
+            </div>
+            <span class="estado-badge" data-estado="EDITANDO">Activos</span>
+          </div>
+          <p class="mb-0 small text-muted">Incluye borradores editando, pendientes y revisados.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="tarjeta-estado h-100">
+          <div class="d-flex align-items-center justify-content-between">
+            <div>
+              <p class="text-muted mb-1">Listos para autorizar</p>
+              <div class="numero" id="totalRevisados">0</div>
+            </div>
+            <span class="estado-badge" data-estado="REVISADO">Revisado</span>
+          </div>
+          <p class="mb-0 small text-muted">Borradores marcados como revisados o auto autorizados.</p>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="tarjeta-estado h-100">
+          <div class="d-flex align-items-center justify-content-between">
+            <div>
+              <p class="text-muted mb-1">Autorizados / guardados</p>
+              <div class="numero" id="totalAutorizados">0</div>
+            </div>
+            <span class="estado-badge" data-estado="APROBADO">OK</span>
+          </div>
+          <p class="mb-0 small text-muted">Autorizados o guardados en base de datos.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="row g-3">
+      <div class="col-lg-8">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-header bg-white d-flex align-items-center justify-content-between">
+            <div>
+              <p class="mb-0 text-muted small">Flujo de autorizaciones</p>
+              <h5 class="mb-0">Borradores registrados</h5>
+            </div>
+            <div class="d-flex align-items-center gap-2">
+              <span class="text-muted small"><i class="bi bi-activity me-1"></i>Sincronización automática</span>
+              <button id="btnRefrescar" class="btn btn-sm btn-outline-primary"><i class="bi bi-arrow-clockwise"></i> Refrescar</button>
+            </div>
+          </div>
+          <div class="card-body p-0">
+            <div class="table-responsive">
+              <table class="table tabla-borradores mb-0 align-middle">
+                <thead class="table-light">
+                  <tr>
+                    <th class="text-muted small text-uppercase">Módulo</th>
+                    <th class="text-muted small text-uppercase">Empresa</th>
+                    <th class="text-muted small text-uppercase">Ejercicio</th>
+                    <th class="text-muted small text-uppercase">Estado</th>
+                    <th class="text-muted small text-uppercase">Actualizado</th>
+                    <th class="text-muted small text-uppercase text-end">Acción</th>
+                  </tr>
+                </thead>
+                <tbody id="listaBorradores">
+                  <tr>
+                    <td colspan="6" class="text-center py-5 text-muted">
+                      <div class="spinner-border text-primary mb-2" role="status"></div>
+                      <p class="mb-0">Cargando borradores...</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-4">
+        <div class="card border-0 shadow-sm h-100">
+          <div class="card-header bg-white d-flex justify-content-between align-items-center">
+            <div>
+              <p class="mb-0 text-muted small">Detalle</p>
+              <h5 class="mb-0">Vista contextual</h5>
+            </div>
+            <span class="estado-badge" id="detalleEstado">Sin selección</span>
+          </div>
+          <div class="card-body">
+            <div class="mb-3" id="detalleResumen">
+              <p class="text-muted small mb-1">Selecciona un borrador para ver su historial y acciones disponibles.</p>
+              <div class="resaltado d-flex align-items-center gap-2">
+                <i class="bi bi-info-circle text-warning"></i>
+                <span class="small">Los botones se habilitan según el estado y los permisos del usuario.</span>
+              </div>
+            </div>
+
+            <div class="acciones-flujo d-flex flex-wrap gap-2 mb-4">
+              <button id="accionRevisar" class="btn btn-outline-primary btn-sm" disabled><i class="bi bi-check2-square"></i> Marcar revisado</button>
+              <button id="accionAutorizar" class="btn btn-success btn-sm" disabled><i class="bi bi-shield-check"></i> Autorizar</button>
+              <button id="accionRechazar" class="btn btn-outline-danger btn-sm" disabled><i class="bi bi-x-circle"></i> Rechazar</button>
+              <button id="accionGuardar" class="btn btn-dark btn-sm" disabled><i class="bi bi-database-check"></i> Guardar en BD</button>
+              <button id="accionVer" class="btn btn-outline-secondary btn-sm" disabled><i class="bi bi-eye"></i> Ver borrador</button>
+            </div>
+
+            <div class="mb-3">
+              <div class="d-flex align-items-center justify-content-between mb-2">
+                <h6 class="mb-0">Timeline</h6>
+                <span class="small text-muted" id="detalleMeta"></span>
+              </div>
+              <div id="historial" class="timeline-historial"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080;">
+    <div id="gestionToast" class="toast align-items-center text-bg-dark border-0" role="status" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body" id="gestionToastBody">Listo.</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/sesion.js"></script>
+  <script src="js/flujo-autorizacion-gestion.js"></script>
+</body>
+</html>

--- a/vistas/js/flujo-autorizacion-gestion.js
+++ b/vistas/js/flujo-autorizacion-gestion.js
@@ -1,0 +1,373 @@
+(() => {
+  const origin = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
+  const API_BASE = `${origin}/api`;
+  const ESTADOS = ['EDITANDO', 'PENDIENTE', 'REVISADO', 'APROBADO', 'RECHAZADO', 'GUARDADO'];
+  const META_ESTADOS = {
+    EDITANDO: { texto: 'Editando', icono: 'bi-pencil-square', tono: 'warning' },
+    PENDIENTE: { texto: 'Pendiente', icono: 'bi-send-check', tono: 'info' },
+    REVISADO: { texto: 'Revisado', icono: 'bi-search-heart', tono: 'primary' },
+    APROBADO: { texto: 'Aprobado', icono: 'bi-check2-circle', tono: 'success' },
+    RECHAZADO: { texto: 'Rechazado', icono: 'bi-x-octagon', tono: 'danger' },
+    GUARDADO: { texto: 'Guardado', icono: 'bi-database-check', tono: 'dark' }
+  };
+
+  const MAPA_VISTAS = {
+    'Membresía': 'Membresía.html',
+    'Serv Membresía': 'Serv_Membresía.html',
+    'Comunicación': 'Comunicación.html',
+    'Eventos': 'Eventos.html',
+    'Dirección': 'Dirección.html',
+    'Comités': 'Comités.html',
+    'T&IC': 'T&IC.html',
+    RH: 'RH.html',
+    VPE: 'VPE.html',
+    Finanzas: 'Finanzas.html',
+    'Gtos Corporativos': 'Gtos_Corporativos.html',
+    SUMMARY: 'SUMMARY.html',
+    RESUMEN: 'RESUMEN.html',
+    Presupuestos: 'Presupuestos.html'
+  };
+
+  const state = {
+    borradores: [],
+    seleccionado: null,
+    filtros: {
+      estados: new Set(['EDITANDO', 'PENDIENTE', 'REVISADO', 'APROBADO', 'RECHAZADO', 'GUARDADO']),
+      empresaId: null,
+      anio: null,
+      busqueda: ''
+    }
+  };
+
+  const ui = {
+    filtroEmpresa: document.getElementById('filtroEmpresa'),
+    filtroAnio: document.getElementById('filtroAnio'),
+    filtroEstados: document.getElementById('filtroEstados'),
+    filtroBusqueda: document.getElementById('filtroBusqueda'),
+    listaBorradores: document.getElementById('listaBorradores'),
+    totalBorradores: document.getElementById('totalBorradores'),
+    totalRevisados: document.getElementById('totalRevisados'),
+    totalAutorizados: document.getElementById('totalAutorizados'),
+    detalleEstado: document.getElementById('detalleEstado'),
+    detalleResumen: document.getElementById('detalleResumen'),
+    detalleMeta: document.getElementById('detalleMeta'),
+    historial: document.getElementById('historial'),
+    accionRevisar: document.getElementById('accionRevisar'),
+    accionAutorizar: document.getElementById('accionAutorizar'),
+    accionRechazar: document.getElementById('accionRechazar'),
+    accionGuardar: document.getElementById('accionGuardar'),
+    accionVer: document.getElementById('accionVer'),
+    btnRefrescar: document.getElementById('btnRefrescar'),
+    toast: document.getElementById('gestionToast'),
+    toastBody: document.getElementById('gestionToastBody')
+  };
+
+  const toastInstance = ui.toast ? bootstrap.Toast.getOrCreateInstance(ui.toast, { delay: 2600 }) : null;
+
+  const notificar = (mensaje, tipo = 'info') => {
+    if (!ui.toast || !ui.toastBody) return;
+    ui.toast.className = `toast align-items-center text-bg-${tipo} border-0`;
+    ui.toastBody.textContent = mensaje;
+    toastInstance?.show();
+  };
+
+  const construirHeaders = () => ({
+    'Content-Type': 'application/json',
+    ...(window.Sesion?.headersAutenticacion?.() || {})
+  });
+
+  const fetchJson = async (url, opciones = {}) => {
+    const respuesta = await fetch(url, {
+      ...opciones,
+      headers: { ...construirHeaders(), ...(opciones.headers || {}) }
+    });
+    const data = await respuesta.json().catch(() => ({}));
+    if (!respuesta.ok) {
+      const mensaje = data.mensaje || 'No fue posible completar la operación.';
+      throw new Error(mensaje);
+    }
+    return data;
+  };
+
+  const formatearFecha = (valor) => {
+    if (!valor) return 'Sin fecha';
+    const fecha = new Date(valor);
+    if (Number.isNaN(fecha.getTime())) return valor;
+    return fecha.toLocaleString('es-MX');
+  };
+
+  const crearChipEstado = (estado) => {
+    const meta = META_ESTADOS[estado] || { texto: estado, icono: 'bi-flag', tono: 'secondary' };
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'btn btn-sm btn-chip btn-chip-outline';
+    chip.dataset.estado = estado;
+    chip.innerHTML = `<i class="bi ${meta.icono}"></i> ${meta.texto}`;
+    chip.addEventListener('click', () => {
+      if (state.filtros.estados.has(estado)) {
+        state.filtros.estados.delete(estado);
+        chip.classList.add('btn-chip-warning');
+      } else {
+        state.filtros.estados.add(estado);
+        chip.classList.remove('btn-chip-warning');
+      }
+      cargarBorradores();
+    });
+    return chip;
+  };
+
+  const renderEstados = () => {
+    ui.filtroEstados.innerHTML = '';
+    ESTADOS.forEach((estado) => {
+      const chip = crearChipEstado(estado);
+      ui.filtroEstados.appendChild(chip);
+    });
+  };
+
+  const renderResumen = (resumen = { total: 0, porEstado: {} }) => {
+    ui.totalBorradores.textContent = resumen.total || 0;
+    ui.totalRevisados.textContent = (resumen.porEstado.REVISADO || 0) + (resumen.porEstado.APROBADO || 0);
+    ui.totalAutorizados.textContent = (resumen.porEstado.APROBADO || 0) + (resumen.porEstado.GUARDADO || 0);
+  };
+
+  const obtenerEmpresaActiva = () => {
+    return window.Sesion?.obtenerEmpresaActiva?.() || null;
+  };
+
+  const poblarEmpresas = async () => {
+    try {
+      const respuesta = await fetchJson(`${API_BASE}/empresas`);
+      const empresas = respuesta.empresas || [];
+      ui.filtroEmpresa.innerHTML = empresas
+        .map((empresa) => `<option value="${empresa.id}">${empresa.nombre}</option>`)
+        .join('');
+      const activa = obtenerEmpresaActiva();
+      const valor = activa?.id || empresas[0]?.id || '';
+      ui.filtroEmpresa.value = valor;
+      state.filtros.empresaId = valor;
+    } catch (error) {
+      console.error(error);
+      notificar(error.message, 'warning');
+    }
+  };
+
+  const poblarAnios = () => {
+    const actual = new Date().getFullYear();
+    const opciones = [];
+    for (let delta = -1; delta <= 2; delta += 1) {
+      opciones.push(actual + delta);
+    }
+    ui.filtroAnio.innerHTML = opciones
+      .map((anio) => `<option value="${anio}">${anio}</option>`)
+      .join('');
+    ui.filtroAnio.value = actual;
+    state.filtros.anio = actual;
+  };
+
+  const badgeEstado = (estado) => {
+    const meta = META_ESTADOS[estado] || { texto: estado, icono: 'bi-flag' };
+    return `<span class="estado-badge" data-estado="${estado}"><i class="bi ${meta.icono}"></i> ${meta.texto}</span>`;
+  };
+
+  const renderBorradores = () => {
+    if (!state.borradores.length) {
+      ui.listaBorradores.innerHTML = `
+        <tr>
+          <td colspan="6" class="text-center py-5 text-muted">
+            <i class="bi bi-inboxes me-2"></i> No se encontraron borradores con los filtros seleccionados.
+          </td>
+        </tr>
+      `;
+      return;
+    }
+
+    ui.listaBorradores.innerHTML = '';
+    state.borradores.forEach((borrador) => {
+      const tr = document.createElement('tr');
+      tr.classList.toggle('table-active', state.seleccionado?.id === borrador.id);
+      tr.innerHTML = `
+        <td>
+          <div class="fw-semibold">${borrador.modulo}</div>
+          <div class="subtexto">${borrador.usuarioNombre || 'Sin usuario'}</div>
+        </td>
+        <td>${borrador.empresaId}</td>
+        <td>${borrador.anio}</td>
+        <td>${badgeEstado(borrador.estado)}</td>
+        <td class="small text-muted">${formatearFecha(borrador.fechaEnvio || borrador.fechaCreacion)}</td>
+        <td class="text-end">
+          <button class="btn btn-sm btn-chip btn-chip-outline" data-id="${borrador.id}">
+            <i class="bi bi-journal-text"></i> Abrir
+          </button>
+        </td>
+      `;
+      tr.addEventListener('click', () => seleccionarBorrador(borrador.id));
+      tr.querySelector('button')?.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        seleccionarBorrador(borrador.id);
+      });
+      ui.listaBorradores.appendChild(tr);
+    });
+  };
+
+  const renderHistorial = (historial = []) => {
+    if (!historial.length) {
+      ui.historial.innerHTML = '<p class="text-muted small">Sin eventos registrados.</p>';
+      return;
+    }
+    ui.historial.innerHTML = '';
+    historial.forEach((evento) => {
+      const meta = META_ESTADOS[evento.estado] || {};
+      const div = document.createElement('div');
+      div.className = 'timeline-item';
+      div.innerHTML = `
+        <div class="d-flex align-items-center gap-2 mb-1">
+          ${badgeEstado(evento.estado)}
+          <span class="fecha">${formatearFecha(evento.fecha)}</span>
+        </div>
+        <p class="mb-1 fw-semibold">${evento.comentario || meta.texto || 'Actualización'}</p>
+        <p class="mb-0 text-muted small">${evento.nombre || evento.usuario || 'Sistema'}</p>
+      `;
+      ui.historial.appendChild(div);
+    });
+  };
+
+  const actualizarDetalle = (detalle) => {
+    const borrador = detalle?.borrador;
+    state.seleccionado = borrador || null;
+    if (!borrador) {
+      ui.detalleEstado.textContent = 'Sin selección';
+      ui.detalleEstado.dataset.estado = '';
+      ui.detalleResumen.classList.remove('d-none');
+      ui.historial.innerHTML = '';
+      ui.accionRevisar.disabled = true;
+      ui.accionAutorizar.disabled = true;
+      ui.accionRechazar.disabled = true;
+      ui.accionGuardar.disabled = true;
+      ui.accionVer.disabled = true;
+      return;
+    }
+
+    ui.detalleResumen.classList.add('d-none');
+    ui.detalleEstado.innerHTML = badgeEstado(borrador.estado);
+    ui.detalleEstado.dataset.estado = borrador.estado;
+    ui.detalleMeta.textContent = `${borrador.modulo} · ${borrador.empresaId} · ${borrador.anio}`;
+
+    const historial = detalle.historial || [];
+    renderHistorial(historial);
+
+    const estado = borrador.estado;
+    ui.accionRevisar.disabled = estado !== 'PENDIENTE';
+    ui.accionAutorizar.disabled = !['REVISADO', 'PENDIENTE'].includes(estado);
+    ui.accionRechazar.disabled = !['PENDIENTE', 'REVISADO', 'APROBADO'].includes(estado);
+    ui.accionGuardar.disabled = estado !== 'APROBADO';
+    ui.accionVer.disabled = !MAPA_VISTAS[borrador.modulo];
+  };
+
+  const seleccionarBorrador = async (id) => {
+    try {
+      const detalle = await fetchJson(`${API_BASE}/borradores/${id}`);
+      actualizarDetalle(detalle);
+    } catch (error) {
+      console.error(error);
+      notificar(error.message, 'warning');
+    }
+  };
+
+  const cargarBorradores = async () => {
+    const params = new URLSearchParams();
+    if (state.filtros.empresaId) params.set('empresaId', state.filtros.empresaId);
+    if (state.filtros.anio) params.set('anio', state.filtros.anio);
+    if (state.filtros.estados.size && state.filtros.estados.size !== ESTADOS.length) {
+      params.set('estado', Array.from(state.filtros.estados).join(','));
+    }
+    if (state.filtros.busqueda) params.set('busca', state.filtros.busqueda);
+
+    ui.listaBorradores.innerHTML = `
+      <tr><td colspan="6" class="text-center py-4 text-muted"><div class="spinner-border spinner-border-sm me-2"></div>Actualizando...</td></tr>
+    `;
+
+    try {
+      const respuesta = await fetchJson(`${API_BASE}/borradores?${params.toString()}`);
+      state.borradores = respuesta.borradores || [];
+      renderResumen(respuesta.resumen);
+      renderBorradores();
+      if (state.seleccionado) {
+        const sigue = state.borradores.find((b) => b.id === state.seleccionado.id);
+        if (!sigue) {
+          actualizarDetalle({});
+        }
+      }
+    } catch (error) {
+      console.error(error);
+      notificar(error.message, 'danger');
+    }
+  };
+
+  const ejecutarAccion = async (ruta, payload, mensajeOk) => {
+    if (!state.seleccionado) return;
+    try {
+      await fetchJson(`${API_BASE}/borradores/${ruta}`, {
+        method: 'POST',
+        body: JSON.stringify({ borradorId: state.seleccionado.id, ...payload })
+      });
+      notificar(mensajeOk || 'Acción realizada.', 'success');
+      await cargarBorradores();
+      await seleccionarBorrador(state.seleccionado.id);
+    } catch (error) {
+      console.error(error);
+      notificar(error.message, 'danger');
+    }
+  };
+
+  const manejarRechazo = async () => {
+    if (!state.seleccionado) return;
+    const motivo = window.prompt('Motivo del rechazo:');
+    if (!motivo) return;
+    await ejecutarAccion('rechazar', { motivo }, 'Borrador rechazado.');
+  };
+
+  const manejarVer = () => {
+    if (!state.seleccionado) return;
+    const vista = MAPA_VISTAS[state.seleccionado.modulo];
+    if (!vista) return;
+    window.open(vista, '_blank');
+  };
+
+  const inicializarEventos = () => {
+    ui.filtroEmpresa?.addEventListener('change', (ev) => {
+      state.filtros.empresaId = ev.target.value;
+      cargarBorradores();
+    });
+
+    ui.filtroAnio?.addEventListener('change', (ev) => {
+      state.filtros.anio = Number(ev.target.value);
+      cargarBorradores();
+    });
+
+    ui.filtroBusqueda?.addEventListener('input', (ev) => {
+      state.filtros.busqueda = ev.target.value.trim();
+      cargarBorradores();
+    });
+
+    ui.btnRefrescar?.addEventListener('click', () => cargarBorradores());
+    ui.accionRevisar?.addEventListener('click', () => ejecutarAccion('revisar', { cancelar: false }, 'Borrador marcado como revisado.'));
+    ui.accionAutorizar?.addEventListener('click', () => ejecutarAccion('autorizar', {}, 'Borrador autorizado.'));
+    ui.accionRechazar?.addEventListener('click', manejarRechazo);
+    ui.accionGuardar?.addEventListener('click', () => ejecutarAccion('finalizar', {}, 'Borrador guardado en base de datos.'));
+    ui.accionVer?.addEventListener('click', manejarVer);
+  };
+
+  const init = async () => {
+    renderEstados();
+    poblarAnios();
+    await poblarEmpresas();
+    inicializarEventos();
+    cargarBorradores();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add centralized authorization dashboard page with status filters, timeline and actions
- extend API for listing, history retrieval, and deletion of budget drafts with audit logging
- enhance draft persistence with history records and refreshed styling for workflow badges

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693097517654832dbb7778580a80d208)