### PR TITLE
Add discard control and unlock workflow drawers

### DIFF
--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -432,7 +432,9 @@
       }
       if (this.buttons.verBorrador) {
         this.buttons.verBorrador.addEventListener('click', () => this._mostrarCentroBorradores());
+        this.buttons.verBorrador.classList.remove('d-none');
       }
+      this._asegurarBotonDescartar();
       if (this.buttons.autorizar) {
         this.buttons.autorizar.addEventListener('click', () => this._handleAutorizar());
       }
@@ -450,6 +452,25 @@
         }
         this.buttons.guardarCOI.addEventListener('click', () => this._handleGuardarCOI());
       }
+    }
+
+    _asegurarBotonDescartar() {
+      if (this.buttons.descartar) return;
+      const contenedor = this.buttons.verBorrador?.parentElement;
+      if (!contenedor) return;
+
+      const boton = document.createElement('button');
+      boton.type = 'button';
+      boton.className = 'btn btn-chip btn-outline-danger d-none';
+      boton.id = 'btnDescartarBorrador';
+      boton.innerHTML = `
+        <i class="bi bi-eraser"></i>
+        <span>Descartar borrador</span>
+      `;
+
+      contenedor.insertBefore(boton, this.buttons.verBorrador?.nextSibling || null);
+      this.buttons.descartar = boton;
+      boton.addEventListener('click', () => this._descartarBorrador());
     }
 
     _prepararToast() {
@@ -492,6 +513,7 @@
     async _actualizarEstadoServidor() {
       if (!this._contextoCompleto()) {
         this._notificarEstadoBorrador(null);
+        this._actualizarBotones();
         return;
       }
       try {
@@ -950,10 +972,6 @@
     }
 
     async _mostrarCentroBorradores() {
-      if (!this._contextoCompleto()) {
-        this._mostrarToast('Selecciona empresa y ejercicio para consultar los borradores.', 'warning');
-        return;
-      }
       const drawer = ensureDraftsDrawer();
       if (!drawer) {
         console.error('[FlujoAutorizacion] No se pudo crear el drawer de borradores');
@@ -976,13 +994,41 @@
         this._mostrarToast('Error al abrir el centro de borradores.', 'danger');
         return;
       }
-      
+
+      if (!this._contextoCompleto()) {
+        draftsDrawerStatus.className = 'alert alert-warning';
+        draftsDrawerStatus.textContent = 'Selecciona empresa y ejercicio para consultar los borradores.';
+        draftsDrawerBody.innerHTML = `
+          <tr>
+            <td colspan="5" class="text-center text-muted">Sin contexto seleccionado</td>
+          </tr>`;
+        return;
+      }
+
       await this._cargarCentroBorradores();
+    }
+
+    _descartarBorrador() {
+      FlujoAutorizacion.limpiarBorrador(this.tableElement);
+      this.borradorActual = null;
+      this._notificarEstadoBorrador(null);
+      this._actualizarInfoPanel();
+      this._actualizarBotones();
+      this._mostrarToast('Borrador descartado.', 'info');
     }
 
     async _cargarCentroBorradores() {
       ensureDraftsDrawer();
       if (!draftsDrawerBody || !draftsDrawerStatus) return;
+      if (!this._contextoCompleto()) {
+        draftsDrawerStatus.className = 'alert alert-warning';
+        draftsDrawerStatus.textContent = 'Selecciona empresa y ejercicio para consultar los borradores.';
+        draftsDrawerBody.innerHTML = `
+          <tr>
+            <td colspan="5" class="text-center text-muted">Sin contexto seleccionado</td>
+          </tr>`;
+        return;
+      }
       draftsDrawerStatus.className = 'alert alert-info';
       draftsDrawerStatus.textContent = 'Cargando borradores...';
       draftsDrawerBody.innerHTML = `
@@ -1202,12 +1248,14 @@
       }
 
       if (this.buttons.verBorrador) {
-        const puedeVerCentro = this.esAdminGlobal
-          || this._permitido('guardar')
-          || this._permitido('revision')
-          || this._permitido('autorizar')
-          || this._permitido('rechazar');
-        this.buttons.verBorrador.classList.toggle('d-none', !puedeVerCentro);
+        this.buttons.verBorrador.classList.remove('d-none');
+        this.buttons.verBorrador.disabled = false;
+      }
+
+      if (this.buttons.descartar) {
+        const puedeDescartar = Boolean(this.borradorActual);
+        this.buttons.descartar.classList.toggle('d-none', !puedeDescartar);
+        this.buttons.descartar.disabled = !puedeDescartar;
       }
     }
 
@@ -1545,8 +1593,7 @@
     return { init };
   })();
 
-  const tieneControles = Boolean(document.getElementById('btnGuardarBorrador'));
-  if (tieneControles) {
+  if (!window.__flujoAutorizacionInstance) {
     window.__flujoAutorizacionInstance = new FlujoAutorizacion();
   }
 
@@ -1605,6 +1652,59 @@
     };
   })();
 
+  const vincularAccesosRapidos = () => {
+    const asegurarWorkflowDrawer = () => {
+      const drawer = ensureWorkflowDrawer();
+      const elemento = drawer || document.getElementById('workflowDrawer');
+      if (!elemento || !window.bootstrap?.Offcanvas) return null;
+      elemento.setAttribute('data-bs-scroll', 'true');
+      return window.bootstrap.Offcanvas.getOrCreateInstance(elemento);
+    };
+
+    document.querySelectorAll('.workflow-toggle').forEach((btn) => {
+      if (btn.dataset.workflowBound === '1') return;
+      btn.dataset.workflowBound = '1';
+      btn.classList.remove('disabled');
+      btn.removeAttribute('disabled');
+      btn.setAttribute('aria-disabled', 'false');
+      btn.setAttribute('data-bs-toggle', 'offcanvas');
+      btn.setAttribute('data-bs-target', '#workflowDrawer');
+      btn.addEventListener('click', (event) => {
+        event.preventDefault();
+        const instancia = asegurarWorkflowDrawer();
+        if (instancia) instancia.show();
+      });
+    });
+
+    const abrirCentroBorradores = () => {
+      ensureDraftsDrawer();
+      const instancia = window.__flujoAutorizacionInstance;
+      if (instancia?.init) {
+        instancia.init();
+        instancia._mostrarCentroBorradores();
+        return;
+      }
+      if (draftsDrawerEl && window.bootstrap?.Offcanvas) {
+        window.bootstrap.Offcanvas.getOrCreateInstance(draftsDrawerEl).show();
+      }
+    };
+
+    document.querySelectorAll('#btnVerBorrador, [data-open-drafts-center]')
+      .forEach((btn) => {
+        if (btn.dataset.draftsBound === '1') return;
+        btn.dataset.draftsBound = '1';
+        btn.classList.remove('disabled');
+        btn.removeAttribute('disabled');
+        btn.setAttribute('aria-disabled', 'false');
+        btn.setAttribute('data-bs-toggle', 'offcanvas');
+        btn.setAttribute('data-bs-target', `#${DRAFTS_DRAWER_ID}`);
+        btn.addEventListener('click', (event) => {
+          event.preventDefault();
+          abrirCentroBorradores();
+        });
+      });
+  };
+
   const autoInit = () => {
     const instancia = window.__flujoAutorizacionInstance;
     if (instancia) {
@@ -1612,6 +1712,7 @@
     }
     DraftHistoryCenter.init();
     renderWorkflowGuide();
+    vincularAccesosRapidos();
   };
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Keep workflow and draft toggles active by removing disabled states and forcing the draft center entry point to stay visible
- Inject a reusable “Descartar borrador” control that clears applied drafts, resets workflow state, and keeps the drawer usable even sin contexto

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931bf098f24832d885420170fc3c837)