### PR TITLE
Add remote API config and client mode handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
+const { CLIENTE_REMOTO } = require('./src/config/apiConfig');
 
 const resolveAssetPath = (...segments) => {
   return path.join(app.getAppPath(), ...segments);
@@ -37,8 +38,12 @@ const createWindow = () => {
 
 app.whenReady().then(() => {
   process.env.PANELAMCHAM_DATA_DIR = path.join(app.getPath('userData'), 'datos');
-  const iniciarServidor = require('./src/server');
-  iniciarServidor();
+  if (!CLIENTE_REMOTO) {
+    const iniciarServidor = require('./src/server');
+    iniciarServidor();
+  } else {
+    console.info('Modo cliente remoto activo: no se iniciará el servidor local.');
+  }
   app.setAppUserModelId('com.summa.cham');
   createWindow();
 

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,0 +1,9 @@
+const DEFAULT_API_BASE_URL = 'https://amcham.iconetcloud.com.mx/api';
+
+const API_BASE_URL = process.env.API_BASE_URL || DEFAULT_API_BASE_URL;
+const CLIENTE_REMOTO = String(process.env.CLIENTE_REMOTO || '').toLowerCase() === 'true';
+
+module.exports = {
+  API_BASE_URL,
+  CLIENTE_REMOTO
+};

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,0 +1,33 @@
+const { API_BASE_URL } = require('../config/apiConfig');
+
+const parsearJson = async (respuesta) => {
+  const texto = await respuesta.text();
+  try {
+    return JSON.parse(texto);
+  } catch (error) {
+    throw new Error(`No se pudo interpretar la respuesta del API: ${texto}`);
+  }
+};
+
+const solicitarAPI = async (ruta, opciones = {}) => {
+  const url = ruta.startsWith('http') ? ruta : `${API_BASE_URL}${ruta}`;
+  const respuesta = await fetch(url, {
+    ...opciones,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(opciones.headers || {})
+    }
+  });
+
+  if (!respuesta.ok) {
+    const cuerpo = await respuesta.text();
+    throw new Error(`API remota respondió ${respuesta.status}: ${cuerpo}`);
+  }
+
+  return parsearJson(respuesta);
+};
+
+module.exports = {
+  API_BASE_URL,
+  solicitarAPI
+};

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -1,5 +1,7 @@
+const { CLIENTE_REMOTO } = require('../config/apiConfig');
+const { solicitarAPI } = require('./apiClient');
 const { ejecutarConsulta } = require('./firebirdService');
-const { listarAniosSaldos } = require('./saldosMetadataService');
+const { listarAniosSaldos: listarAniosSaldosLocal } = require('./saldosMetadataService');
 const { construirSelectResumen } = require('./saldosResumenHelper');
 
 // Mapea filas crudas a objetos tipados por codigo
@@ -25,6 +27,16 @@ const normalizarCodigos = (codigos) => (Array.isArray(codigos) ? codigos : []).m
 
 // Punto de entrada desde el router: arma payload para el front (detalle + ejercicios)
 async function obtenerResumen({ empresaId, anio, periodo, codigos = [], anioComparativo, usarAjusteEnYTD = false }) {
+  if (CLIENTE_REMOTO) {
+    return solicitarAPI('/modulos/summary-resumen-e', {
+      method: 'POST',
+      body: JSON.stringify({ empresaId, anio, periodo, codigos, anioComparativo, usarAjusteEnYTD }),
+      headers: {
+        'X-Empresa-Activa': empresaId
+      }
+    });
+  }
+
   const ejercicio = Number(anio);
   const periodoNum = Number(periodo);
   const comp = anioComparativo != null ? Number(anioComparativo) : ejercicio - 1;
@@ -123,6 +135,19 @@ async function obtenerResumen({ empresaId, anio, periodo, codigos = [], anioComp
     ejerciciosDisponibles
   };
 }
+
+const listarAniosSaldos = async (empresaId) => {
+  if (CLIENTE_REMOTO) {
+    const params = new URLSearchParams({ empresaId: empresaId || '' });
+    return solicitarAPI(`/modulos/summary-anios?${params.toString()}`, {
+      headers: {
+        'X-Empresa-Activa': empresaId
+      }
+    });
+  }
+
+  return listarAniosSaldosLocal(empresaId);
+};
 
 module.exports = {
   obtenerResumen,

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -504,6 +504,7 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="js/api-config.js"></script>
   <script src="js/sesion.js"></script>
   <script src="js/capitulos-modulos.js"></script>
   <script type="text/babel" src="js/react-app.jsx"></script>

--- a/vistas/crear_usuario.html
+++ b/vistas/crear_usuario.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/estilos.css">
+  <script src="js/api-config.js"></script>
   <style>
  :root {
       --bs-primary: #2f5496;
@@ -201,7 +202,20 @@
   <script src="js/sesion.js"></script>
 
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const configurarApi = () => {
+      if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+      const baseDetectada = window.location.protocol === 'file:'
+        ? 'https://amcham.iconetcloud.com.mx/api'
+        : `${window.location.origin}/api`;
+      const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+      const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+      window.API_BASE_URL = apiBase;
+      window.apiUrl = construir;
+    };
+
+    configurarApi();
+
+    const API_BASE = window.API_BASE_URL;
     const MODULOS = ['Membresía', 'Eventos', 'Comunicación', 'Dirección', 'Serv Membresía', 'Comités', 'T&IC', 'RH', 'VPE', 'Finanzas', 'Gtos Corporativos', 'SUMMARY', 'Presupuestos', 'RESUMEN'];
     const ACCIONES = ['Cargar y guardar', 'Revisar', 'Aprobar'];
     const normalizarUsuarioEntrada = (valor = '') => valor.toString().trim().toUpperCase();
@@ -599,7 +613,7 @@
     const cargarEmpresas = async () => {
       let empresas = [];
       try {
-        const respuesta = await fetch(`${API_BASE}/empresas`);
+        const respuesta = await fetch(window.apiUrl('empresas'));
         const datos = await respuesta.json();
         if (!respuesta.ok) throw new Error();
         empresas = Array.isArray(datos.empresas) ? datos.empresas : [];
@@ -624,7 +638,7 @@
     };
 
     const cargarUsuario = async (id) => {
-      const respuesta = await fetch(`${API_BASE}/usuarios/${id}`,
+      const respuesta = await fetch(window.apiUrl(`usuarios/${id}`),
         { headers: Sesion.headersAutenticacion() });
       const datos = await respuesta.json();
       if (!respuesta.ok) {
@@ -789,7 +803,7 @@
       const payload = recopilarDatos(esEdicion);
 
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios${esEdicion ? `/${idEdicion}` : ''}`, {
+        const respuesta = await fetch(window.apiUrl(`usuarios${esEdicion ? `/${idEdicion}` : ''}`), {
           method: esEdicion ? 'PUT' : 'POST',
           headers: {
             ...Sesion.headersAutenticacion(),

--- a/vistas/js/api-config.js
+++ b/vistas/js/api-config.js
@@ -1,0 +1,26 @@
+(() => {
+  const DEFAULT_API_BASE_URL = 'https://amcham.iconetcloud.com.mx/api';
+
+  const sanitizeBase = (valor) => {
+    const limpio = (valor || '').toString().trim();
+    if (!limpio) return '';
+    return limpio.replace(/\/$/, '');
+  };
+
+  const detectarBasePorUbicacion = () => {
+    if (window.location.protocol === 'file:') {
+      return DEFAULT_API_BASE_URL;
+    }
+    return `${window.location.origin}/api`;
+  };
+
+  const apiBase = sanitizeBase(window.API_BASE_URL) || detectarBasePorUbicacion();
+
+  const construirUrl = (ruta = '') => {
+    const prefijo = ruta.startsWith('/') ? '' : '/';
+    return `${apiBase}${prefijo}${ruta}`;
+  };
+
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construirUrl;
+})();

--- a/vistas/js/cuentas-modulo.js
+++ b/vistas/js/cuentas-modulo.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const EVENTO_TABLA_ACTUALIZADA = 'modulo-planeacion:tabla-actualizada';
   const EVENTO_CONTEXTO = 'planeacion:contexto-actualizado';
   const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];

--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -1,6 +1,18 @@
 (() => {
-  const origin = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_BASE = `${origin}/api`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const FORMATTER_NUMEROS = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   const EVENTO_CONTEXTO = 'planeacion:contexto-actualizado';
   const EVENTO_EDICION = 'modulo-planeacion:presupuesto-editado';

--- a/vistas/js/logica-resumen.js
+++ b/vistas/js/logica-resumen.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const YEAR_SELECT = document.getElementById('resumenYearSelect');
   const MONTH_SELECT = document.getElementById('resumenMonthSelect');
   const TABLE_BODY = document.getElementById('tablaCuentasBody');

--- a/vistas/js/modulo-generico.js
+++ b/vistas/js/modulo-generico.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
 
   const crearTarjeta = (item = {}) => {
     const titulo = item.titulo || item.title || 'Elemento sin nombre';

--- a/vistas/js/planeacion-modulo-vista.js
+++ b/vistas/js/planeacion-modulo-vista.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
 
   const crearSlug = (texto, fallback = 'modulo') => {
     if (!texto) {

--- a/vistas/js/presupuesto-vista.js
+++ b/vistas/js/presupuesto-vista.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const MESES = [
     { etiqueta: 'Ene', clave: 'ene' },
     { etiqueta: 'Feb', clave: 'feb' },

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -1,6 +1,19 @@
 const { useState, useEffect, useMemo, useCallback } = React;
 
-const API_BASE = 'http://localhost:3000/api';
+const configurarApi = () => {
+  if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+  const baseDetectada = window.location.protocol === 'file:'
+    ? 'https://amcham.iconetcloud.com.mx/api'
+    : `${window.location.origin}/api`;
+  const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+  const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construir;
+};
+
+configurarApi();
+
+const API_BASE = window.API_BASE_URL;
 
 const MODULE_GROUPS = [
   {

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -1,7 +1,19 @@
 (() => {
-  const base = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_ENDPOINT = `${base}/api/reportes/resumen`;
-  const API_ANIOS = `${base}/api/saldos/anios`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_ENDPOINT = window.apiUrl('reportes/resumen');
+  const API_ANIOS = window.apiUrl('saldos/anios');
   
   const formatNumber = (valor) => {
     const monto = Number(valor ?? 0);
@@ -109,7 +121,7 @@
       });
       
       if (!response.ok) {
-        throw new Error('No fue posible obtener años disponibles');
+        throw new Error('No fue posible obtener aÃ±os disponibles');
       }
       
       const data = await response.json();
@@ -119,7 +131,7 @@
       if (!anios.length) {
         const option = document.createElement('option');
         option.value = '';
-        option.textContent = 'Sin años disponibles';
+        option.textContent = 'Sin aÃ±os disponibles';
         yearSelect.appendChild(option);
         return [];
       }
@@ -135,8 +147,8 @@
 
       return anios;
     } catch (error) {
-      console.error('Error cargando años:', error);
-      yearSelect.innerHTML = '<option value="">Error cargando años</option>';
+      console.error('Error cargando aÃ±os:', error);
+      yearSelect.innerHTML = '<option value="">Error cargando aÃ±os</option>';
       return [];
     }
   };
@@ -283,7 +295,7 @@
   const renderTable = (nodos = [], anioActual) => {
     if (!tablaBody) return;
     if (!nodos.length) {
-      setStatusRow('No hay datos disponibles para este a�o.');
+      setStatusRow('No hay datos disponibles para este año.');
       return;
     }
     tablaBody.innerHTML = '';
@@ -358,7 +370,7 @@
 
           totalesRow.innerHTML = `
             <td class="ps-4">${seccion.label}</td>
-            <td>Total secci�n</td>
+            <td>Total sección</td>
             <td class="text-end">${formatNumber(seccion.totalActualMonth)}</td>
             <td class="text-end">${formatNumber(seccion.totalPlanMonth)}</td>
             <td class="text-end">${formatNumber(seccion.totalPrevMonth)}</td>

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -1,7 +1,19 @@
 (() => {
-  const base = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_ENDPOINT = `${base}/api/reportes/summary`;
-  const API_ANIOS = `${base}/api/saldos/anios`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_ENDPOINT = window.apiUrl('reportes/summary');
+  const API_ANIOS = window.apiUrl('saldos/anios');
 
   const toNumber = (valor) => {
     const numero = Number(valor);

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -10,7 +10,20 @@
 // ================================
 // === CONFIG / ESTADO GENERAL ===
 // ================================
-const API_BASE = 'http://localhost:3000/api';
+const configurarApi = () => {
+  if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+  const baseDetectada = window.location.protocol === 'file:'
+    ? 'https://amcham.iconetcloud.com.mx/api'
+    : `${window.location.origin}/api`;
+  const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+  const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construir;
+};
+
+configurarApi();
+
+const API_BASE = window.API_BASE_URL;
 /*
   Resumen de la logica (guia rapida):
   - CURRENT_LAYOUT describe la jerarquia/colores de la tabla (simula el Excel original).

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -7,6 +7,7 @@
   <title>Iniciar sesión</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="js/api-config.js"></script>
   <style>
     :root {
       --color-primario: #2f5496;
@@ -110,7 +111,7 @@
 
   <script src="js/sesion.js"></script>
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const API_BASE = window.API_BASE_URL;
     const formulario = document.getElementById('formularioLogin');
     const alerta = document.getElementById('alerta');
     const boton = document.getElementById('botonIngresar');
@@ -141,7 +142,7 @@
       };
 
       try {
-        const respuesta = await fetch(`${API_BASE}/auth/login`, {
+        const respuesta = await fetch(window.apiUrl('auth/login'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(cuerpo)

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/estilos.css">
+  <script src="js/api-config.js"></script>
   <style>
     :root {
       --bs-primary: #2f5496;
@@ -182,7 +183,20 @@
 
   <script src="js/sesion.js"></script>
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const configurarApi = () => {
+      if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+      const baseDetectada = window.location.protocol === 'file:'
+        ? 'https://amcham.iconetcloud.com.mx/api'
+        : `${window.location.origin}/api`;
+      const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+      const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+      window.API_BASE_URL = apiBase;
+      window.apiUrl = construir;
+    };
+
+    configurarApi();
+
+    const API_BASE = window.API_BASE_URL;
     const sesion = Sesion.requerirSesion({ requireAdmin: true });
     if (!sesion) {
       throw new Error('Redireccionando al inicio de sesión.');
@@ -298,7 +312,7 @@
     const cargarUsuarios = async () => {
       limpiarAlerta();
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios`, {
+        const respuesta = await fetch(window.apiUrl('usuarios'), {
           headers: Sesion.headersAutenticacion()
         });
         const datos = await respuesta.json();
@@ -343,7 +357,7 @@
       const ok = await confirmarEliminacion('¿Deseas eliminar al usuario seleccionado? Esta acción no se puede deshacer.');
       if (!ok) return;
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios/${id}`, {
+        const respuesta = await fetch(window.apiUrl(`usuarios/${id}`), {
           method: 'DELETE',
           headers: Sesion.headersAutenticacion()
         });


### PR DESCRIPTION
## Summary
- add a shared API configuration file to centralize the remote backend URL and remote client flag
- create a reusable API client helper and update the summary service to call the remote backend when configured
- update Electron startup to skip booting the local server while in remote client mode
- propagate the shared API base to all renderer views via a shared helper to remove hardcoded localhost URLs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930c9feaf4c832dbdbaa2936e26e96b)