### PR TITLE
Add authorization workflow and editing to summary views

### DIFF
--- a/vistas/SUMMARY.html
+++ b/vistas/SUMMARY.html
@@ -9,6 +9,7 @@
   <!-- Bootstrap & Fonts -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="css/estilos.css">
 
   <style>
@@ -389,7 +390,7 @@
   </style>
 </head>
 
-<body>
+<body data-modulo="summary" data-modulo-id="summary" data-tabla="mainTable">
   <div class="container-fluid py-4 py-lg-5">
     <!--
       SUMMARY.html
@@ -406,6 +407,39 @@
             <div class="text-center text-lg-start">
               <h2 class="fw-bold mb-2">AMERICAN CHAMBER OF COMMERCE OF MEXICO, A. C.</h2>
               <p class="mb-0">STATEMENT OF OPERATIONS - <span class="mes">ENERO</span> <span class="anio">2022</span></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-12">
+        <div class="card table-card fade-in">
+          <div class="card-body p-3">
+            <div class="workflow-toolbar">
+              <div>
+                <p class="text-muted fw-semibold mb-1">Estado del presupuesto</p>
+                <div class="workflow-badge" id="workflowBadge">Sin cargar</div>
+                <p class="workflow-meta mb-0" id="workflowMeta"></p>
+              </div>
+              <div class="toolbar-actions" role="group">
+                <button type="button" class="btn btn-chip btn-chip-warning d-none" id="btnGuardarBorrador">
+                  <i class="bi bi-upload"></i>
+                  <span>Enviar presupuesto</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-chip-success d-none" id="btnAutorizar">
+                  <i class="bi bi-shield-check"></i>
+                  <span>Autorizar</span>
+                </button>
+                <button type="button" class="btn btn-chip btn-outline-danger d-none" id="btnRechazar">
+                  <i class="bi bi-x-octagon"></i>
+                  <span>Rechazar</span>
+                </button>
+                <button type="button" class="workflow-toggle" data-bs-toggle="offcanvas" data-bs-target="#workflowDrawer" aria-controls="workflowDrawer" aria-label="Ver flujo de autorización">
+                  <i class="bi bi-list-task"></i>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -539,19 +573,46 @@
         </div>
       </div>
     </div>
+    <div
+      class="offcanvas offcanvas-end workflow-drawer"
+      tabindex="-1"
+      id="workflowDrawer"
+      aria-labelledby="workflowDrawerLabel"
+    >
+      <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="workflowDrawerLabel">
+          Flujo de autorización
+        </h5>
+        <button
+          type="button"
+          class="btn-close text-reset"
+          data-bs-dismiss="offcanvas"
+          aria-label="Cerrar"
+        ></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="list-group list-group-flush" id="workflowHistory"></ul>
+      </div>
+    </div>
   </div>
 
-  <!-- Toast de exito al actualizar (Bootstrap) -->
   <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1080">
-    <div id="summaryToast" class="toast align-items-center text-white bg-success border-0" role="status" aria-live="polite" aria-atomic="true">
+    <div
+      id="actionToast"
+      class="toast align-items-center text-bg-success border-0"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+    >
       <div class="d-flex">
-        <div class="toast-body" id="summaryToastBody">Datos actualizados correctamente.</div>
+        <div class="toast-body" id="actionToastBody">Acción realizada correctamente.</div>
         <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Cerrar"></button>
       </div>
     </div>
   </div>
 
   <script src="js/sesion.js"></script>
+  <script src="js/flujo-autorizacion.js"></script>
   <script src="js/summary-view.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>

--- a/vistas/js/cuentas-modulo.js
+++ b/vistas/js/cuentas-modulo.js
@@ -1111,10 +1111,23 @@
     return porCapitulo[normalizarTexto(seccion)] || null;
   };
 
+  const resolverPlaceholdersPorFila = (placeholdersPorFila, cuerpo) => {
+    if (Number.isInteger(placeholdersPorFila) && placeholdersPorFila >= 0) {
+      return placeholdersPorFila;
+    }
+    if (Number.isInteger(estadoModulo.placeholdersPorFila) && estadoModulo.placeholdersPorFila >= 0) {
+      return estadoModulo.placeholdersPorFila;
+    }
+    const tabla = cuerpo?.closest ? cuerpo.closest('table') : estadoModulo.tabla;
+    const columnas = contarColumnas(tabla);
+    return Math.max(0, columnas - 2);
+  };
+
   const agregarFilaResumen = ({ texto, clase, cuerpo, placeholdersPorFila }) => {
-    if (!texto) {
+    if (!texto || !cuerpo) {
       return null;
     }
+    const placeholders = resolverPlaceholdersPorFila(placeholdersPorFila, cuerpo);
     const fila = document.createElement('tr');
     fila.className = clase;
     const celdaCuenta = document.createElement('td');
@@ -1123,7 +1136,7 @@
     const celdaDescripcion = document.createElement('td');
     celdaDescripcion.textContent = texto;
     fila.appendChild(celdaDescripcion);
-    for (let i = 0; i < placeholdersPorFila; i += 1) {
+    for (let i = 0; i < placeholders; i += 1) {
       const celda = document.createElement('td');
       celda.className = 'budget-value';
       celda.textContent = '-';
@@ -1143,6 +1156,7 @@
     resultadoForzado,
     mostrarCuentaVisible = false
   }) => {
+    const placeholders = resolverPlaceholdersPorFila(placeholdersPorFila, cuerpo);
     const secciones = new Map();
     const faltantesNombre = new Set();
     registros.forEach((item) => {
@@ -1166,7 +1180,7 @@
         const filaSeccion = document.createElement('tr');
         filaSeccion.className = 'section-header-row';
         const celda = document.createElement('td');
-        celda.colSpan = placeholdersPorFila + 2;
+        celda.colSpan = placeholders + 2;
         celda.textContent = seccion;
         filaSeccion.appendChild(celda);
         cuerpo.appendChild(filaSeccion);
@@ -1200,7 +1214,7 @@
         fila.dataset.cuenta = item.cuenta || '';
         fila.dataset.cuenta21 = cuenta21;
         fila.dataset.seccion = claveSeccion;
-        for (let i = 0; i < placeholdersPorFila; i += 1) {
+        for (let i = 0; i < placeholders; i += 1) {
           const celda = document.createElement('td');
           celda.className = 'budget-value';
           celda.textContent = '-';
@@ -1247,7 +1261,7 @@
           texto: etiquetaSumRow,
           clase: 'sum-row',
           cuerpo,
-          placeholdersPorFila
+          placeholdersPorFila: placeholders
         });
         const registrarSumario = (texto) => {
           if (!texto) return;

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -107,12 +107,115 @@
     }
   };
 
+  const cambiosPendientes = new Map();
+  let editMode = false;
+
+  const limpiarCambios = () => {
+    cambiosPendientes.clear();
+    editMode = false;
+  };
+
+  const claveCambio = (cuenta, columna) => `${cuenta}|${columna}`;
+
+  const registrarCambio = (cuenta, columna, valor, original) => {
+    if (!cuenta || !columna) return;
+    cambiosPendientes.set(claveCambio(cuenta, columna), {
+      cuenta,
+      columna,
+      valor,
+      original
+    });
+  };
+
+  const eliminarCambio = (cuenta, columna) => {
+    cambiosPendientes.delete(claveCambio(cuenta, columna));
+  };
+
+  const obtenerCambiosPendientes = () => {
+    const porCuenta = new Map();
+    cambiosPendientes.forEach((registro) => {
+      const valores = porCuenta.get(registro.cuenta) || {};
+      valores[registro.columna] = registro.valor;
+      porCuenta.set(registro.cuenta, valores);
+    });
+
+    const presupuesto = Array.from(porCuenta.entries()).map(([cuenta, valores]) => ({
+      cuenta,
+      valores
+    }));
+
+    return { presupuesto, hayCambios: presupuesto.length > 0 };
+  };
+
+  const notificarCambios = () => {
+    const detalle = { ...obtenerCambiosPendientes(), borradorGuardado: false };
+    window.dispatchEvent(new CustomEvent('modulo-planeacion:presupuesto-editado', { detail: detalle }));
+  };
+
+  const parseNumber = (texto) => {
+    const limpio = String(texto || '')
+      .replace(/[^0-9,.-]/g, '')
+      .replace(/,/g, '');
+    const numero = Number(limpio);
+    return Number.isFinite(numero) ? numero : 0;
+  };
+
+  const restaurarValoresOriginales = () => {
+    if (!tablaBody) return;
+    Array.from(tablaBody.querySelectorAll('.editable-cell')).forEach((celda) => {
+      const original = Number(celda.dataset.valorOriginal ?? 0);
+      celda.textContent = formatNumber(original);
+    });
+  };
+
+  const cancelarEdicion = () => {
+    restaurarValoresOriginales();
+    limpiarCambios();
+    notificarCambios();
+  };
+
+  const manejarBlurCelda = (event) => {
+    const celda = event.currentTarget;
+    const fila = celda.closest('tr');
+    const cuenta = fila?.dataset.cuenta;
+    const columna = celda.dataset.columnaClave;
+    const original = Number(celda.dataset.valorOriginal ?? 0);
+    const nuevoValor = parseNumber(celda.textContent);
+
+    if (!cuenta || !columna) return;
+
+    if (nuevoValor !== original) {
+      celda.textContent = formatNumber(nuevoValor);
+      registrarCambio(cuenta, columna, nuevoValor, original);
+    } else {
+      celda.textContent = formatNumber(original);
+      eliminarCambio(cuenta, columna);
+    }
+
+    notificarCambios();
+  };
+
+  const activarModoEdicion = () => {
+    if (editMode || !tablaBody) return;
+    editMode = true;
+    const celdas = Array.from(tablaBody.querySelectorAll('.editable-cell'));
+    celdas.forEach((celda) => {
+      celda.contentEditable = 'true';
+      celda.addEventListener('blur', manejarBlurCelda);
+    });
+  };
+
+  window.CuentasModulo = window.CuentasModulo || {};
+  window.CuentasModulo.cancelEdit = cancelarEdicion;
+  window.CuentasModulo.getCambios = obtenerCambiosPendientes;
+
   const renderTable = (nodos = [], anioActual) => {
     if (!tablaBody) return;
     if (!nodos.length) {
       setStatusRow('No hay datos disponibles para este año.');
       return;
     }
+    limpiarCambios();
     tablaBody.innerHTML = '';
     nodos.forEach((nodo) => {
       const header = document.createElement('tr');
@@ -155,13 +258,20 @@
           const variacionCuentaPrev = formatPercent(cuenta.actualMonth - cuenta.prevMonth, cuenta.prevMonth);
           const row = document.createElement('tr');
           row.className = 'data-row';
+          row.dataset.cuenta = cuenta.cuenta;
           row.dataset.section = nodo.key;
           row.innerHTML = `
             <td>${cuenta.cuenta}</td>
             <td>${cuenta.descripcion || ''}</td>
-            <td class="text-end">${formatNumber(cuenta.actualMonth)}</td>
-            <td class="text-end">${formatNumber(cuenta.planMonth)}</td>
-            <td class="text-end">${formatNumber(cuenta.prevMonth)}</td>
+            <td class="text-end editable-cell" data-columna-clave="actualMonth" data-valor-original="${Number(
+              cuenta.actualMonth ?? 0
+            )}">${formatNumber(cuenta.actualMonth)}</td>
+            <td class="text-end editable-cell" data-columna-clave="planMonth" data-valor-original="${Number(
+              cuenta.planMonth ?? 0
+            )}">${formatNumber(cuenta.planMonth)}</td>
+            <td class="text-end editable-cell" data-columna-clave="prevMonth" data-valor-original="${Number(
+              cuenta.prevMonth ?? 0
+            )}">${formatNumber(cuenta.prevMonth)}</td>
             <td class="text-end">${variacionCuentaPlan}</td>
             <td class="text-end">${variacionCuentaPrev}</td>
           `;
@@ -173,6 +283,8 @@
     if (anioActual) {
       actualizarEtiquetasAnio(anioActual);
     }
+
+    activarModoEdicion();
   };
 
   const filterRows = (termino) => {

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -23,6 +23,9 @@
     return window.CapitulosModulos?.obtenerCapituloPorEmpresa?.(empresaId) || null;
   };
 
+  const cambiosPendientes = new Map();
+  let editMode = false;
+
   const MESES = [
     { etiqueta: 'Enero', clave: 'ene', periodo: 1 },
     { etiqueta: 'Febrero', clave: 'feb', periodo: 2 },
@@ -37,6 +40,105 @@
     { etiqueta: 'Noviembre', clave: 'nov', periodo: 11 },
     { etiqueta: 'Diciembre', clave: 'dic', periodo: 12 }
   ];
+
+  const limpiarCambios = () => {
+    cambiosPendientes.clear();
+    editMode = false;
+  };
+
+  const claveCambio = (cuenta, columna) => `${cuenta}|${columna}`;
+
+  const registrarCambio = (cuenta, columna, valor, original) => {
+    if (!cuenta || !columna) return;
+    cambiosPendientes.set(claveCambio(cuenta, columna), {
+      cuenta,
+      columna,
+      valor,
+      original
+    });
+  };
+
+  const eliminarCambio = (cuenta, columna) => {
+    cambiosPendientes.delete(claveCambio(cuenta, columna));
+  };
+
+  const obtenerCambiosPendientes = () => {
+    const porCuenta = new Map();
+    cambiosPendientes.forEach((registro) => {
+      const valores = porCuenta.get(registro.cuenta) || {};
+      valores[registro.columna] = registro.valor;
+      porCuenta.set(registro.cuenta, valores);
+    });
+
+    const presupuesto = Array.from(porCuenta.entries()).map(([cuenta, valores]) => ({
+      cuenta,
+      valores
+    }));
+
+    return { presupuesto, hayCambios: presupuesto.length > 0 };
+  };
+
+  const notificarCambios = () => {
+    const detalle = { ...obtenerCambiosPendientes(), borradorGuardado: false };
+    window.dispatchEvent(new CustomEvent('modulo-planeacion:presupuesto-editado', { detail: detalle }));
+  };
+
+  const parseNumber = (texto) => {
+    const limpio = String(texto || '')
+      .replace(/[^0-9,.-]/g, '')
+      .replace(/,/g, '');
+    const numero = Number(limpio);
+    return Number.isFinite(numero) ? numero : 0;
+  };
+
+  const restaurarValoresOriginales = () => {
+    if (!summaryBody) return;
+    Array.from(summaryBody.querySelectorAll('.editable-cell')).forEach((celda) => {
+      const original = Number(celda.dataset.valorOriginal ?? 0);
+      celda.textContent = formatNumber(original);
+    });
+  };
+
+  const cancelarEdicion = () => {
+    restaurarValoresOriginales();
+    limpiarCambios();
+    notificarCambios();
+  };
+
+  const manejarBlurCelda = (event) => {
+    const celda = event.currentTarget;
+    const fila = celda.closest('tr');
+    const cuenta = fila?.dataset.cuenta;
+    const columna = celda.dataset.columnaClave;
+    const original = Number(celda.dataset.valorOriginal ?? 0);
+    const nuevoValor = parseNumber(celda.textContent);
+
+    if (!cuenta || !columna) return;
+
+    if (nuevoValor !== original) {
+      celda.textContent = formatNumber(nuevoValor);
+      registrarCambio(cuenta, columna, nuevoValor, original);
+    } else {
+      celda.textContent = formatNumber(original);
+      eliminarCambio(cuenta, columna);
+    }
+
+    notificarCambios();
+  };
+
+  const activarModoEdicion = () => {
+    if (editMode || !summaryBody) return;
+    editMode = true;
+    const celdas = Array.from(summaryBody.querySelectorAll('.editable-cell'));
+    celdas.forEach((celda) => {
+      celda.contentEditable = 'true';
+      celda.addEventListener('blur', manejarBlurCelda);
+    });
+  };
+
+  window.CuentasModulo = window.CuentasModulo || {};
+  window.CuentasModulo.cancelEdit = cancelarEdicion;
+  window.CuentasModulo.getCambios = obtenerCambiosPendientes;
 
   // Compatibilidad: algunos layouts antiguos esperaban esta función.
   // Hoy el capítulo se deriva de la empresa activa, pero exponemos un
@@ -111,8 +213,9 @@
 
   const renderSummary = (resumen = [], mesSeleccionado) => {
     if (!summaryBody) return;
+    limpiarCambios();
     summaryBody.innerHTML = '';
-    
+
     if (!resumen.length) {
       summaryBody.innerHTML = '<tr><td colspan="12" class="text-center">Sin datos disponibles.</td></tr>';
       return;
@@ -177,17 +280,31 @@
           const ctaVarYTDPrev = calculateVar(cta.actualYTD, cta.prevYTD);
 
           const ctaRow = document.createElement('tr');
+          ctaRow.className = 'data-row';
+          ctaRow.dataset.cuenta = cta.cuenta;
           ctaRow.innerHTML = `
             <td class="font-monospace small text-start account-column">${cta.cuenta}</td>
-            ${createCell(cta.actualMonth)}
-            ${createCell(cta.planMonth)}
-            ${createCell(cta.prevMonth)}
+            <td class="text-end editable-cell" data-columna-clave="actualMonth" data-valor-original="${Number(
+              cta.actualMonth ?? 0
+            )}">${formatNumber(cta.actualMonth)}</td>
+            <td class="text-end editable-cell" data-columna-clave="planMonth" data-valor-original="${Number(
+              cta.planMonth ?? 0
+            )}">${formatNumber(cta.planMonth)}</td>
+            <td class="text-end editable-cell" data-columna-clave="prevMonth" data-valor-original="${Number(
+              cta.prevMonth ?? 0
+            )}">${formatNumber(cta.prevMonth)}</td>
             ${createPercentCell(ctaVarMonthPlan)}
             ${createPercentCell(ctaVarMonthPrev)}
             <td class="text-center">${cta.descripcion}</td>
-            ${createCell(cta.actualYTD)}
-            ${createCell(cta.planYTD)}
-            ${createCell(cta.prevYTD)}
+            <td class="text-end editable-cell" data-columna-clave="actualYTD" data-valor-original="${Number(
+              cta.actualYTD ?? 0
+            )}">${formatNumber(cta.actualYTD)}</td>
+            <td class="text-end editable-cell" data-columna-clave="planYTD" data-valor-original="${Number(
+              cta.planYTD ?? 0
+            )}">${formatNumber(cta.planYTD)}</td>
+            <td class="text-end editable-cell" data-columna-clave="prevYTD" data-valor-original="${Number(
+              cta.prevYTD ?? 0
+            )}">${formatNumber(cta.prevYTD)}</td>
             ${createPercentCell(ctaVarYTDPlan)}
             ${createPercentCell(ctaVarYTDPrev)}
           `;
@@ -199,6 +316,8 @@
     if (mesSeleccionado) {
       actualizarEtiquetaMes(mesSeleccionado);
     }
+
+    activarModoEdicion();
   };
 
   const renderAggregateTable = (resumen = []) => {
@@ -312,18 +431,25 @@
   document.addEventListener('DOMContentLoaded', async () => {
     const sesion = Sesion.requerirSesion();
     if (!sesion) return;
-    
+
     const empresa = Sesion.obtenerEmpresaActiva(sesion);
     if (!empresa?.id) {
       showStatus('Selecciona una empresa para continuar.', 'warning');
       return;
     }
-    
+
     // Cargar años disponibles
     const anios = await cargarAniosDisponibles(empresa.id);
     const mesActual = new Date().getMonth() + 1;
     const anioInicial = Number(selectAnio?.value) || anios[0] || new Date().getFullYear();
     const mesInicial = Number.isInteger(mesActual) ? mesActual : 1;
+    const modulo = document.body?.dataset?.modulo || 'summary';
+
+    window.dispatchEvent(
+      new CustomEvent('planeacion:contexto-actualizado', {
+        detail: { empresaId: empresa.id, anio: anioInicial, modulo }
+      })
+    );
 
     actualizarEtiquetasAnio(anioInicial, anioInicial - 1);
     await fetchSummary(empresa.id, anioInicial, mesInicial);
@@ -333,6 +459,11 @@
         const anio = Number(selectAnio.value) || anioInicial;
         const mes = Number(selectMes?.value) || mesInicial;
         actualizarEtiquetasAnio(anio, anio - 1);
+        window.dispatchEvent(
+          new CustomEvent('planeacion:contexto-actualizado', {
+            detail: { empresaId: empresa.id, anio, modulo }
+          })
+        );
         fetchSummary(empresa.id, anio, mes);
       });
     }
@@ -350,6 +481,11 @@
       selectMes.addEventListener('change', () => {
         const anio = Number(selectAnio?.value) || anioInicial;
         const mes = Number(selectMes.value) || mesInicial;
+        window.dispatchEvent(
+          new CustomEvent('planeacion:contexto-actualizado', {
+            detail: { empresaId: empresa.id, anio, modulo }
+          })
+        );
         fetchSummary(empresa.id, anio, mes);
       });
       actualizarEtiquetaMes(mesInicial);


### PR DESCRIPTION
## Summary
- add workflow toolbar and authorization drawer to SUMMARY, reusing shared toast and button identifiers
- enable inline edit tracking on resumen and summary tables so draft workflow buttons can operate on pending changes
- dispatch planning context updates for summary and expose change callbacks for the authorization flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930957c62e0832dbf2cd037d9088207)