### PR TITLE
Debug Cloudflare tunnel with Express and Firebird

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -73,8 +73,8 @@ const iniciarServidor = (puerto = Number(process.env.PORT || 3000)) => {
     res.status(500).json({ mensaje: 'Ocurrió un error inesperado.' });
   });
 
-  instanciaServidor = app.listen(puerto, () => {
-    console.log(`API interna escuchando en el puerto ${puerto}`);
+  instanciaServidor = app.listen(puerto, '127.0.0.1', () => {
+    console.log(`API interna escuchando en http://127.0.0.1:${puerto}`);
   });
 
   return instanciaServidor;


### PR DESCRIPTION
El servidor ahora escucha explícitamente en 127.0.0.1 en lugar de todas las interfaces (0.0.0.0). Esto asegura que el túnel de Cloudflare pueda conectarse correctamente al servidor local.