### PR TITLE
Fix hardcoded localhost URLs in packaged app

### DIFF
--- a/vistas/js/logica-resumen.js
+++ b/vistas/js/logica-resumen.js
@@ -1,5 +1,6 @@
 (() => {
-  const API_BASE = 'http://localhost:3000/api';
+  const base = window.location.protocol === 'file:' ? 'http://127.0.0.1:3000' : window.location.origin;
+  const API_BASE = `${base}/api`;
   const YEAR_SELECT = document.getElementById('resumenYearSelect');
   const MONTH_SELECT = document.getElementById('resumenMonthSelect');
   const TABLE_BODY = document.getElementById('tablaCuentasBody');

--- a/vistas/js/summary.js
+++ b/vistas/js/summary.js
@@ -10,7 +10,8 @@
 // ================================
 // === CONFIG / ESTADO GENERAL ===
 // ================================
-const API_BASE = 'http://localhost:3000/api';
+const base = window.location.protocol === 'file:' ? 'http://127.0.0.1:3000' : window.location.origin;
+const API_BASE = `${base}/api`;
 /*
   Resumen de la logica (guia rapida):
   - CURRENT_LAYOUT describe la jerarquia/colores de la tabla (simula el Excel original).


### PR DESCRIPTION
- Cambiar API_BASE hardcodeado por detección dinámica del protocolo
- Si carga desde file:// (app empaquetada): usa http://127.0.0.1:3000
- Si carga desde servidor web: usa window.location.origin
- Corrige problema donde Resumen y Summary no cargaban en app empaquetada