### PR TITLE
Ajustar cálculo de la sección Other en NORESTE/NOROESTE (restar Pérdida cambiaria)

### DIFF
--- a/src/services/reportes/planeacionReportesEngine.js
+++ b/src/services/reportes/planeacionReportesEngine.js
@@ -206,6 +206,13 @@ const crearAcumulador = () => ({
   prevYTD: 0
 });
 
+const normalizarTexto = (valor = '') => valor
+  .toString()
+  .trim()
+  .toUpperCase()
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '');
+
 const sumarTotales = (destino, origen, factor = 1) => {
   if (!destino || !origen) return destino;
   destino.actualMonth += factor * Number(origen.actualMonth ?? 0);
@@ -262,7 +269,24 @@ const construirNodoSeccion = ({ seccion, cuentas, definicion, claveMes, planeaci
     };
   });
 
-    return {
+  const esOther = normalizarTexto(seccion) === 'OTHER';
+  const requiereAjusteOther = esOther && ['NORESTE', 'NOROESTE'].some((token) => capNorm.includes(token));
+  if (requiereAjusteOther) {
+    const cuentasAjuste = cuentasDetalle.filter((cuenta) => {
+      const descNorm = normalizarTexto(cuenta.descripcion || '');
+      return descNorm.includes('PERDIDA CAMBIARIA');
+    });
+    cuentasAjuste.forEach((cuenta) => {
+      totales.actualMonth -= 2 * Number(cuenta.actualMonth ?? 0);
+      totales.planMonth -= 2 * Number(cuenta.planMonth ?? 0);
+      totales.prevMonth -= 2 * Number(cuenta.prevMonth ?? 0);
+      totales.actualYTD -= 2 * Number(cuenta.actualYTD ?? 0);
+      totales.planYTD -= 2 * Number(cuenta.planYTD ?? 0);
+      totales.prevYTD -= 2 * Number(cuenta.prevYTD ?? 0);
+    });
+  }
+
+  return {
     label: seccion,
     cuentas: cuentasDetalle,
     orden,


### PR DESCRIPTION
### Motivation
- Corrige totales incorrectos en la sección `Other` para los capítulos `NORESTE` y `NOROESTE` al asegurar que la `Pérdida cambiaria` se resta de la suma de Other. 
- Evita discrepancias donde `Other` estaba sumando en vez de restar la cuenta de pérdida cambiaria en los informes mensuales. 
- Mejora la robustez de la comparación de etiquetas frente a acentos y mayúsculas/minúsculas. 

### Description
- Se agregó la función `normalizarTexto` para normalizar etiquetas y descripciones removiendo acentos y comparando en mayúsculas en `src/services/reportes/planeacionReportesEngine.js`.
- En `construirNodoSeccion` se detecta cuando la sección es `Other` y el capítulo es `NORESTE` o `NOROESTE` y se filtran las cuentas cuya `descripcion` coincide con `PÉRDIDA CAMBIARIA` (normalizada).
- Para cada cuenta coincidente se ajustan los totales de la sección restando los importes en todos los periodos (`actualMonth`, `planMonth`, `prevMonth`, `actualYTD`, `planYTD`, `prevYTD`) aplicando un factor negativo (implementado como `-2 * valor` en el código).
- Todos los cambios quedaron implementados en `src/services/reportes/planeacionReportesEngine.js` dentro de la lógica de construcción de nodos de sección.

### Testing
- No se ejecutaron pruebas automatizadas sobre la rama modificada.
- No se ejecutaron tests unitarios ni de integración durante este cambio.
- Se validó localmente la modificación del archivo y la generación del patch (commit), pero no se ejecutaron suites automáticas.
- Recomiendo correr la suite de `npm test` o el pipeline CI para verificar efectos colaterales antes de desplegar en producción.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949abad4b50832d8952d6cde0a36c6d)