### PR TITLE
Alinear selección de empresa y orden en summary y resumen

### DIFF
--- a/info IMPORTANTE/API TUNEL.md
+++ b/info IMPORTANTE/API TUNEL.md
@@ -1,0 +1,56 @@
+### La Solución: Divide y Vencerás (Arquitectura API)
+
+No puedes instalar la App "entera" en el Servidor B y esperar que lea los archivos del Servidor A.
+Lo que debes hacer es **separar el cerebro del cuerpo**.
+
+1. **Servidor A (Windows 8 - Donde están los archivos):**
+
+   * Aquí **SÍ** necesitas ejecutar algo, pero no la App completa.
+   * Ejecutas solo el **Backend (API)**. Es un script ligero de Node.js que sí es compatible con Windows 8.
+   * Este script lee los archivos localmente (rápido y seguro) y los convierte en datos web (JSON).
+   * El túnel expone este script a internet.
+2. **Servidor B (Nuevo - Donde instalarás la App):**
+
+   * Aquí instalas tu aplicación "Visual" (PanelAMCHAM).
+   * Pero en lugar de configurarla para que busque un archivo local `C:\...`, la configuras para que pida los datos a `https://amcham.iconetcloud.com.mx` (que es tu túnel en el Servidor A).
+
+---
+
+### Guía para implementar esto
+
+#### Paso 1: En el Servidor A (El viejo con los archivos)
+
+Ya lograste configurar el túnel. Ahora necesitamos que el túnel tenga algo que mostrar.
+Como la App completa no se instala, usaremos la versión "portable" de Node.js que te mencioné antes:
+
+1. Copia tu carpeta de código (`src`, `package.json`, `node_modules`) al Servidor A.
+2. Descarga **Node.js v16 (versión ZIP/Binario)** y ponlo en una carpeta.
+3. Crea un archivo `.bat` simple en el escritorio para iniciar el "cerebro":
+   ```batch
+   C:\Ruta\Node16\node.exe C:\Ruta\TuProyecto\src\server.js
+   ```
+4. Al darle doble clic, tu Servidor A empezará a "servir" los datos de Aspel y SQLite por el puerto 3000.
+5. Tu túnel (que ya configuraste apuntando a `localhost:3000`) empezará a transmitir esos datos al mundo.
+
+#### Paso 2: En el Servidor B (El nuevo)
+
+Instala tu aplicación `PanelAMCHAM`.
+Ahora, necesitas hacer un pequeño cambio en tu código **antes** de instalarla o compilarla para este servidor.
+
+En tu archivo (y otros servicios donde hagas `fetch`), seguramente tienes llamadas a `localhost` o rutas relativas `/api/...`.
+
+Debes configurar la App del Servidor B para que sus peticiones apunten al túnel:
+
+* Cambia la `BASE_URL` de tu frontend para que sea: `https://amcham.iconetcloud.com.mx`.
+
+**Ejemplo conceptual:**
+
+* **Antes (Local):** `fetch('/api/compc')` -\> Busca en sí mismo.
+* **Ahora (Remoto):** `fetch('https://amcham.iconetcloud.com.mx/api/compc')` -\> Viaja por internet -\> Entra al Túnel -\> Llega al Servidor A -\> Node.js lee el archivo local -\> Regresa el dato.
+
+### Resumen
+
+* **¿Puedo usar el túnel para leer la ruta de archivos?** No.
+* **¿Qué hago entonces?** Ejecuta un pequeño script (API) en el servidor viejo que lea los archivos y te los mande por el túnel a tu servidor nuevo.
+
+¿Te sientes cómodo ejecutando solo el script `server.js` con un Node.js portable en el Windows 8? Es la solución más robusta y profesional.

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
+const { CLIENTE_REMOTO } = require('./src/config/apiConfig');
 
 const resolveAssetPath = (...segments) => {
   return path.join(app.getAppPath(), ...segments);
@@ -37,8 +38,12 @@ const createWindow = () => {
 
 app.whenReady().then(() => {
   process.env.PANELAMCHAM_DATA_DIR = path.join(app.getPath('userData'), 'datos');
-  const iniciarServidor = require('./src/server');
-  iniciarServidor();
+  if (!CLIENTE_REMOTO) {
+    const iniciarServidor = require('./src/server');
+    iniciarServidor();
+  } else {
+    console.info('Modo cliente remoto activo: no se iniciará el servidor local.');
+  }
   app.setAppUserModelId('com.summa.cham');
   createWindow();
 

--- a/src/config/apiConfig.js
+++ b/src/config/apiConfig.js
@@ -1,0 +1,9 @@
+const DEFAULT_API_BASE_URL = 'https://amcham.iconetcloud.com.mx/api';
+
+const API_BASE_URL = process.env.API_BASE_URL || DEFAULT_API_BASE_URL;
+const CLIENTE_REMOTO = String(process.env.CLIENTE_REMOTO || '').toLowerCase() === 'true';
+
+module.exports = {
+  API_BASE_URL,
+  CLIENTE_REMOTO
+};

--- a/src/services/apiClient.js
+++ b/src/services/apiClient.js
@@ -1,0 +1,33 @@
+const { API_BASE_URL } = require('../config/apiConfig');
+
+const parsearJson = async (respuesta) => {
+  const texto = await respuesta.text();
+  try {
+    return JSON.parse(texto);
+  } catch (error) {
+    throw new Error(`No se pudo interpretar la respuesta del API: ${texto}`);
+  }
+};
+
+const solicitarAPI = async (ruta, opciones = {}) => {
+  const url = ruta.startsWith('http') ? ruta : `${API_BASE_URL}${ruta}`;
+  const respuesta = await fetch(url, {
+    ...opciones,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(opciones.headers || {})
+    }
+  });
+
+  if (!respuesta.ok) {
+    const cuerpo = await respuesta.text();
+    throw new Error(`API remota respondió ${respuesta.status}: ${cuerpo}`);
+  }
+
+  return parsearJson(respuesta);
+};
+
+module.exports = {
+  API_BASE_URL,
+  solicitarAPI
+};

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -1,5 +1,7 @@
+const { CLIENTE_REMOTO } = require('../config/apiConfig');
+const { solicitarAPI } = require('./apiClient');
 const { ejecutarConsulta } = require('./firebirdService');
-const { listarAniosSaldos } = require('./saldosMetadataService');
+const { listarAniosSaldos: listarAniosSaldosLocal } = require('./saldosMetadataService');
 const { construirSelectResumen } = require('./saldosResumenHelper');
 
 // Mapea filas crudas a objetos tipados por codigo
@@ -25,6 +27,16 @@ const normalizarCodigos = (codigos) => (Array.isArray(codigos) ? codigos : []).m
 
 // Punto de entrada desde el router: arma payload para el front (detalle + ejercicios)
 async function obtenerResumen({ empresaId, anio, periodo, codigos = [], anioComparativo, usarAjusteEnYTD = false }) {
+  if (CLIENTE_REMOTO) {
+    return solicitarAPI('/modulos/summary-resumen-e', {
+      method: 'POST',
+      body: JSON.stringify({ empresaId, anio, periodo, codigos, anioComparativo, usarAjusteEnYTD }),
+      headers: {
+        'X-Empresa-Activa': empresaId
+      }
+    });
+  }
+
   const ejercicio = Number(anio);
   const periodoNum = Number(periodo);
   const comp = anioComparativo != null ? Number(anioComparativo) : ejercicio - 1;
@@ -123,6 +135,19 @@ async function obtenerResumen({ empresaId, anio, periodo, codigos = [], anioComp
     ejerciciosDisponibles
   };
 }
+
+const listarAniosSaldos = async (empresaId) => {
+  if (CLIENTE_REMOTO) {
+    const params = new URLSearchParams({ empresaId: empresaId || '' });
+    return solicitarAPI(`/modulos/summary-anios?${params.toString()}`, {
+      headers: {
+        'X-Empresa-Activa': empresaId
+      }
+    });
+  }
+
+  return listarAniosSaldosLocal(empresaId);
+};
 
 module.exports = {
   obtenerResumen,

--- a/vistas/app.html
+++ b/vistas/app.html
@@ -504,6 +504,7 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="js/api-config.js"></script>
   <script src="js/sesion.js"></script>
   <script src="js/capitulos-modulos.js"></script>
   <script type="text/babel" src="js/react-app.jsx"></script>

--- a/vistas/crear_usuario.html
+++ b/vistas/crear_usuario.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/estilos.css">
+  <script src="js/api-config.js"></script>
   <style>
  :root {
       --bs-primary: #2f5496;
@@ -201,7 +202,20 @@
   <script src="js/sesion.js"></script>
 
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const configurarApi = () => {
+      if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+      const baseDetectada = window.location.protocol === 'file:'
+        ? 'https://amcham.iconetcloud.com.mx/api'
+        : `${window.location.origin}/api`;
+      const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+      const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+      window.API_BASE_URL = apiBase;
+      window.apiUrl = construir;
+    };
+
+    configurarApi();
+
+    const API_BASE = window.API_BASE_URL;
     const MODULOS = ['Membresía', 'Eventos', 'Comunicación', 'Dirección', 'Serv Membresía', 'Comités', 'T&IC', 'RH', 'VPE', 'Finanzas', 'Gtos Corporativos', 'SUMMARY', 'Presupuestos', 'RESUMEN'];
     const ACCIONES = ['Cargar y guardar', 'Revisar', 'Aprobar'];
     const normalizarUsuarioEntrada = (valor = '') => valor.toString().trim().toUpperCase();
@@ -599,7 +613,7 @@
     const cargarEmpresas = async () => {
       let empresas = [];
       try {
-        const respuesta = await fetch(`${API_BASE}/empresas`);
+        const respuesta = await fetch(window.apiUrl('empresas'));
         const datos = await respuesta.json();
         if (!respuesta.ok) throw new Error();
         empresas = Array.isArray(datos.empresas) ? datos.empresas : [];
@@ -624,7 +638,7 @@
     };
 
     const cargarUsuario = async (id) => {
-      const respuesta = await fetch(`${API_BASE}/usuarios/${id}`,
+      const respuesta = await fetch(window.apiUrl(`usuarios/${id}`),
         { headers: Sesion.headersAutenticacion() });
       const datos = await respuesta.json();
       if (!respuesta.ok) {
@@ -789,7 +803,7 @@
       const payload = recopilarDatos(esEdicion);
 
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios${esEdicion ? `/${idEdicion}` : ''}`, {
+        const respuesta = await fetch(window.apiUrl(`usuarios${esEdicion ? `/${idEdicion}` : ''}`), {
           method: esEdicion ? 'PUT' : 'POST',
           headers: {
             ...Sesion.headersAutenticacion(),

--- a/vistas/js/api-config.js
+++ b/vistas/js/api-config.js
@@ -1,0 +1,26 @@
+(() => {
+  const DEFAULT_API_BASE_URL = 'https://amcham.iconetcloud.com.mx/api';
+
+  const sanitizeBase = (valor) => {
+    const limpio = (valor || '').toString().trim();
+    if (!limpio) return '';
+    return limpio.replace(/\/$/, '');
+  };
+
+  const detectarBasePorUbicacion = () => {
+    if (window.location.protocol === 'file:') {
+      return DEFAULT_API_BASE_URL;
+    }
+    return `${window.location.origin}/api`;
+  };
+
+  const apiBase = sanitizeBase(window.API_BASE_URL) || detectarBasePorUbicacion();
+
+  const construirUrl = (ruta = '') => {
+    const prefijo = ruta.startsWith('/') ? '' : '/';
+    return `${apiBase}${prefijo}${ruta}`;
+  };
+
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construirUrl;
+})();

--- a/vistas/js/cuentas-modulo.js
+++ b/vistas/js/cuentas-modulo.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const EVENTO_TABLA_ACTUALIZADA = 'modulo-planeacion:tabla-actualizada';
   const EVENTO_CONTEXTO = 'planeacion:contexto-actualizado';
   const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];

--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -1,6 +1,18 @@
 (() => {
-  const origin = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_BASE = `${origin}/api`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const FORMATTER_NUMEROS = new Intl.NumberFormat('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   const EVENTO_CONTEXTO = 'planeacion:contexto-actualizado';
   const EVENTO_EDICION = 'modulo-planeacion:presupuesto-editado';

--- a/vistas/js/logica-resumen.js
+++ b/vistas/js/logica-resumen.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const YEAR_SELECT = document.getElementById('resumenYearSelect');
   const MONTH_SELECT = document.getElementById('resumenMonthSelect');
   const TABLE_BODY = document.getElementById('tablaCuentasBody');

--- a/vistas/js/modulo-generico.js
+++ b/vistas/js/modulo-generico.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
 
   const crearTarjeta = (item = {}) => {
     const titulo = item.titulo || item.title || 'Elemento sin nombre';

--- a/vistas/js/planeacion-modulo-vista.js
+++ b/vistas/js/planeacion-modulo-vista.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
 
   const crearSlug = (texto, fallback = 'modulo') => {
     if (!texto) {

--- a/vistas/js/presupuesto-vista.js
+++ b/vistas/js/presupuesto-vista.js
@@ -1,5 +1,18 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_BASE = window.API_BASE_URL;
   const MESES = [
     { etiqueta: 'Ene', clave: 'ene' },
     { etiqueta: 'Feb', clave: 'feb' },

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -1,6 +1,19 @@
 const { useState, useEffect, useMemo, useCallback } = React;
 
-const API_BASE = 'http://localhost:3000/api';
+const configurarApi = () => {
+  if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+  const baseDetectada = window.location.protocol === 'file:'
+    ? 'https://amcham.iconetcloud.com.mx/api'
+    : `${window.location.origin}/api`;
+  const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+  const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construir;
+};
+
+configurarApi();
+
+const API_BASE = window.API_BASE_URL;
 
 const MODULE_GROUPS = [
   {

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -50,13 +50,20 @@
     'COMMITTEES',
     'T&IC',
     'SERVICES TO MEMBERS',
+    'GUADALAJARA INCOME',
+    'MONTERREY INCOME',
+    'NORTHWEST INCOME',
     'GASTOS ADMINISTRATIVOS',
     'GASTOS GENERALES',
     'NOMINA',
     'GASTOS CORPORATIVOS',
+    'GUADALAJARA EXPENSE',
+    'MONTERREY EXPENSE',
+    'NORTHWEST EXPENSE',
     'CARGOS ADMINISTRATIVOS',
     'MEMBER CENTRICITY',
-    'OTHER'
+    'OTHER',
+    'OTHER INCOME'
   ];
   const SECTION_DEFAULT_ORDER = SECTION_ORDER.length;
   const sectionOrder = (label) => {
@@ -72,7 +79,8 @@
     'INCOME',
     'EXPENSE',
     'OPERATING',
-    'OTHER'
+    'OTHER',
+    'NET'
   ];
   const nodePriority = (label) => {
     const text = normalizeText(label);
@@ -97,19 +105,29 @@
       return normalizeText(a.label).localeCompare(normalizeText(b.label));
     });
   };
-  const obtenerSelectorEmpresaGlobal = () => window.parent?.document?.getElementById('companyFilter') || null;
+  const obtenerSelectorEmpresaGlobal = () =>
+    window.parent?.document?.getElementById('companyFilter')
+    || document.getElementById('companyFilter')
+    || null;
+
   const sincronizarSelectorEmpresaGlobal = () => {
     const selector = obtenerSelectorEmpresaGlobal();
     if (!selector) return;
-    selector.addEventListener('change', async () => {
-      const nuevoId = selector.value;
+
+    const aplicarSeleccion = async (nuevoId) => {
       if (!nuevoId) return;
       const empresaLocal = Sesion.obtenerEmpresaActiva();
       if (empresaLocal?.id === nuevoId) return;
       Sesion.establecerEmpresaActiva(nuevoId);
       empresaActual = Sesion.obtenerEmpresaActiva();
       await aplicarEmpresaResumen(empresaActual?.id);
-    });
+    };
+
+    if (selector.value) {
+      aplicarSeleccion(selector.value);
+    }
+
+    selector.addEventListener('change', () => aplicarSeleccion(selector.value));
   };
 
   const cargarAniosDisponibles = async (empresaId) => {
@@ -456,7 +474,12 @@
   document.addEventListener('DOMContentLoaded', async () => {
     const sesion = Sesion.requerirSesion();
     if (!sesion) return;
-    const empresa = Sesion.obtenerEmpresaActiva(sesion);
+    const selectorEmpresa = obtenerSelectorEmpresaGlobal();
+    let empresa = Sesion.obtenerEmpresaActiva(sesion);
+    if (!empresa?.id && selectorEmpresa?.value) {
+      Sesion.establecerEmpresaActiva(selectorEmpresa.value);
+      empresa = Sesion.obtenerEmpresaActiva();
+    }
     if (!empresa?.id) {
       setStatusRow('Selecciona una empresa para continuar.');
       return;

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -1,7 +1,19 @@
 (() => {
-  const base = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_ENDPOINT = `${base}/api/reportes/resumen`;
-  const API_ANIOS = `${base}/api/saldos/anios`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_ENDPOINT = window.apiUrl('reportes/resumen');
+  const API_ANIOS = window.apiUrl('saldos/anios');
   
   const formatNumber = (valor) => {
     const monto = Number(valor ?? 0);
@@ -109,7 +121,7 @@
       });
       
       if (!response.ok) {
-        throw new Error('No fue posible obtener años disponibles');
+        throw new Error('No fue posible obtener aÃ±os disponibles');
       }
       
       const data = await response.json();
@@ -119,7 +131,7 @@
       if (!anios.length) {
         const option = document.createElement('option');
         option.value = '';
-        option.textContent = 'Sin años disponibles';
+        option.textContent = 'Sin aÃ±os disponibles';
         yearSelect.appendChild(option);
         return [];
       }
@@ -135,8 +147,8 @@
 
       return anios;
     } catch (error) {
-      console.error('Error cargando años:', error);
-      yearSelect.innerHTML = '<option value="">Error cargando años</option>';
+      console.error('Error cargando aÃ±os:', error);
+      yearSelect.innerHTML = '<option value="">Error cargando aÃ±os</option>';
       return [];
     }
   };
@@ -283,7 +295,7 @@
   const renderTable = (nodos = [], anioActual) => {
     if (!tablaBody) return;
     if (!nodos.length) {
-      setStatusRow('No hay datos disponibles para este a�o.');
+      setStatusRow('No hay datos disponibles para este año.');
       return;
     }
     tablaBody.innerHTML = '';
@@ -358,7 +370,7 @@
 
           totalesRow.innerHTML = `
             <td class="ps-4">${seccion.label}</td>
-            <td>Total secci�n</td>
+            <td>Total sección</td>
             <td class="text-end">${formatNumber(seccion.totalActualMonth)}</td>
             <td class="text-end">${formatNumber(seccion.totalPlanMonth)}</td>
             <td class="text-end">${formatNumber(seccion.totalPrevMonth)}</td>

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -99,7 +99,7 @@
     return index === -1 ? 999 : index;
   };
 
-  const PRINCIPAL_ORDER = ['INCOME', 'EXPENSE', 'OPERATING', 'OTHER'];
+  const PRINCIPAL_ORDER = ['INCOME', 'EXPENSE', 'OPERATING', 'OTHER', 'NET'];
   const getPrincipalPriority = (label) => {
     const text = normalizeText(label);
     const index = PRINCIPAL_ORDER.findIndex(key => text.includes(key));
@@ -499,7 +499,13 @@
         flujoAutorizacion.init();
     }
 
-    const empresa = Sesion.obtenerEmpresaActiva(sesion);
+    const selectorEmpresa = obtenerSelectorGlobalEmpresa();
+    let empresa = Sesion.obtenerEmpresaActiva(sesion);
+    if (!empresa?.id && selectorEmpresa?.value) {
+      Sesion.establecerEmpresaActiva(selectorEmpresa.value);
+      empresa = Sesion.obtenerEmpresaActiva();
+    }
+
     if (!empresa?.id) {
       showStatus('Selecciona una empresa para continuar.', 'warning');
       return;

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -21,14 +21,26 @@
   const selectMes = document.getElementById('selectMes');
   const capituloLabel = document.getElementById('capituloLabel');
   const selectCapitulo = document.getElementById('selectCapitulo');
+  
   let capituloActual = '';
   let empresaActual = null;
+  let flujoAutorizacion = null;
+
   const leerAnioSeleccionado = () => Number(selectAnio?.value) || new Date().getFullYear();
   const leerMesSeleccionado = () => Number(selectMes?.value) || (new Date().getMonth() + 1);
-  const obtenerSelectorGlobalEmpresa = () => window.parent?.document?.getElementById('companyFilter') || null;
+  
+  const obtenerSelectorGlobalEmpresa = () => window.parent?.document?.getElementById('companyFilter') || document.getElementById('companyFilter');
+  
   const sincronizarSelectorEmpresaGlobal = () => {
     const selector = obtenerSelectorGlobalEmpresa();
     if (!selector) return;
+    
+    if (selector.value && (!empresaActual || empresaActual.id !== selector.value)) {
+        Sesion.establecerEmpresaActiva(selector.value);
+        empresaActual = Sesion.obtenerEmpresaActiva();
+        aplicarEmpresa(empresaActual?.id);
+    }
+
     selector.addEventListener('change', async () => {
       const nuevoId = selector.value;
       if (!nuevoId) return;
@@ -39,15 +51,68 @@
       await aplicarEmpresa(empresaActual?.id);
     });
   };
+
   const obtenerCapituloEmpresa = (empresaId) => {
     return window.CapitulosModulos?.obtenerCapituloPorEmpresa?.(empresaId) || null;
   };
 
-  const cambiosPendientes = new Map();
-  let editMode = false;
-
+  // --- Ordering Logic (Waterfall) ---
   const normalizeText = (texto) => (texto || '').toString().normalize('NFD').replace(/\p{Diacritic}/gu, '').toUpperCase();
 
+  const SECTION_ORDER = [
+    'MEMBERSHIP',
+    'EVENTS',
+    'COMMITTEES',
+    'T&IC',
+    'SERVICES TO MEMBERS',
+    'GUADALAJARA INCOME',
+    'MONTERREY INCOME',
+    'NORTHWEST INCOME',
+    'GASTOS ADMINISTRATIVOS',
+    'GASTOS GENERALES',
+    'NOMINA',
+    'GASTOS CORPORATIVOS',
+    'GUADALAJARA EXPENSE',
+    'MONTERREY EXPENSE',
+    'NORTHWEST EXPENSE',
+    'CARGOS ADMINISTRATIVOS',
+    'MEMBER CENTRICITY',
+    'OTHER',
+    'OTHER INCOME'
+  ];
+
+  const getSectionPriority = (label) => {
+    const text = normalizeText(label);
+    const index = SECTION_ORDER.findIndex(key => text.includes(key));
+    return index === -1 ? 999 : index;
+  };
+
+  const PRINCIPAL_ORDER = ['INCOME', 'EXPENSE', 'OPERATING', 'OTHER'];
+  const getPrincipalPriority = (label) => {
+    const text = normalizeText(label);
+    const index = PRINCIPAL_ORDER.findIndex(key => text.includes(key));
+    return index === -1 ? 999 : index;
+  };
+
+  const sortSections = (sections) => {
+    return [...sections].sort((a, b) => {
+      const pA = getSectionPriority(a.label);
+      const pB = getSectionPriority(b.label);
+      if (pA !== pB) return pA - pB;
+      return (a.label || '').localeCompare(b.label || '');
+    });
+  };
+
+  const sortPrincipals = (principals) => {
+    return [...principals].sort((a, b) => {
+      const pA = getPrincipalPriority(a.label);
+      const pB = getPrincipalPriority(b.label);
+      if (pA !== pB) return pA - pB;
+      return (a.label || '').localeCompare(b.label || '');
+    });
+  };
+
+  // --- Rendering ---
   const MESES = [
     { etiqueta: 'Enero', clave: 'ene', periodo: 1 },
     { etiqueta: 'Febrero', clave: 'feb', periodo: 2 },
@@ -63,234 +128,28 @@
     { etiqueta: 'Diciembre', clave: 'dic', periodo: 12 }
   ];
 
-  const limpiarCambios = () => {
-    cambiosPendientes.clear();
-    editMode = false;
-  };
-
-  const claveCambio = (cuenta, columna) => `${cuenta}|${columna}`;
-
-  const registrarCambio = (cuenta, columna, valor, original) => {
-    if (!cuenta || !columna) return;
-    cambiosPendientes.set(claveCambio(cuenta, columna), {
-      cuenta,
-      columna,
-      valor,
-      original
+  const actualizarEtiquetaMes = (mesSeleccionado) => {
+    const etiqueta = MESES.find((m) => m.periodo === mesSeleccionado)?.etiqueta || '';
+    document.querySelectorAll('.mes').forEach((span) => {
+      span.textContent = etiqueta.toUpperCase();
     });
   };
 
-  const eliminarCambio = (cuenta, columna) => {
-    cambiosPendientes.delete(claveCambio(cuenta, columna));
-  };
+  const actualizarEtiquetasAnio = (anioActual, anioComparativo) => {
+    const anioNum = Number(anioActual);
+    const anioAnterior = Number.isFinite(Number(anioComparativo)) ? Number(anioComparativo) : anioNum - 1;
+    const etiquetaActual = Number.isFinite(anioNum) ? anioNum : '—';
+    const etiquetaAnterior = Number.isFinite(anioAnterior) ? anioAnterior : '—';
 
-  const obtenerCambiosPendientes = () => {
-    const porCuenta = new Map();
-    cambiosPendientes.forEach((registro) => {
-      const valores = porCuenta.get(registro.cuenta) || {};
-      valores[registro.columna] = registro.valor;
-      porCuenta.set(registro.cuenta, valores);
+    document.querySelectorAll('.anio').forEach((span) => {
+      span.textContent = etiquetaActual;
     });
-
-    const presupuesto = Array.from(porCuenta.entries()).map(([cuenta, valores]) => ({
-      cuenta,
-      valores
-    }));
-
-    return { presupuesto, hayCambios: presupuesto.length > 0 };
-  };
-
-  const notificarCambios = () => {
-    const detalle = { ...obtenerCambiosPendientes(), borradorGuardado: false };
-    window.dispatchEvent(new CustomEvent('modulo-planeacion:presupuesto-editado', { detail: detalle }));
-  };
-
-  const parseNumber = (texto) => {
-    const limpio = String(texto || '')
-      .replace(/[^0-9,.-]/g, '')
-      .replace(/,/g, '');
-    const numero = Number(limpio);
-    return Number.isFinite(numero) ? numero : 0;
-  };
-
-  const restaurarValoresOriginales = () => {
-    if (!summaryBody) return;
-    Array.from(summaryBody.querySelectorAll('.editable-cell')).forEach((celda) => {
-      const original = Number(celda.dataset.valorOriginal ?? 0);
-      celda.textContent = formatNumber(original);
+    document.querySelectorAll('.anio-seleccionado').forEach((span) => {
+      span.textContent = etiquetaActual;
     });
-  };
-
-  const cancelarEdicion = () => {
-    restaurarValoresOriginales();
-    limpiarCambios();
-    notificarCambios();
-  };
-
-  const manejarBlurCelda = (event) => {
-    const celda = event.currentTarget;
-    const fila = celda.closest('tr');
-    const cuenta = fila?.dataset.cuenta;
-    const columna = celda.dataset.columnaClave;
-    const original = Number(celda.dataset.valorOriginal ?? 0);
-    const nuevoValor = parseNumber(celda.textContent);
-
-    if (!cuenta || !columna) return;
-
-    if (nuevoValor !== original) {
-      celda.textContent = formatNumber(nuevoValor);
-      registrarCambio(cuenta, columna, nuevoValor, original);
-    } else {
-      celda.textContent = formatNumber(original);
-      eliminarCambio(cuenta, columna);
-    }
-
-    notificarCambios();
-  };
-
-  const activarModoEdicion = () => {
-    if (editMode || !summaryBody) return;
-    editMode = true;
-    const celdas = Array.from(summaryBody.querySelectorAll('.editable-cell'));
-    celdas.forEach((celda) => {
-      celda.contentEditable = 'true';
-      celda.addEventListener('blur', manejarBlurCelda);
+    document.querySelectorAll('.anio-seleccionado-anterior').forEach((span) => {
+      span.textContent = etiquetaAnterior;
     });
-  };
-
-  window.CuentasModulo = window.CuentasModulo || {};
-  window.CuentasModulo.cancelEdit = cancelarEdicion;
-  window.CuentasModulo.getCambios = obtenerCambiosPendientes;
-
-  // Compatibilidad: algunos layouts antiguos esperaban esta función.
-  // Hoy el capítulo se deriva de la empresa activa, pero aquí podemos
-  // también mostrar y permitir cambiar la selección.
-  const SECTION_PRIORITY = [
-    'MEMBERSHIP',
-    'EVENTS',
-    'COMMITTEES',
-    'T&IC',
-    'SERVICES TO MEMBERS',
-    'GUADALAJARA',
-    'MONTERREY',
-    'NORTHWEST',
-    'GASTOS ADMINISTRATIVOS',
-    'GASTOS GENERALES',
-    'NOMINA',
-    'GASTOS CORPORATIVOS',
-    'CARGOS ADMINISTRATIVOS',
-    'MEMBER CENTRICITY',
-    'OTHER',
-    'OTHER INCOME'
-  ];
-
-  const SECTION_PRIORITY_DEFAULT = SECTION_PRIORITY.length;
-  const sectionPriority = (label) => {
-    const text = normalizeText(label);
-    for (let idx = 0; idx < SECTION_PRIORITY.length; idx += 1) {
-      if (text.includes(SECTION_PRIORITY[idx])) {
-        return idx;
-      }
-    }
-    return SECTION_PRIORITY_DEFAULT;
-  };
-
-  const PRINCIPAL_PRIORITY = [
-    'INCOME',
-    'EXPENSE',
-    'OPERATING',
-    'OTHER'
-  ];
-
-  const principalPriority = (label) => {
-    const text = normalizeText(label);
-    for (let idx = 0; idx < PRINCIPAL_PRIORITY.length; idx += 1) {
-      if (text.includes(PRINCIPAL_PRIORITY[idx])) {
-        return idx;
-      }
-    }
-    return PRINCIPAL_PRIORITY.length;
-  };
-
-  const sortSections = (secciones = []) => {
-    return (Array.isArray(secciones) ? secciones : []).slice().sort((a, b) => {
-      const orden = sectionPriority(a.label) - sectionPriority(b.label);
-      if (orden !== 0) return orden;
-      return normalizeText(a.label).localeCompare(normalizeText(b.label));
-    });
-  };
-
-  const sortPrincipals = (principales = []) => {
-    return (Array.isArray(principales) ? principales : []).slice().sort((a, b) => {
-      const orden = principalPriority(a.label) - principalPriority(b.label);
-      if (orden !== 0) return orden;
-      return normalizeText(a.label).localeCompare(normalizeText(b.label));
-    });
-  };
-
-  const actualizarEtiquetaCapitulo = (texto) => {
-    if (!capituloLabel) return;
-    const valor = texto ? texto.toString() : '';
-    capituloLabel.textContent = valor ? `Capítulo: ${valor}` : 'Capítulo: -';
-  };
-
-  const actualizarCapitulos = (capitulos = [], seleccionado = '') => {
-    if (!selectCapitulo) {
-      capituloActual = seleccionado || capituloActual;
-      actualizarEtiquetaCapitulo(capituloActual);
-      return;
-    }
-
-    selectCapitulo.innerHTML = '';
-    if (!Array.isArray(capitulos) || !capitulos.length) {
-      const option = document.createElement('option');
-      option.value = '';
-      option.textContent = 'Sin capítulos disponibles';
-      selectCapitulo.appendChild(option);
-      selectCapitulo.disabled = true;
-      capituloActual = '';
-      actualizarEtiquetaCapitulo('');
-      return;
-    }
-
-    capitulos.forEach((item) => {
-      const etiqueta = (item?.etiqueta ?? item?.clave ?? '').toString().trim();
-      if (!etiqueta) return;
-      const option = document.createElement('option');
-      option.value = etiqueta;
-      option.textContent = etiqueta;
-      selectCapitulo.appendChild(option);
-    });
-
-    const preferido = capitulos.find((item) => (item?.etiqueta ?? '').toString().trim() === (seleccionado || '').toString().trim())
-      ? (seleccionado || '')
-      : (selectCapitulo.options[0]?.value || '');
-
-    selectCapitulo.value = preferido;
-    selectCapitulo.disabled = capitulos.length <= 1;
-    capituloActual = preferido;
-    actualizarEtiquetaCapitulo(preferido);
-  };
-
-  const CITY_LABELS = {
-    empresa1: 'Ciudad de México',
-    empresa2: 'Guadalajara',
-    empresa3: 'Noreste',
-    empresa4: 'Noroeste'
-  };
-
-  const emptyCells = (count) => Array(count).fill('<td></td>').join('');
-
-  const showStatus = (mensaje, tipo = 'info') => {
-    if (!summaryStatus) return;
-    summaryStatus.textContent = mensaje;
-    summaryStatus.className = `alert alert-${tipo} mb-3`;
-  };
-
-  const hideStatus = () => {
-    if (!summaryStatus) return;
-    summaryStatus.textContent = '';
-    summaryStatus.className = 'alert alert-info mb-3 visually-hidden';
   };
 
   const safeDiv = (numerador, denominador) => {
@@ -356,33 +215,8 @@
     return row;
   };
 
-  const actualizarEtiquetaMes = (mesSeleccionado) => {
-    const etiqueta = MESES.find((m) => m.periodo === mesSeleccionado)?.etiqueta || '';
-    document.querySelectorAll('.mes').forEach((span) => {
-      span.textContent = etiqueta.toUpperCase();
-    });
-  };
-
-  const actualizarEtiquetasAnio = (anioActual, anioComparativo) => {
-    const anioNum = Number(anioActual);
-    const anioAnterior = Number.isFinite(Number(anioComparativo)) ? Number(anioComparativo) : anioNum - 1;
-    const etiquetaActual = Number.isFinite(anioNum) ? anioNum : '—';
-    const etiquetaAnterior = Number.isFinite(anioAnterior) ? anioAnterior : '—';
-
-    document.querySelectorAll('.anio').forEach((span) => {
-      span.textContent = etiquetaActual;
-    });
-    document.querySelectorAll('.anio-seleccionado').forEach((span) => {
-      span.textContent = etiquetaActual;
-    });
-    document.querySelectorAll('.anio-seleccionado-anterior').forEach((span) => {
-      span.textContent = etiquetaAnterior;
-    });
-  };
-
   const renderSummary = (resumen = [], mesSeleccionado) => {
     if (!summaryBody) return;
-    limpiarCambios();
     summaryBody.innerHTML = '';
 
     if (!resumen.length) {
@@ -391,6 +225,7 @@
     }
 
     resumen.forEach((capitulo) => {
+      // Render Chapter Header (Operating Results)
       summaryBody.appendChild(createTotalsRow(capitulo, {
         label: capitulo.label || '',
         rowClass: 'section-header-row table-secondary fw-bold text-center',
@@ -448,8 +283,6 @@
     if (mesSeleccionado) {
       actualizarEtiquetaMes(mesSeleccionado);
     }
-
-    activarModoEdicion();
   };
 
   const renderAggregateTable = (resumen = []) => {
@@ -466,6 +299,12 @@
       aggregateBody.innerHTML = '<tr><td colspan="8" class="text-center">Sin datos consolidados.</td></tr>';
       return;
     }
+    const CITY_LABELS = {
+        empresa1: 'Ciudad de México',
+        empresa2: 'Guadalajara',
+        empresa3: 'Noreste',
+        empresa4: 'Noroeste'
+    };
     Object.entries(totals).forEach(([empresa, total]) => {
       const row = document.createElement('tr');
       row.innerHTML = `
@@ -528,6 +367,13 @@
       renderAggregateTable(data.resumen || []);
       actualizarCapitulos(data.capitulosDisponibles || [], data.capituloSeleccionado || preferido);
       actualizarEtiquetasAnio(anioReporte, anioPrevio);
+      
+      if (flujoAutorizacion) {
+        window.dispatchEvent(new CustomEvent('planeacion:contexto-actualizado', {
+            detail: { empresaId, anio, modulo: 'summary' }
+        }));
+      }
+
       hideStatus();
     } catch (error) {
       console.error('Error Summary:', error);
@@ -579,22 +425,73 @@
     }
   };
 
+  const actualizarCapitulos = (capitulos = [], seleccionado = '') => {
+    if (!selectCapitulo) {
+      capituloActual = seleccionado || capituloActual;
+      if(capituloLabel) capituloLabel.textContent = `Capítulo: ${capituloActual || '-'}`;
+      return;
+    }
+
+    selectCapitulo.innerHTML = '';
+    if (!Array.isArray(capitulos) || !capitulos.length) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = 'Sin capítulos disponibles';
+      selectCapitulo.appendChild(option);
+      selectCapitulo.disabled = true;
+      capituloActual = '';
+      if(capituloLabel) capituloLabel.textContent = 'Capítulo: -';
+      return;
+    }
+
+    capitulos.forEach((item) => {
+      const etiqueta = (item?.etiqueta ?? item?.clave ?? '').toString().trim();
+      if (!etiqueta) return;
+      const option = document.createElement('option');
+      option.value = etiqueta;
+      option.textContent = etiqueta;
+      selectCapitulo.appendChild(option);
+    });
+
+    const preferido = capitulos.find((item) => (item?.etiqueta ?? '').toString().trim() === (seleccionado || '').toString().trim())
+      ? (seleccionado || '')
+      : (selectCapitulo.options[0]?.value || '');
+
+    selectCapitulo.value = preferido;
+    selectCapitulo.disabled = capitulos.length <= 1;
+    capituloActual = preferido;
+    if(capituloLabel) capituloLabel.textContent = `Capítulo: ${preferido}`;
+  };
+
+  const showStatus = (mensaje, tipo = 'info') => {
+    if (!summaryStatus) return;
+    summaryStatus.textContent = mensaje;
+    summaryStatus.className = `alert alert-${tipo} mb-3`;
+  };
+
+  const hideStatus = () => {
+    if (!summaryStatus) return;
+    summaryStatus.textContent = '';
+    summaryStatus.className = 'alert alert-info mb-3 visually-hidden';
+  };
+
   document.addEventListener('DOMContentLoaded', async () => {
     const sesion = Sesion.requerirSesion();
     if (!sesion) return;
+
+    if (window.FlujoAutorizacion) {
+        flujoAutorizacion = new window.FlujoAutorizacion({
+            modulo: 'summary',
+            tablaId: 'summaryTable'
+        });
+        flujoAutorizacion.init();
+    }
 
     const empresa = Sesion.obtenerEmpresaActiva(sesion);
     if (!empresa?.id) {
       showStatus('Selecciona una empresa para continuar.', 'warning');
       return;
     }
-
-    const modulo = document.body?.dataset?.modulo || 'summary';
-    const publicarContexto = (anio) => {
-      window.dispatchEvent(new CustomEvent('planeacion:contexto-actualizado', {
-        detail: { empresaId: empresa.id, anio, modulo }
-      }));
-    };
 
     empresaActual = empresa;
     await aplicarEmpresa(empresaActual.id);
@@ -605,7 +502,6 @@
       const anio = leerAnioSeleccionado();
       const mes = leerMesSeleccionado();
       actualizarEtiquetasAnio(anio, anio - 1);
-      publicarContexto(anio);
       if (empresaActual?.id) {
         fetchSummary(empresaActual.id, anio, mes, leerCapitulo());
       }
@@ -615,7 +511,6 @@
       const anio = leerAnioSeleccionado();
       const mes = leerMesSeleccionado();
       actualizarEtiquetaMes(mes);
-      publicarContexto(anio);
       if (empresaActual?.id) {
         fetchSummary(empresaActual.id, anio, mes, leerCapitulo());
       }

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -1,7 +1,19 @@
 (() => {
-  const base = window.location.protocol === 'file:' ? 'http://localhost:3000' : window.location.origin;
-  const API_ENDPOINT = `${base}/api/reportes/summary`;
-  const API_ANIOS = `${base}/api/saldos/anios`;
+  const configurarApi = () => {
+    if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+    const baseDetectada = window.location.protocol === 'file:'
+      ? 'https://amcham.iconetcloud.com.mx/api'
+      : `${window.location.origin}/api`;
+    const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+    const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+    window.API_BASE_URL = apiBase;
+    window.apiUrl = construir;
+  };
+
+  configurarApi();
+
+  const API_ENDPOINT = window.apiUrl('reportes/summary');
+  const API_ANIOS = window.apiUrl('saldos/anios');
 
   const toNumber = (valor) => {
     const numero = Number(valor);

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -10,7 +10,20 @@
 // ================================
 // === CONFIG / ESTADO GENERAL ===
 // ================================
-const API_BASE = 'http://localhost:3000/api';
+const configurarApi = () => {
+  if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+  const baseDetectada = window.location.protocol === 'file:'
+    ? 'https://amcham.iconetcloud.com.mx/api'
+    : `${window.location.origin}/api`;
+  const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+  const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+  window.API_BASE_URL = apiBase;
+  window.apiUrl = construir;
+};
+
+configurarApi();
+
+const API_BASE = window.API_BASE_URL;
 /*
   Resumen de la logica (guia rapida):
   - CURRENT_LAYOUT describe la jerarquia/colores de la tabla (simula el Excel original).

--- a/vistas/login.html
+++ b/vistas/login.html
@@ -7,6 +7,7 @@
   <title>Iniciar sesión</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="js/api-config.js"></script>
   <style>
     :root {
       --color-primario: #2f5496;
@@ -110,7 +111,7 @@
 
   <script src="js/sesion.js"></script>
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const API_BASE = window.API_BASE_URL;
     const formulario = document.getElementById('formularioLogin');
     const alerta = document.getElementById('alerta');
     const boton = document.getElementById('botonIngresar');
@@ -141,7 +142,7 @@
       };
 
       try {
-        const respuesta = await fetch(`${API_BASE}/auth/login`, {
+        const respuesta = await fetch(window.apiUrl('auth/login'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(cuerpo)

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/estilos.css">
+  <script src="js/api-config.js"></script>
   <style>
     :root {
       --bs-primary: #2f5496;
@@ -182,7 +183,20 @@
 
   <script src="js/sesion.js"></script>
   <script>
-    const API_BASE = 'http://localhost:3000/api';
+    const configurarApi = () => {
+      if (typeof window.apiUrl === 'function' && window.API_BASE_URL) return;
+      const baseDetectada = window.location.protocol === 'file:'
+        ? 'https://amcham.iconetcloud.com.mx/api'
+        : `${window.location.origin}/api`;
+      const apiBase = (window.API_BASE_URL || baseDetectada).replace(/\/$/, '');
+      const construir = (ruta = '') => `${apiBase}${ruta.startsWith('/') ? '' : '/'}${ruta}`;
+      window.API_BASE_URL = apiBase;
+      window.apiUrl = construir;
+    };
+
+    configurarApi();
+
+    const API_BASE = window.API_BASE_URL;
     const sesion = Sesion.requerirSesion({ requireAdmin: true });
     if (!sesion) {
       throw new Error('Redireccionando al inicio de sesión.');
@@ -298,7 +312,7 @@
     const cargarUsuarios = async () => {
       limpiarAlerta();
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios`, {
+        const respuesta = await fetch(window.apiUrl('usuarios'), {
           headers: Sesion.headersAutenticacion()
         });
         const datos = await respuesta.json();
@@ -343,7 +357,7 @@
       const ok = await confirmarEliminacion('¿Deseas eliminar al usuario seleccionado? Esta acción no se puede deshacer.');
       if (!ok) return;
       try {
-        const respuesta = await fetch(`${API_BASE}/usuarios/${id}`, {
+        const respuesta = await fetch(window.apiUrl(`usuarios/${id}`), {
           method: 'DELETE',
           headers: Sesion.headersAutenticacion()
         });


### PR DESCRIPTION
## Summary
- Lee la empresa activa desde el selector global de empresa cuando no existe en sesión para Summary y Resumen
- Ajusta la prioridad de ordenamiento de secciones siguiendo las guías de Summary y Resumen
- Mantiene la posición final de totales/neto al extender el orden principal

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930f8abb438832d9e31e261cce87cb0)