### PR TITLE
Soportar operaciones entre filas (SUMA DE VARIAS SECCIONES) y mejorar wizard de inserción

### DIFF
--- a/src/routes/insercion.js
+++ b/src/routes/insercion.js
@@ -23,6 +23,9 @@ function validarJerarquia(tipo, context, moduleType) {
     if (tipo === 'secundaria' && !context.principal) {
       errors.push('Una Sección Secundaria requiere una Sección Principal');
     }
+    if (tipo === 'operacion_sumas' && (!context.principal || !context.secundaria)) {
+      errors.push('Una Operación de sumas requiere Sección Principal y Secundaria');
+    }
   }
 
   if (moduleType === 'RESUMEN') {
@@ -31,6 +34,9 @@ function validarJerarquia(tipo, context, moduleType) {
     }
     if (tipo === 'operacion' && (!context.principal || !context.secundaria)) {
       errors.push('Una Operación requiere Sección Principal y Secundaria');
+    }
+    if (tipo === 'operacion_sumas' && (!context.principal || !context.secundaria)) {
+      errors.push('Una Operación de sumas requiere Sección Principal y Secundaria');
     }
     if (tipo === 'secundaria' && !context.principal) {
       errors.push('Una Sección Secundaria requiere una Sección Principal');
@@ -93,6 +99,21 @@ function verificarDuplicado(tipo, data, config, moduleType) {
 
     if (existe) {
       return { duplicado: true, mensaje: `Ya existe una Operación con ese nombre en esa sección` };
+    }
+  }
+
+  if (tipo === 'operacion_sumas') {
+    const operaciones = config['SUMA DE VARIAS SECCIONES'] || [];
+    const capitulo = data.capitulo || '';
+    const seccion = data.seccion || data.secundaria || '';
+    const clase = data.clase || '';
+    const existe = operaciones.some((item) =>
+      item.CAPITULO === capitulo &&
+      item.SECCION === seccion &&
+      item.Clase === clase
+    );
+    if (existe) {
+      return { duplicado: true, mensaje: 'Ya existe una operación de sumas con esa sección y clase' };
     }
   }
 
@@ -161,14 +182,23 @@ router.post('/validar', requireAuth, async (req, res) => {
     if (tipo === 'cuenta') {
       if (!formData.numero) errors.push('El número de cuenta es obligatorio');
       if (!formData.nombre) errors.push('El nombre de cuenta es obligatorio');
+    } else if (tipo === 'operacion_sumas') {
+      if (!formData.clase) errors.push('La clase es obligatoria');
+      if (!formData.seccion && !context.secundaria) errors.push('La sección es obligatoria');
+      const operaciones = formData.operaciones || {};
+      const tieneOperacion = Object.values(operaciones).some((value) => value);
+      if (!tieneOperacion) errors.push('Define al menos una etiqueta de operación');
     } else {
       if (!formData.nombre) errors.push('El nombre es obligatorio');
       if (!formData.etiquetaSum) errors.push('La etiqueta de SUM ROW es obligatoria');
     }
 
     // 5. Advertencias
-    if (tipo !== 'cuenta') {
+    if (tipo !== 'cuenta' && tipo !== 'operacion_sumas') {
       warnings.push('Se creará automáticamente un SUM ROW con la etiqueta especificada');
+    }
+    if (tipo === 'operacion_sumas') {
+      warnings.push('Se agregará una configuración en SUMA DE VARIAS SECCIONES para el capítulo actual');
     }
 
     res.json({
@@ -594,6 +624,100 @@ router.post('/operacion', requireAuth, async (req, res) => {
 
   } catch (error) {
     console.error('Error en /insercion/operacion:', error);
+    res.status(500).json({
+      exito: false,
+      mensaje: error.message
+    });
+  }
+});
+
+/**
+ * POST /api/insercion/operacion-sumas
+ * Inserta una nueva operación entre filas (SUMA DE VARIAS SECCIONES)
+ */
+router.post('/operacion-sumas', requireAuth, async (req, res) => {
+  try {
+    const { moduleType, context, formData } = req.body;
+
+    if (!moduleType || !context || !formData) {
+      return res.status(400).json({
+        exito: false,
+        mensaje: 'Faltan datos requeridos'
+      });
+    }
+
+    if (!['SUMMARY', 'RESUMEN'].includes(moduleType)) {
+      return res.status(400).json({
+        exito: false,
+        mensaje: 'Este tipo de operación solo aplica a SUMMARY/RESUMEN'
+      });
+    }
+
+    const jerarquiaErrors = validarJerarquia('operacion_sumas', context, moduleType);
+    if (jerarquiaErrors.length > 0) {
+      return res.status(400).json({
+        exito: false,
+        mensaje: jerarquiaErrors.join(', ')
+      });
+    }
+
+    const operaciones = formData.operaciones || {};
+    const tieneOperacion = Object.values(operaciones).some((value) => value);
+    if (!formData.clase || (!formData.seccion && !context.secundaria) || !tieneOperacion) {
+      return res.status(400).json({
+        exito: false,
+        mensaje: 'Clase, sección y al menos una operación son obligatorias'
+      });
+    }
+
+    const config = await loadLayoutConfig(moduleType, {
+      anio: context?.anio
+    });
+
+    const duplicado = verificarDuplicado(
+      'operacion_sumas',
+      { ...formData, ...context },
+      config,
+      moduleType
+    );
+    if (duplicado.duplicado) {
+      return res.status(400).json({
+        exito: false,
+        mensaje: duplicado.mensaje
+      });
+    }
+
+    if (!config['SUMA DE VARIAS SECCIONES']) config['SUMA DE VARIAS SECCIONES'] = [];
+
+    const nuevaOperacion = {
+      HOJA: moduleType,
+      CAPITULO: context.capitulo || '',
+      Clase: formData.clase,
+      SECCION: formData.seccion || context.secundaria || ''
+    };
+    if (Number.isFinite(Number(formData.signo))) {
+      nuevaOperacion.signo = Number(formData.signo);
+    }
+
+    Object.entries(operaciones).forEach(([tipo, etiqueta]) => {
+      if (etiqueta) {
+        nuevaOperacion[tipo] = etiqueta;
+      }
+    });
+
+    config['SUMA DE VARIAS SECCIONES'].push(nuevaOperacion);
+
+    await saveLayoutConfig(moduleType, config, {
+      anio: context?.anio
+    });
+
+    res.json({
+      exito: true,
+      mensaje: 'Operación entre filas agregada exitosamente',
+      operacion: nuevaOperacion
+    });
+  } catch (error) {
+    console.error('Error en /insercion/operacion-sumas:', error);
     res.status(500).json({
       exito: false,
       mensaje: error.message

--- a/src/services/layoutService.js
+++ b/src/services/layoutService.js
@@ -386,8 +386,9 @@ const guardarOperaciones = ({ empresaId = 'EMPRESA01', modulo, anio, operaciones
 
       tiposOperacion.forEach((tipo, tipoIndex) => {
         if (op[tipo]) {
-          let signo = 1;
-          if (op.Clase && op.Clase.toLowerCase().includes('expense')) {
+          const signoConfigurado = Number(op.signo);
+          let signo = Number.isFinite(signoConfigurado) && signoConfigurado !== 0 ? signoConfigurado : 1;
+          if (!Number.isFinite(signoConfigurado) && op.Clase && op.Clase.toLowerCase().includes('expense')) {
             signo = -1;
           }
 

--- a/src/services/reportes/planeacionReportesEngine.js
+++ b/src/services/reportes/planeacionReportesEngine.js
@@ -206,6 +206,13 @@ const crearAcumulador = () => ({
   prevYTD: 0
 });
 
+const normalizarTexto = (valor = '') => valor
+  .toString()
+  .trim()
+  .toUpperCase()
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '');
+
 const sumarTotales = (destino, origen, factor = 1) => {
   if (!destino || !origen) return destino;
   destino.actualMonth += factor * Number(origen.actualMonth ?? 0);
@@ -262,7 +269,24 @@ const construirNodoSeccion = ({ seccion, cuentas, definicion, claveMes, planeaci
     };
   });
 
-    return {
+  const esOther = normalizarTexto(seccion) === 'OTHER';
+  const requiereAjusteOther = esOther && ['NORESTE', 'NOROESTE'].some((token) => capNorm.includes(token));
+  if (requiereAjusteOther) {
+    const cuentasAjuste = cuentasDetalle.filter((cuenta) => {
+      const descNorm = normalizarTexto(cuenta.descripcion || '');
+      return descNorm.includes('PERDIDA CAMBIARIA');
+    });
+    cuentasAjuste.forEach((cuenta) => {
+      totales.actualMonth -= 2 * Number(cuenta.actualMonth ?? 0);
+      totales.planMonth -= 2 * Number(cuenta.planMonth ?? 0);
+      totales.prevMonth -= 2 * Number(cuenta.prevMonth ?? 0);
+      totales.actualYTD -= 2 * Number(cuenta.actualYTD ?? 0);
+      totales.planYTD -= 2 * Number(cuenta.planYTD ?? 0);
+      totales.prevYTD -= 2 * Number(cuenta.prevYTD ?? 0);
+    });
+  }
+
+  return {
     label: seccion,
     cuentas: cuentasDetalle,
     orden,

--- a/vistas/Graficas.html
+++ b/vistas/Graficas.html
@@ -90,37 +90,37 @@
         <div class="col-12 col-xl-6">
           <div class="card chart-card p-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="mb-0">Resultados Operativos (Actual)</h5>
-              <small class="text-muted">Ingreso vs Gasto</small>
+              <h5 class="mb-0">Resultados Operativos por Capítulo</h5>
+              <small class="text-muted">Actual vs Plan</small>
             </div>
-            <canvas id="chartOperating"></canvas>
+            <canvas id="chartOperatingByChapter"></canvas>
           </div>
         </div>
         <div class="col-12 col-xl-6">
           <div class="card chart-card p-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="mb-0">Net Results (Actual)</h5>
-              <small class="text-muted">Resultado neto por capitulo</small>
+              <h5 class="mb-0">Resultados Netos por Capítulo</h5>
+              <small class="text-muted">Actual vs Plan</small>
             </div>
-            <canvas id="chartNet"></canvas>
+            <canvas id="chartNetByChapter"></canvas>
           </div>
         </div>
         <div class="col-12">
           <div class="card chart-card p-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="mb-0">Comparativo Net Results</h5>
-              <small class="text-muted">Mexico vs Guadalajara vs Monterrey vs Northwest</small>
+              <h5 class="mb-0">Net Results CDMX (detalle)</h5>
+              <small class="text-muted">Mexico · Guadalajara · Monterrey · Northwest</small>
             </div>
-            <canvas id="chartNetCompare"></canvas>
+            <canvas id="chartNetCdmx"></canvas>
           </div>
         </div>
         <div class="col-12">
           <div class="card chart-card p-3">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="mb-0">Consolidated Income</h5>
-              <small class="text-muted">Ingreso consolidado del periodo</small>
+              <h5 class="mb-0">Consolidados Operativos vs Netos</h5>
+              <small class="text-muted">Resultados consolidados por capítulo</small>
             </div>
-            <canvas id="chartConsolidated"></canvas>
+            <canvas id="chartConsolidatedResults"></canvas>
           </div>
         </div>
       </div>
@@ -189,41 +189,26 @@
 
         const buildMetrics = (resumen = []) => {
           if (!Array.isArray(resumen) || !resumen.length) return null;
-          const map = flattenLabels(resumen);
-          const get = (lbl) => map.get(normalizarLabel(lbl)) || {};
-          const ingreso = (lbl) => toNumber(get(lbl).actualMonth);
-          const planIngreso = (lbl) => toNumber(get(lbl).planMonth);
-          const expense = (lbl) => toNumber(get(lbl).actualMonth);
+          const nodo = resumen[0] || {};
+          const mapa = flattenLabels(nodo.layout || nodo.children || []);
+          const get = (lbl) => mapa.get(normalizarLabel(lbl)) || {};
+          const getActual = (lbl) => toNumber(get(lbl).actualMonth);
+          const getPlan = (lbl) => toNumber(get(lbl).planMonth);
 
-          const makeOperating = (incLbl, expLbl, fallbackOpLbl) => {
-            const inc = ingreso(incLbl);
-            const exp = expense(expLbl);
-            if (inc || exp) return { actual: inc - exp, plan: planIngreso(incLbl) - planIngreso(expLbl) };
-            const op = get(fallbackOpLbl);
-            return { actual: toNumber(op.actualMonth), plan: toNumber(op.planMonth) };
-          };
-
-          const makeNet = (netLbl) => {
-            const n = get(netLbl);
-            return { actual: toNumber(n.actualMonth), plan: toNumber(n.planMonth) };
-          };
+          const readTotals = (lbl) => ({ actual: getActual(lbl), plan: getPlan(lbl) });
 
           return {
-            operating: {
-              mexico: makeOperating('CDMX INCOME', 'CDMX EXPENSE', 'OPERATING RESULTS MEXICO'),
-              gdl: makeOperating('GUADALAJARA INCOME', 'GUADALAJARA EXPENSE', 'OPERATING RESULTS GUADALAJARA'),
-              mty: makeOperating('MONTERREY INCOME', 'MONTERREY EXPENSE', 'OPERATING RESULTS MONTERREY'),
-              nw: makeOperating('NORTHWEST INCOME', 'NORTHWEST EXPENSE', 'OPERATING RESULTS NORTHWEST')
-            },
-            net: {
-              mexico: makeNet('NET RESULTS MEXICO'),
-              gdl: makeNet('NET RESULTS GUADALAJARA'),
-              mty: makeNet('NET RESULTS MONTERREY'),
-              nw: makeNet('NET RESULTS NORTHWEST')
-            },
-            consolidatedIncome: {
-              actual: ingreso('CONSOLIDATED INCOME'),
-              plan: planIngreso('CONSOLIDATED INCOME')
+            chapter: nodo.label || '',
+            operating: readTotals('OPERATING RESULTS'),
+            net: readTotals('NET RESULTS'),
+            consolidatedOperating: readTotals('CONSOLIDATED OPERATING RESULTS'),
+            consolidatedNet: readTotals('CONSOLIDATED NET RESULTS'),
+            cdmxOperating: readTotals('OPERATING RESULTS MEXICO'),
+            cdmxNet: {
+              mexico: readTotals('NET RESULTS MEXICO'),
+              gdl: readTotals('NET RESULTS GUADALAJARA'),
+              mty: readTotals('NET RESULTS MONTERREY'),
+              nw: readTotals('NET RESULTS NORTHWEST')
             }
           };
         };
@@ -235,23 +220,25 @@
           charts[id] = new Chart(ctx, cfg);
         };
 
-        const renderCharts = (metrics) => {
-          if (!metrics) return;
-          const labels = ['Mexico', 'Guadalajara', 'Monterrey', 'Northwest'];
+        const renderCharts = (metricsList = []) => {
+          if (!Array.isArray(metricsList) || !metricsList.length) return;
+          const labels = metricsList.map((m) => m.chapter || 'Capítulo');
+          const hasData = (totals) => toNumber(totals?.actual) !== 0 || toNumber(totals?.plan) !== 0;
+          const pickTotals = (primary, fallback) => (hasData(primary) ? primary : (fallback || { actual: 0, plan: 0 }));
 
-          renderChart('chartOperating', {
+          renderChart('chartOperatingByChapter', {
             type: 'bar',
             data: {
               labels,
               datasets: [
                 {
                   label: 'Operating (Actual)',
-                  data: [metrics.operating.mexico.actual, metrics.operating.gdl.actual, metrics.operating.mty.actual, metrics.operating.nw.actual],
+                  data: metricsList.map((m) => pickTotals(m.operating, m.cdmxOperating).actual),
                   backgroundColor: '#2f5496'
                 },
                 {
                   label: 'Operating (Plan)',
-                  data: [metrics.operating.mexico.plan, metrics.operating.gdl.plan, metrics.operating.mty.plan, metrics.operating.nw.plan],
+                  data: metricsList.map((m) => pickTotals(m.operating, m.cdmxOperating).plan),
                   backgroundColor: '#8fb2ff'
                 }
               ]
@@ -263,19 +250,19 @@
             }
           });
 
-          renderChart('chartNet', {
+          renderChart('chartNetByChapter', {
             type: 'bar',
             data: {
               labels,
               datasets: [
                 {
                   label: 'Net (Actual)',
-                  data: [metrics.net.mexico.actual, metrics.net.gdl.actual, metrics.net.mty.actual, metrics.net.nw.actual],
+                  data: metricsList.map((m) => pickTotals(m.net, m.consolidatedNet).actual),
                   backgroundColor: '#10b981'
                 },
                 {
                   label: 'Net (Plan)',
-                  data: [metrics.net.mexico.plan, metrics.net.gdl.plan, metrics.net.mty.plan, metrics.net.nw.plan],
+                  data: metricsList.map((m) => pickTotals(m.net, m.consolidatedNet).plan),
                   backgroundColor: '#6ee7b7'
                 }
               ]
@@ -287,44 +274,66 @@
             }
           });
 
-          renderChart('chartNetCompare', {
-            type: 'radar',
+          const cdmx = metricsList.find((m) => normalizarLabel(m.chapter).includes('CIUDAD DE MEXICO')) || {};
+          renderChart('chartNetCdmx', {
+            type: 'bar',
             data: {
-              labels,
+              labels: ['Mexico', 'Guadalajara', 'Monterrey', 'Northwest'],
               datasets: [
                 {
                   label: 'Net Actual',
-                  data: [metrics.net.mexico.actual, metrics.net.gdl.actual, metrics.net.mty.actual, metrics.net.nw.actual],
-                  backgroundColor: 'rgba(47,84,150,0.25)',
-                  borderColor: '#2f5496'
+                  data: [
+                    toNumber(cdmx.cdmxNet?.mexico?.actual),
+                    toNumber(cdmx.cdmxNet?.gdl?.actual),
+                    toNumber(cdmx.cdmxNet?.mty?.actual),
+                    toNumber(cdmx.cdmxNet?.nw?.actual)
+                  ],
+                  backgroundColor: '#2f5496'
                 },
                 {
                   label: 'Net Plan',
-                  data: [metrics.net.mexico.plan, metrics.net.gdl.plan, metrics.net.mty.plan, metrics.net.nw.plan],
-                  backgroundColor: 'rgba(16,185,129,0.25)',
-                  borderColor: '#10b981'
+                  data: [
+                    toNumber(cdmx.cdmxNet?.mexico?.plan),
+                    toNumber(cdmx.cdmxNet?.gdl?.plan),
+                    toNumber(cdmx.cdmxNet?.mty?.plan),
+                    toNumber(cdmx.cdmxNet?.nw?.plan)
+                  ],
+                  backgroundColor: '#8fb2ff'
                 }
               ]
             },
             options: {
               responsive: true,
               plugins: { legend: { position: 'bottom' } },
-              scales: {
-                r: {
-                  angleLines: { color: '#e5e7eb' },
-                  grid: { color: '#e5e7eb' }
-                }
-              }
+              scales: { y: { beginAtZero: true } }
             }
           });
 
-          renderChart('chartConsolidated', {
+          renderChart('chartConsolidatedResults', {
             type: 'bar',
             data: {
-              labels: ['Consolidated Income'],
+              labels,
               datasets: [
-                { label: 'Actual', data: [metrics.consolidatedIncome.actual], backgroundColor: '#f59e0b' },
-                { label: 'Plan', data: [metrics.consolidatedIncome.plan], backgroundColor: '#fcd34d' }
+                {
+                  label: 'Consolidated Operating (Actual)',
+                  data: metricsList.map((m) => m.consolidatedOperating.actual),
+                  backgroundColor: '#f59e0b'
+                },
+                {
+                  label: 'Consolidated Operating (Plan)',
+                  data: metricsList.map((m) => m.consolidatedOperating.plan),
+                  backgroundColor: '#fcd34d'
+                },
+                {
+                  label: 'Consolidated Net (Actual)',
+                  data: metricsList.map((m) => m.consolidatedNet.actual),
+                  backgroundColor: '#9333ea'
+                },
+                {
+                  label: 'Consolidated Net (Plan)',
+                  data: metricsList.map((m) => m.consolidatedNet.plan),
+                  backgroundColor: '#c4b5fd'
+                }
               ]
             },
             options: {
@@ -364,22 +373,39 @@
           empresaLabel.textContent = `Capitulo: ${empresa?.nombre || empresa?.etiqueta || empresa?.id}`;
           const anio = Number(yearSelect.value) || new Date().getFullYear();
           const mes = Number(monthSelect.value) || new Date().getMonth() + 1;
-          const capitulo = obtenerCapituloSeleccionado(empresa.id);
           try {
-            const url = new URL(API_ENDPOINT);
-            url.searchParams.set('empresaId', empresa.id);
-            url.searchParams.set('anio', anio);
-            url.searchParams.set('mes', mes.toString()); // API espera mes numerico (1-12)
-            if (capitulo) url.searchParams.set('capitulo', capitulo);
-            const res = await fetch(url.toString(), { headers: window.Sesion?.headersAutenticacion?.() || {} });
+            const baseUrl = new URL(API_ENDPOINT);
+            baseUrl.searchParams.set('empresaId', empresa.id);
+            baseUrl.searchParams.set('anio', anio);
+            baseUrl.searchParams.set('mes', mes.toString()); // API espera mes numerico (1-12)
+            const res = await fetch(baseUrl.toString(), { headers: window.Sesion?.headersAutenticacion?.() || {} });
             if (!res.ok) {
               const text = await res.text();
               console.warn('Graficas resumen 400/500', res.status, text);
               throw new Error(`No se pudo obtener resumen (${res.status})`);
             }
             const data = await res.json().catch(() => ({}));
-            const metrics = buildMetrics(data.resumen || []);
-            renderCharts(metrics);
+            const capitulos = Array.isArray(data.capitulosDisponibles) ? data.capitulosDisponibles : [];
+            const etiquetas = capitulos.length
+              ? capitulos.map((c) => c.etiqueta).filter(Boolean)
+              : [obtenerCapituloSeleccionado(empresa.id)].filter(Boolean);
+            const headers = window.Sesion?.headersAutenticacion?.() || {};
+            const responses = await Promise.all(etiquetas.map(async (capitulo) => {
+              const url = new URL(API_ENDPOINT);
+              url.searchParams.set('empresaId', empresa.id);
+              url.searchParams.set('anio', anio);
+              url.searchParams.set('mes', mes.toString());
+              if (capitulo) url.searchParams.set('capitulo', capitulo);
+              const resp = await fetch(url.toString(), { headers });
+              if (!resp.ok) {
+                console.warn('Graficas resumen 400/500', resp.status, capitulo);
+                return null;
+              }
+              const json = await resp.json().catch(() => ({}));
+              return buildMetrics(json.resumen || []);
+            }));
+            const metricsList = responses.filter(Boolean);
+            renderCharts(metricsList);
           } catch (e) {
             console.error('Error cargando resumen para graficas', e);
           }

--- a/vistas/js/insertion-validator.js
+++ b/vistas/js/insertion-validator.js
@@ -79,6 +79,13 @@
             severity: 'error'
           });
         }
+        if (tipo === 'operacion_sumas' && (!context.secundaria || !context.principal)) {
+          errors.push({
+            field: 'jerarquia',
+            message: 'Una operación de sumas debe estar dentro de una Secundaria (que está en una Principal)',
+            severity: 'error'
+          });
+        }
       }
 
       if (moduleType === 'RESUMEN') {
@@ -86,6 +93,13 @@
           errors.push({
             field: 'jerarquia',
             message: 'Una Operación debe estar en una Secundaria (que está en una Principal)',
+            severity: 'error'
+          });
+        }
+        if (tipo === 'operacion_sumas' && (!context.secundaria || !context.principal)) {
+          errors.push({
+            field: 'jerarquia',
+            message: 'Una operación de sumas debe estar en una Secundaria (que está en una Principal)',
             severity: 'error'
           });
         }
@@ -218,6 +232,32 @@
       }
 
       if (tipo !== 'cuenta') {
+        if (tipo === 'operacion_sumas') {
+          if (!formData.clase || formData.clase.trim() === '') {
+            errors.push({
+              field: 'clase',
+              message: 'La clase es obligatoria para operaciones de sumas',
+              severity: 'error'
+            });
+          }
+          if (!formData.seccion && (!context.secundaria || context.secundaria.trim() === '')) {
+            errors.push({
+              field: 'seccion',
+              message: 'Selecciona la sección secundaria para la operación',
+              severity: 'error'
+            });
+          }
+          const operaciones = formData.operaciones || {};
+          const tieneOperacion = Object.values(operaciones).some((value) => value);
+          if (!tieneOperacion) {
+            errors.push({
+              field: 'operaciones',
+              message: 'Define al menos una etiqueta de operación',
+              severity: 'error'
+            });
+          }
+          return errors;
+        }
         // Validar nombre de sección/operación
         if (!formData.nombre || formData.nombre.trim() === '') {
           errors.push({
@@ -238,7 +278,7 @@
       }
 
       const factorValor = formData.factor ?? formData.operacionFactor;
-      if (!Number.isFinite(Number(factorValor))) {
+      if (tipo !== 'operacion_sumas' && !Number.isFinite(Number(factorValor))) {
         errors.push({
           field: 'factor',
           message: 'Selecciona si la fila suma, resta o usa un factor numérico.',
@@ -380,12 +420,14 @@
       return {
         SUMMARY: {
           cuenta: { hierarchy: ['capitulo', 'principal', 'secundaria'] },
+          operacion_sumas: { hierarchy: ['capitulo', 'principal', 'secundaria'] },
           secundaria: { hierarchy: ['capitulo', 'principal'] },
           principal: { hierarchy: ['capitulo'] }
         },
         RESUMEN: {
           cuenta: { hierarchy: ['capitulo', 'principal', 'secundaria', 'operacion'] },
           operacion: { hierarchy: ['capitulo', 'principal', 'secundaria'] },
+          operacion_sumas: { hierarchy: ['capitulo', 'principal', 'secundaria'] },
           secundaria: { hierarchy: ['capitulo', 'principal'] },
           principal: { hierarchy: ['capitulo'] }
         },

--- a/vistas/js/insertion-wizard.js
+++ b/vistas/js/insertion-wizard.js
@@ -14,6 +14,17 @@
     selectedType: null, // 'cuenta', 'operacion', 'secundaria', 'principal'
     contextData: {},
     formData: {},
+    operacionesSumasTipos: [
+      { key: 'sum-row', label: 'Sum Row (sección)' },
+      { key: 'sum-row-sumavarios', label: 'Sum Row (sumavarios)' },
+      { key: 'sum-row-sumavarios-consolidado', label: 'Sum Row (consolidado)' },
+      { key: 'sum-row-operativo', label: 'Sum Row (operativo)' },
+      { key: 'sum-row-operativo-consolidado', label: 'Sum Row (operativo consolidado)' },
+      { key: 'result-row', label: 'Result Row' },
+      { key: 'net-row', label: 'Net Row' },
+      { key: 'net-row-adicional', label: 'Net Row adicional' },
+      { key: 'result-net-row', label: 'Result Net Row' }
+    ],
 
     /**
      * Detecta el tipo de módulo actual
@@ -51,6 +62,10 @@
             required: ['nombre', 'etiquetaSum', 'factor'],
             hierarchy: ['capitulo'],
             autoCreate: ['sumRow']
+          },
+          operacion_sumas: {
+            required: ['clase', 'seccion'],
+            hierarchy: ['secundaria', 'principal', 'capitulo']
           }
         },
         RESUMEN: {
@@ -74,6 +89,10 @@
             required: ['nombre', 'etiquetaSum', 'factor'],
             hierarchy: ['capitulo'],
             autoCreate: ['sumRow']
+          },
+          operacion_sumas: {
+            required: ['clase', 'seccion'],
+            hierarchy: ['secundaria', 'principal', 'capitulo']
           }
         },
         MODULOS: {
@@ -107,11 +126,15 @@
     open(referenceRow = null) {
       this.moduleType = this.detectModuleType();
       this.contextData = this.extractContextFromRow(referenceRow);
-      this.formData = { factor: null, factorChoice: '' };
+      this.formData = { factor: null, factorChoice: '', operaciones: {} };
 
-      // Forzar tipo cuenta por defecto y saltar directamente al paso de contexto.
-      this.selectedType = 'cuenta';
-      this.currentStep = 2;
+      const tieneTipo = Boolean(this.selectedType);
+      if (!tieneTipo) {
+        this.selectedType = null;
+        this.currentStep = 1;
+      } else {
+        this.currentStep = 2;
+      }
 
       this.renderWizard();
       this.showModal();
@@ -353,7 +376,12 @@
       // Renderizar con placeholders, cargaremos opciones después
       const html = `
         <div class="wizard-step active" data-step="2">
-          <h6 class="mb-3">Selecciona la ubicación</h6>
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h6 class="mb-0">Selecciona la ubicación</h6>
+            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="InsertionWizard.volverSeleccionTipo()">
+              Cambiar tipo
+            </button>
+          </div>
 
           <div class="mb-3">
             <label class="form-label">Capítulo activo</label>
@@ -470,6 +498,16 @@
         this.formData.factorChoice ||
         (factorNumerico === null ? '' : factorNumerico === -1 ? '-1' : factorNumerico === 1 ? '1' : 'custom');
       const factorCustomValor = factorChoice === 'custom' ? (this.formData.factor ?? '') : '';
+      const claseSugerida = this.buildClaseSugerida();
+      const seccionSugerida = this.contextData.secundaria || '';
+      const operacionesActuales = this.formData.operaciones || {};
+      const signoActual = Number.isFinite(Number(this.formData.signo)) ? Number(this.formData.signo) : 1;
+      if (!this.formData.clase && claseSugerida) {
+        this.formData.clase = claseSugerida;
+      }
+      if (!this.formData.seccion && seccionSugerida) {
+        this.formData.seccion = seccionSugerida;
+      }
 
 
       return `
@@ -508,7 +546,7 @@
             </div>
           ` : ''}
 
-          ${this.selectedType !== 'cuenta' ? `
+          ${this.selectedType !== 'cuenta' && this.selectedType !== 'operacion_sumas' ? `
             <div class="mb-3">
               <label for="data_nombre" class="form-label">
                 Nombre de ${this.getTypeLabel(this.selectedType)} <span class="text-danger">*</span>
@@ -540,6 +578,66 @@
               </select>
             </div>
           ` : ''}
+
+          ${this.selectedType === 'operacion_sumas' ? `
+            <div class="mb-3">
+              <label for="data_clase" class="form-label">
+                Clase (identificador) <span class="text-danger">*</span>
+              </label>
+              <input type="text" class="form-control" id="data_clase" required
+                     value="${this.formData.clase || claseSugerida}"
+                     placeholder="Ej: income-Membership"
+                     oninput="InsertionWizard.validateField('clase', this.value)">
+              <div class="form-text">
+                Usa una clase consistente (ej: income-Membership, expense-Other).
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label for="data_seccion" class="form-label">
+                Sección asociada <span class="text-danger">*</span>
+              </label>
+              <input type="text" class="form-control" id="data_seccion" required
+                     value="${this.formData.seccion || seccionSugerida}"
+                     placeholder="Ej: Membership"
+                     oninput="InsertionWizard.validateField('seccion', this.value)">
+              <div class="form-text">
+                Por defecto se toma la Sección Secundaria seleccionada.
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label for="data_signo" class="form-label">Signo de la operación</label>
+              <select class="form-select" id="data_signo" onchange="InsertionWizard.updateOperacionSumasSigno(this.value)">
+                <option value="1" ${signoActual === 1 ? 'selected' : ''}>Suma (+1)</option>
+                <option value="-1" ${signoActual === -1 ? 'selected' : ''}>Resta (-1)</option>
+              </select>
+              <div class="form-text">
+                Determina si la clase suma o resta en las consolidaciones.
+              </div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">
+                Operaciones entre filas <span class="text-danger">*</span>
+              </label>
+              <div class="row g-2">
+                ${this.operacionesSumasTipos.map((op) => `
+                  <div class="col-12 col-md-6">
+                    <label class="form-label small text-muted mb-1" for="data_op_${op.key}">
+                      ${op.label}
+                    </label>
+                    <input type="text" class="form-control" id="data_op_${op.key}"
+                           value="${operacionesActuales[op.key] || ''}"
+                           placeholder="Etiqueta (ej: NET RESULTS)"
+                           oninput="InsertionWizard.updateOperacionSumas('${op.key}', this.value)">
+                  </div>
+                `).join('')}
+              </div>
+            </div>
+          ` : ''}
+
+          ${this.selectedType !== 'operacion_sumas' ? `
           <div class="mb-3">
             <label for="data_factor" class="form-label">
               Operaci¢n / Factor <span class="text-danger">*</span>
@@ -562,6 +660,7 @@
               Define si esta fila suma, resta o usa un factor distinto en los totales.
             </div>
           </div>
+          ` : ''}
         </div>
       `;
     },
@@ -595,6 +694,12 @@
             label: 'Nueva Sección Principal',
             icon: '📂',
             description: 'Crear una nueva sección principal en el capítulo'
+          },
+          {
+            value: 'operacion_sumas',
+            label: 'Operación entre filas',
+            icon: '➗',
+            description: 'Definir SUMA DE VARIAS SECCIONES (sumavarios, net, operativo)'
           }
         ],
         RESUMEN: [
@@ -621,6 +726,12 @@
             label: 'Nueva Sección Principal',
             icon: '📂',
             description: 'Crear una nueva sección principal en el capítulo'
+          },
+          {
+            value: 'operacion_sumas',
+            label: 'Operación entre filas',
+            icon: '➗',
+            description: 'Definir SUMA DE VARIAS SECCIONES (sumavarios, net, operativo)'
           }
         ],
         MODULOS: [
@@ -671,7 +782,8 @@
         operacion: 'Operación',
         secundaria: 'Sección Secundaria',
         principal: 'Sección Principal',
-        seccion: 'Sección'
+        seccion: 'Sección',
+        operacion_sumas: 'Operación entre filas'
       };
       return labels[type] || type;
     },
@@ -766,6 +878,47 @@
       this.updatePreview();
     },
 
+    buildClaseSugerida() {
+      const principal = (this.contextData.principal || '').toString().trim();
+      const secundaria = (this.contextData.secundaria || '').toString().trim();
+      if (!principal && !secundaria) return '';
+      return `${principal}-${secundaria}`.replace(/\s+/g, ' ').trim();
+    },
+
+    updateOperacionSumas(tipo, valor) {
+      if (!this.formData.operaciones) this.formData.operaciones = {};
+      this.formData.operaciones[tipo] = valor;
+      this.updatePreview();
+    },
+
+    updateOperacionSumasSigno(valor) {
+      const numero = Number(valor);
+      this.formData.signo = Number.isFinite(numero) ? numero : 1;
+      this.updatePreview();
+    },
+
+    collectOperacionesSumas() {
+      const operaciones = {};
+      this.operacionesSumasTipos.forEach((op) => {
+        const input = document.getElementById(`data_op_${op.key}`);
+        const valor = input?.value?.trim() || '';
+        if (valor) {
+          operaciones[op.key] = valor;
+        }
+      });
+      this.formData.operaciones = operaciones;
+      const claseInput = document.getElementById('data_clase');
+      const seccionInput = document.getElementById('data_seccion');
+      if (claseInput) this.formData.clase = claseInput.value;
+      if (seccionInput) this.formData.seccion = seccionInput.value;
+      const signoInput = document.getElementById('data_signo');
+      if (signoInput) {
+        const numero = Number(signoInput.value);
+        if (Number.isFinite(numero)) this.formData.signo = numero;
+      }
+      return operaciones;
+    },
+
     handleFactorChange(value) {
       const customGroup = document.getElementById('data_factor_custom_group');
       if (value === 'custom') {
@@ -844,7 +997,10 @@
       
       if (!preview || !content) return;
 
-      if (this.currentStep === 3 && this.formData.nombre) {
+      const tieneDatosPreview = this.selectedType === 'operacion_sumas'
+        ? Boolean(this.formData.clase || this.formData.seccion)
+        : Boolean(this.formData.nombre || this.formData.numero);
+      if (this.currentStep === 3 && tieneDatosPreview) {
         preview.classList.remove('d-none');
         
         const hierarchy = [];
@@ -860,12 +1016,23 @@
               ? 'Resta (-1)'
               : `Factor ${this.formData.factor}`)
           : '';
+        const operaciones = this.formData.operaciones || {};
+        const operacionesTexto = Object.entries(operaciones)
+          .filter(([, value]) => value)
+          .map(([tipo, etiqueta]) => `${tipo}: ${etiqueta}`)
+          .join(' | ');
 
+        const nombrePreview = this.formData.nombre || this.formData.numero || this.formData.clase || '';
         content.innerHTML = `
-          <div><strong>${this.getTypeLabel(this.selectedType)}:</strong> ${this.formData.nombre || this.formData.numero || ''}</div>
+          <div><strong>${this.getTypeLabel(this.selectedType)}:</strong> ${nombrePreview}</div>
           ${hierarchy.length > 0 ? `<div class="text-muted">📍 ${hierarchy.join(' > ')}</div>` : ''}
           ${factorLabel ? `<div class="text-info">Operaci¢n: ${factorLabel}</div>` : ''}
           ${this.formData.etiquetaSum ? `<div class="text-success">✓ Se creará SUM ROW: "${this.formData.etiquetaSum}"</div>` : ''}
+          ${this.selectedType === 'operacion_sumas' ? `
+            <div class="text-info">Clase: ${this.formData.clase || ''}</div>
+            <div class="text-info">Sección: ${this.formData.seccion || this.contextData.secundaria || ''}</div>
+            ${operacionesTexto ? `<div class="text-muted small">Operaciones: ${operacionesTexto}</div>` : ''}
+          ` : ''}
         `;
       } else {
         preview.classList.add('d-none');
@@ -896,6 +1063,12 @@
       this.showModal();
     },
 
+    volverSeleccionTipo() {
+      this.currentStep = 1;
+      this.renderWizard();
+      this.showModal();
+    },
+
     /**
      * Valida el paso actual
      */
@@ -911,6 +1084,15 @@
           const dataRules = this.getValidationRules()[this.selectedType];
           const requiredFields = dataRules?.required || [];
           return requiredFields.every((field) => {
+            if (this.selectedType === 'operacion_sumas') {
+              const operaciones = this.collectOperacionesSumas();
+              const tieneOperacion = Object.values(operaciones).some((value) => value);
+              if (!tieneOperacion) return false;
+              if (!this.formData.clase || this.formData.clase.toString().trim() === '') return false;
+              const seccion = this.formData.seccion || this.contextData.secundaria;
+              if (!seccion || seccion.toString().trim() === '') return false;
+              return true;
+            }
             if (field === 'factor') {
               return Number.isFinite(Number(this.formData.factor));
             }
@@ -987,6 +1169,8 @@
         return await this.insertarSeccion(insertionData);
       } else if (this.selectedType === 'operacion') {
         return await this.insertarOperacion(insertionData);
+      } else if (this.selectedType === 'operacion_sumas') {
+        return await this.insertarOperacionSumas(insertionData);
       }
     },
 
@@ -994,6 +1178,9 @@
      * Construye el objeto de datos para inserción
      */
     buildInsertionData() {
+      if (this.selectedType === 'operacion_sumas') {
+        this.collectOperacionesSumas();
+      }
       const base = {
         moduleType: this.moduleType,
         context: {
@@ -1012,6 +1199,15 @@
           factor: Number.isFinite(Number(this.formData.factor)) ? Number(this.formData.factor) : 1
         }
       };
+
+      if (this.selectedType === 'operacion_sumas') {
+        base.formData = {
+          clase: this.formData.clase || '',
+          seccion: this.formData.seccion || this.contextData.secundaria || '',
+          signo: Number.isFinite(Number(this.formData.signo)) ? Number(this.formData.signo) : 1,
+          operaciones: this.formData.operaciones || {}
+        };
+      }
 
       return base;
     },
@@ -1095,6 +1291,26 @@
 
       const result = await response.json();
       console.log('✅ Operación insertada:', result);
+      return result;
+    },
+
+    /**
+     * Inserta una operación entre filas (SUMA DE VARIAS SECCIONES)
+     */
+    async insertarOperacionSumas(data) {
+      const response = await fetch('/api/insercion/operacion-sumas', {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify(data)
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.mensaje || 'Error al insertar operación entre filas');
+      }
+
+      const result = await response.json();
+      console.log('✅ Operación entre filas insertada:', result);
       return result;
     },
 


### PR DESCRIPTION
### Motivation

- Hacer el wizard de inserción totalmente personalizable para definir operaciones entre filas (`SUMA DE VARIAS SECCIONES`) con etiquetas por tipo, clase y signo.
- Prevenir duplicados y validar jerarquía/formato al crear estas operaciones desde UI y API.
- Respetar el signo configurado al persistir operaciones en layouts para evitar cálculos incorrectos.
- Ajustar la lógica de reportes para normalizar texto y corregir el cálculo de secciones `Other` en capítulos específicos.

### Description

- Se añadió un nuevo endpoint `POST /api/insercion/operacion-sumas` y validaciones en `src/routes/insercion.js` para crear entradas en `SUMA DE VARIAS SECCIONES` con `Clase`, `SECCION`, `signo` y etiquetas por tipo de operación.  
- Se amplió la validación y verificación de duplicados en `src/routes/insercion.js` y en el cliente `vistas/js/insertion-validator.js` para soportar el nuevo tipo `operacion_sumas`.  
- El wizard en `vistas/js/insertion-wizard.js` ahora expone un flujo para `operacion_sumas` con campos para `clase`, `seccion`, `signo` y una lista de etiquetas (`sum-row`, `sum-row-sumavarios`, `result-row`, `net-row`, etc.), recolección de datos y envío a la nueva API.  
- Se modificó `src/services/layoutService.js` para que, al sembrar/guardar operaciones, se respete el `signo` numérico cuando está presente y solo infiera `-1` por `expense` si no hay signo configurado.  
- Se añadieron utilidades en `src/services/reportes/planeacionReportesEngine.js` para normalizar texto y se ajustó `construirNodoSeccion` para restar cuentas con descripción `PÉRDIDA CAMBIARIA` cuando la sección es `Other` en capítulos `NORESTE`/`NOROESTE`.  
- En `vistas/Graficas.html` se reescribió la lectura/renderizado de métricas para pintar series por capítulo (nuevos canvas y extracción por `capitulosDisponibles`).

### Testing

- Se levantó un servidor estático con `python -m http.server 8000` y se ejecutó un script de Playwright que abre `vistas/RESUMEN.html`, abre el wizard en modo `operacion_sumas` y genera una captura (`artifacts/wizard-operacion-sumas.png`), resultado: captura generada (smoke test visual correcto).
- Se inició el proceso de commit/local (cambios añadidos y confirmados), no se encontraron errores en tiempo de edición (lint/runtime básico manual).
- No se ejecutaron pruebas unitarias ni la suite `npm test` en esta rama; tampoco se corrió pipeline CI (recomendado antes de desplegar).
- Recomiendo ejecutar el pipeline CI y `npm test` para validar integraciones y efectos colaterales en backend/frontend con datos reales antes del despliegue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949abad4b50832d8952d6cde0a36c6d)