### PR TITLE
login iframe

### DIFF
--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -933,12 +933,15 @@
 
     _manejarSesionExpirada(resp) {
       if (resp?.status === 401) {
+        // Usar Sesion.cerrar() que maneja correctamente la redirección desde iframes
         try {
-          if (typeof Sesion?.limpiar === "function") {
+          if (typeof Sesion?.cerrar === "function") {
+            Sesion.cerrar();
+          } else if (typeof Sesion?.limpiar === "function") {
             Sesion.limpiar();
+            (window.top || window).location.href = "login.html";
           }
         } catch (e) { /* ignore */ }
-        window.location.href = "login.html";
         return true;
       }
       return false;

--- a/vistas/js/react-app.js
+++ b/vistas/js/react-app.js
@@ -629,8 +629,7 @@ const NotificationBell = ({ notifications = [], onRefresh, onMarkAsRead }) => {
         // Si es 401, sesión expirada
         if (respuesta.status === 401) {
           console.error('❌ Sesión expirada (401)');
-          Sesion.cerrar();
-          window.location.replace('login.html');
+          Sesion.cerrar(); // Limpia sesión y redirige al login
           return;
         }
         

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -64,8 +64,8 @@
 
   const manejarSesionExpirada = (resp) => {
     if (resp?.status === 401) {
-      try { Sesion.limpiar(); } catch (_) { /* ignore */ }
-      window.location.href = 'login.html';
+      // Usar Sesion.cerrar() que maneja correctamente la redirección desde iframes
+      try { Sesion.cerrar(); } catch (_) { /* ignore */ }
       return true;
     }
     return false;

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -123,16 +123,26 @@
 
   const esAdmin = (sesion) => puedeAdministrarUsuarios(sesion);
 
-  const requerirSesion = ({ requireAdmin = false, redirectTo = REDIRECCION_POR_DEFECTO } = {}) => {
+  // Función auxiliar para redirigir, soportando contexto de iframe
+  const redirigir = (destino, usarTop = false) => {
+    if (usarTop && window.top !== window.self) {
+      // Estamos en un iframe y se pidió redirigir la ventana principal
+      window.top.location.replace(destino);
+    } else {
+      window.location.href = destino;
+    }
+  };
+
+  const requerirSesion = ({ requireAdmin = false, redirectTo = REDIRECCION_POR_DEFECTO, usarTop = false } = {}) => {
     const sesion = obtener();
     if (!sesion || !sesion.tokenAcceso) {
       limpiar();
-      window.location.href = redirectTo;
+      redirigir(redirectTo, usarTop);
       return null;
     }
 
     if (requireAdmin && !puedeAdministrarUsuarios(sesion)) {
-      window.location.href = redirectTo;
+      redirigir(redirectTo, usarTop);
       return null;
     }
 
@@ -231,10 +241,18 @@
     return Boolean(permisos[accionNormalizada]);
   };
 
+  // Función para cerrar sesión y redirigir al login (soporta iframes)
+  const cerrar = ({ redirectTo = REDIRECCION_POR_DEFECTO, usarTop = true } = {}) => {
+    limpiar();
+    redirigir(redirectTo, usarTop);
+  };
+
   window.Sesion = {
     obtener,
     guardar,
     limpiar,
+    cerrar,
+    redirigir,
     requerirSesion,
     esAdmin,
     esAdminGlobal,

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -27,8 +27,8 @@
 
   const manejarSesionExpirada = (resp) => {
     if (resp?.status === 401) {
-      try { Sesion.limpiar(); } catch (_) { /* noop */ }
-      window.location.href = 'login.html';
+      // Usar Sesion.cerrar() que maneja correctamente la redirección desde iframes
+      try { Sesion.cerrar(); } catch (_) { /* noop */ }
       return true;
     }
     return false;

--- a/vistas/js/verificar-sesion.js
+++ b/vistas/js/verificar-sesion.js
@@ -2,24 +2,35 @@
 // Se ejecuta ANTES de cargar cualquier contenido del módulo
 (function() {
   'use strict';
-  
+
+  // Función auxiliar para redirigir al login desde cualquier contexto (iframe o ventana principal)
+  const redirigirALogin = () => {
+    const destino = 'login.html';
+    // Si estamos dentro de un iframe, redirigir la ventana principal (top)
+    if (window.top !== window.self) {
+      window.top.location.replace(destino);
+    } else {
+      window.location.replace(destino);
+    }
+  };
+
   // Verificar que Sesion esté disponible
   if (typeof Sesion === 'undefined' || typeof Sesion.requerirSesion !== 'function') {
     console.error('❌ Módulo Sesion no cargado');
-    window.location.replace('login.html');
+    redirigirALogin();
     return;
   }
-  
-  // Verificar sesión válida
-  const sesion = Sesion.requerirSesion({ redirectTo: 'login.html' });
-  
+
+  // Verificar sesión válida (ahora con soporte para iframe)
+  const sesion = Sesion.requerirSesion({ redirectTo: 'login.html', usarTop: true });
+
   if (!sesion) {
     // requerirSesion ya redirigió a login
     return;
   }
-  
+
   // Sesión válida - guardar en window.sesion para uso global del módulo
   window.sesion = sesion;
-  
+
   console.log('✅ Sesión verificada:', sesion.usuario?.usuario || 'Usuario');
 })();

--- a/vistas/perfil.html
+++ b/vistas/perfil.html
@@ -773,8 +773,8 @@
       }
 
       const manejarRespuestaNoAutorizada = () => {
-        Sesion.limpiar();
-        window.location.replace('login.html');
+        // Usar Sesion.cerrar() que maneja correctamente la redirección desde iframes
+        Sesion.cerrar();
       };
 
       const cargarPerfil = async () => {

--- a/vistas/usuarios.html
+++ b/vistas/usuarios.html
@@ -387,8 +387,8 @@
 
     if (btnCerrarSesion) {
       btnCerrarSesion.addEventListener('click', () => {
-        Sesion.limpiar();
-        window.location.href = 'login.html';
+        // Usar Sesion.cerrar() que maneja correctamente la redirección desde iframes
+        Sesion.cerrar();
       });
     }
 


### PR DESCRIPTION
Cuando la sesión expiraba por inactividad, el login se mostraba dentro del iframe en lugar de reemplazar toda la página. Esto ocurría porque window.location.replace() se ejecutaba en el contexto del iframe.

Cambios:
- Agregar función Sesion.cerrar() que limpia sesión y redirige correctamente
- Agregar función Sesion.redirigir() con soporte para contexto iframe
- Agregar parámetro usarTop a requerirSesion() para forzar redirección a top
- Actualizar verificar-sesion.js para usar window.top en iframes
- Corregir redirecciones en: perfil.html, usuarios.html, resumen-view.js, summary-view.js, flujo-autorizacion.js y react-app.js