### PR TITLE
Fix layout loader preview and wizard module handling

### DIFF
--- a/src/routes/insercion.js
+++ b/src/routes/insercion.js
@@ -10,13 +10,22 @@ const { requireAuth } = require('../middleware/auth');
 const layoutService = require('../services/layoutService');
 const { loadLayoutConfig, saveLayoutConfig } = require('../services/layoutConfigStore');
 
+const normalizarModuleType = (moduleType = '') => {
+  const valor = (moduleType || '').toString();
+  if (valor.startsWith('MODULOS_')) {
+    return 'MODULOS';
+  }
+  return valor;
+};
+
 /**
  * Helper: Validar jerarquía según tipo de módulo
  */
 function validarJerarquia(tipo, context, moduleType) {
   const errors = [];
+  const moduleBase = normalizarModuleType(moduleType);
 
-  if (moduleType === 'SUMMARY') {
+  if (moduleBase === 'SUMMARY') {
     if (tipo === 'cuenta' && (!context.principal || !context.secundaria)) {
       errors.push('Una cuenta en SUMMARY requiere Sección Principal y Secundaria');
     }
@@ -28,7 +37,7 @@ function validarJerarquia(tipo, context, moduleType) {
     }
   }
 
-  if (moduleType === 'RESUMEN') {
+  if (moduleBase === 'RESUMEN') {
     if (tipo === 'cuenta' && (!context.principal || !context.secundaria || !context.operacion)) {
       errors.push('Una cuenta en RESUMEN requiere Principal, Secundaria y Operación');
     }
@@ -43,7 +52,7 @@ function validarJerarquia(tipo, context, moduleType) {
     }
   }
 
-  if (moduleType === 'MODULOS') {
+  if (moduleBase === 'MODULOS') {
     if (tipo === 'cuenta' && !context.seccion) {
       errors.push('Una cuenta en MÓDULOS requiere una Sección');
     }
@@ -124,7 +133,8 @@ function verificarDuplicado(tipo, data, config, moduleType) {
  * Helper: Validar formato de cuenta
  */
 function validarFormato(numero, moduleType) {
-  if (moduleType === 'SUMMARY') {
+  const moduleBase = normalizarModuleType(moduleType);
+  if (moduleBase === 'SUMMARY') {
     // SUMMARY: 21 dígitos consecutivos
     if (!/^\d{21}$/.test(numero)) {
       return { valido: false, mensaje: 'Formato incorrecto. Debe ser 21 dígitos consecutivos (ej: 401000000000000000001)' };
@@ -224,6 +234,7 @@ router.post('/validar', requireAuth, async (req, res) => {
 router.post('/cuenta', requireAuth, async (req, res) => {
   try {
     const { moduleType, context, formData } = req.body;
+    const moduleBase = normalizarModuleType(moduleType);
 
     if (!moduleType || !context || !formData) {
       return res.status(400).json({
@@ -267,7 +278,7 @@ router.post('/cuenta', requireAuth, async (req, res) => {
     // Crear nueva cuenta según el módulo
     let nuevaCuenta;
 
-    if (moduleType === 'SUMMARY') {
+    if (moduleBase === 'SUMMARY') {
       nuevaCuenta = {
         "CAPITULO": context.capitulo || '',
         "SECCIÓN Principal": context.principal || '',
@@ -279,7 +290,7 @@ router.post('/cuenta', requireAuth, async (req, res) => {
       if (!config.SUMMARY) config.SUMMARY = [];
       config.SUMMARY.push(nuevaCuenta);
 
-    } else if (moduleType === 'RESUMEN') {
+    } else if (moduleBase === 'RESUMEN') {
       nuevaCuenta = {
         "CAPITULO": context.capitulo || '',
         "SECCIÓN Principal": context.principal || '',
@@ -338,6 +349,7 @@ router.post('/cuenta', requireAuth, async (req, res) => {
 router.post('/seccion', requireAuth, async (req, res) => {
   try {
     const { moduleType, tipo, context, formData } = req.body;
+    const moduleBase = normalizarModuleType(moduleType);
 
     if (!moduleType || !tipo || !context || !formData) {
       return res.status(400).json({
@@ -373,7 +385,7 @@ router.post('/seccion', requireAuth, async (req, res) => {
     let nuevaSeccion;
     let sumRow;
 
-    if (moduleType === 'SUMMARY') {
+    if (moduleBase === 'SUMMARY') {
       if (tipo === 'principal') {
         nuevaSeccion = {
           "CAPITULO": context.capitulo || '',
@@ -417,7 +429,7 @@ router.post('/seccion', requireAuth, async (req, res) => {
       config.SUMMARY.push(nuevaSeccion);
       config.SUMMARY.push(sumRow);
 
-    } else if (moduleType === 'RESUMEN') {
+    } else if (moduleBase === 'RESUMEN') {
       if (tipo === 'principal') {
         nuevaSeccion = {
           "CAPITULO": context.capitulo || '',
@@ -517,6 +529,7 @@ router.post('/seccion', requireAuth, async (req, res) => {
 router.post('/operacion', requireAuth, async (req, res) => {
   try {
     const { moduleType, context, formData } = req.body;
+    const moduleBase = normalizarModuleType(moduleType);
 
     if (!moduleType || !context || !formData) {
       return res.status(400).json({
@@ -525,7 +538,7 @@ router.post('/operacion', requireAuth, async (req, res) => {
       });
     }
 
-    if (moduleType === 'SUMMARY') {
+    if (moduleBase === 'SUMMARY') {
       return res.status(400).json({
         exito: false,
         mensaje: 'SUMMARY no soporta operaciones'
@@ -559,7 +572,7 @@ router.post('/operacion', requireAuth, async (req, res) => {
     let nuevaOperacion;
     let sumRow;
 
-    if (moduleType === 'RESUMEN') {
+    if (moduleBase === 'RESUMEN') {
       nuevaOperacion = {
         "CAPITULO": context.capitulo || '',
         "SECCIÓN Principal": context.principal || '',
@@ -638,6 +651,7 @@ router.post('/operacion', requireAuth, async (req, res) => {
 router.post('/operacion-sumas', requireAuth, async (req, res) => {
   try {
     const { moduleType, context, formData } = req.body;
+    const moduleBase = normalizarModuleType(moduleType);
 
     if (!moduleType || !context || !formData) {
       return res.status(400).json({
@@ -646,7 +660,7 @@ router.post('/operacion-sumas', requireAuth, async (req, res) => {
       });
     }
 
-    if (!['SUMMARY', 'RESUMEN'].includes(moduleType)) {
+    if (!['SUMMARY', 'RESUMEN'].includes(moduleBase)) {
       return res.status(400).json({
         exito: false,
         mensaje: 'Este tipo de operación solo aplica a SUMMARY/RESUMEN'

--- a/vistas/LayoutLoader.html
+++ b/vistas/LayoutLoader.html
@@ -192,8 +192,12 @@
                 <table class="table table-sm preview-table mb-0">
                   <thead>
                     <tr>
-                      <th>Sección</th>
-                      <th class="text-muted">Tipo</th>
+                      <th>Orden</th>
+                      <th>Tipo</th>
+                      <th>Cuenta</th>
+                      <th>Descripción</th>
+                      <th>Sección principal</th>
+                      <th>Sección secundaria</th>
                     </tr>
                   </thead>
                   <tbody id="layoutPreviewBody">
@@ -357,6 +361,16 @@
         const setStatus = (mensaje = 'Listo.') => {
           if (statusMessage) statusMessage.textContent = mensaje;
         };
+        const getWizardModuleType = () => {
+          const modulo = moduloSelect.value;
+          if (['SUMMARY', 'RESUMEN'].includes(modulo)) return modulo;
+          return `MODULOS_${modulo}`;
+        };
+        const getWizardModuleBase = () => {
+          const moduleType = getWizardModuleType();
+          return moduleType.startsWith('MODULOS_') ? 'MODULOS' : moduleType;
+        };
+        const permiteOperacionesSumas = () => ['SUMMARY', 'RESUMEN'].includes(getWizardModuleBase());
 
         const getAuthHeaders = () => {
           if (window.Sesion?.headersAutenticacion) {
@@ -520,6 +534,10 @@
 
         };
 
+        const renderPreview = () => {
+          renderPreviewItems();
+        };
+
         const renderLayoutPreview = (layout) => {
           const cuentas = Array.isArray(layout?.cuentas)
             ? layout.cuentas
@@ -529,29 +547,60 @@
           if (!cuentas.length) {
             layoutPreviewBody.innerHTML = `
               <tr>
-                <td colspan="2" class="text-muted">No hay cuentas para mostrar.</td>
+                <td colspan="6" class="text-muted">No hay cuentas para mostrar.</td>
               </tr>
             `;
             return;
           }
-          const mapa = new Map();
-          cuentas.forEach((cuenta) => {
+          const cuentasOrdenadas = [...cuentas].sort((a, b) => (Number(a.orden) || 0) - (Number(b.orden) || 0));
+          const filas = [];
+          let principalActual = '';
+          let secundariaActual = '';
+          let ordenVista = 1;
+          cuentasOrdenadas.forEach((cuenta) => {
             const principal = cuenta['SECCIàN Principal'] || cuenta['SECCIÓN Principal'] || cuenta['SECCION Principal'] || cuenta.SECCION || cuenta.seccion_principal || 'Sin sección principal';
             const secundaria = cuenta['SECCION Secundaria'] || cuenta['SECCIÓN Secundaria'] || cuenta.seccion_secundaria || 'Sin sección secundaria';
-            if (!mapa.has(principal)) mapa.set(principal, new Set());
-            mapa.get(principal).add(secundaria);
+            if (principal && principal !== principalActual) {
+              principalActual = principal;
+              secundariaActual = '';
+              filas.push({
+                orden: ordenVista++,
+                tipo: 'Sección principal',
+                cuenta: '',
+                descripcion: principal,
+                principal,
+                secundaria: ''
+              });
+            }
+            if (secundaria && secundaria !== secundariaActual) {
+              secundariaActual = secundaria;
+              filas.push({
+                orden: ordenVista++,
+                tipo: 'Sección secundaria',
+                cuenta: '',
+                descripcion: secundaria,
+                principal,
+                secundaria
+              });
+            }
+            filas.push({
+              orden: ordenVista++,
+              tipo: 'Cuenta',
+              cuenta: cuenta.CUENTA || '',
+              descripcion: cuenta.NOMBRE || '',
+              principal,
+              secundaria
+            });
           });
-          layoutPreviewBody.innerHTML = Array.from(mapa.entries()).map(([principal, secundarias]) => `
-            <tr class="preview-principal">
-              <td>${principal}</td>
-              <td>Principal</td>
+          layoutPreviewBody.innerHTML = filas.map((fila) => `
+            <tr class="${fila.tipo === 'Sección principal' ? 'preview-principal' : fila.tipo === 'Sección secundaria' ? 'preview-secundaria' : ''}">
+              <td>${fila.orden}</td>
+              <td>${fila.tipo}</td>
+              <td>${fila.cuenta || '-'}</td>
+              <td>${fila.descripcion || '-'}</td>
+              <td>${fila.principal || '-'}</td>
+              <td>${fila.secundaria || '-'}</td>
             </tr>
-            ${Array.from(secundarias).map((secundaria) => `
-              <tr class="preview-secundaria">
-                <td>${secundaria}</td>
-                <td>Secundaria</td>
-              </tr>
-            `).join('')}
           `).join('');
         };
 
@@ -607,10 +656,12 @@
                         `).join('')}
                         ${items.length > 8 ? `<li class="text-muted">+${items.length - 8} cuentas más…</li>` : ''}
                       </ul>
-                      <button type="button" class="btn btn-sm btn-outline-success"
-                              onclick="window.__layoutLoaderAbrirWizard({ principal: '${principal.replace(/'/g, "\\'")}', secundaria: '${secundaria.replace(/'/g, "\\'")}' }, 'operacion_sumas')">
-                        Agregar operación entre filas
-                      </button>
+                      ${permiteOperacionesSumas() ? `
+                        <button type="button" class="btn btn-sm btn-outline-success"
+                                onclick="window.__layoutLoaderAbrirWizard({ principal: '${principal.replace(/'/g, "\\'")}', secundaria: '${secundaria.replace(/'/g, "\\'")}' }, 'operacion_sumas')">
+                          Agregar operación entre filas
+                        </button>
+                      ` : ''}
                     </div>
                   </details>
                 `).join('')}
@@ -621,6 +672,10 @@
 
         const renderOperacionesMap = (layout) => {
           const operaciones = Array.isArray(layout.operaciones) ? layout.operaciones : [];
+          if (!permiteOperacionesSumas()) {
+            operacionesMap.textContent = 'Operaciones disponibles solo para SUMMARY/RESUMEN.';
+            return;
+          }
           if (!operaciones.length) {
             operacionesMap.textContent = 'No hay operaciones entre filas para este capítulo.';
             return;
@@ -720,7 +775,8 @@
               anioEdicionSelect.innerHTML = '<option value="">Sin años disponibles</option>';
               return;
             }
-            anios.forEach((anio) => {
+            const aniosOrdenados = [...anios].sort((a, b) => Number(b) - Number(a));
+            aniosOrdenados.forEach((anio) => {
               const opt = document.createElement('option');
               opt.value = anio;
               opt.textContent = anio;
@@ -730,10 +786,10 @@
               optEdicion.textContent = anio;
               anioEdicionSelect.appendChild(optEdicion);
             });
-            anioOrigenSelect.value = anios[anios.length - 1];
+            anioOrigenSelect.value = aniosOrdenados[0];
             anioEdicionSelect.value = anioEdicionActual && anios.includes(Number(anioEdicionActual))
               ? anioEdicionActual
-              : (anios[0] || anios[anios.length - 1]);
+              : aniosOrdenados[0];
           } catch (error) {
             console.error(error);
             anioOrigenSelect.innerHTML = '<option value="">Error al cargar</option>';
@@ -815,6 +871,10 @@
             setStatus('InsertionWizard no disponible.');
             return;
           }
+          if (tipo === 'operacion_sumas' && !permiteOperacionesSumas()) {
+            setStatus('Las operaciones entre filas solo están disponibles para SUMMARY/RESUMEN.');
+            return;
+          }
           const capitulo = obtenerCapituloSeleccionado();
           const anio = anioEdicionSelect.value || anioOrigenSelect.value;
           if (!anio || !capitulo) {
@@ -823,7 +883,7 @@
           }
           window.InsertionWizard.selectedType = tipo || null;
           window.InsertionWizard.open(null, {
-            moduleType: moduloSelect.value,
+            moduleType: getWizardModuleType(),
             capitulo,
             anio,
             prefillContext: contextoExtra
@@ -878,6 +938,10 @@
           renderPreviewItems();
         });
         sendPreviewToWizard.addEventListener('click', () => {
+          if (!permiteOperacionesSumas()) {
+            setStatus('Las operaciones entre filas solo están disponibles para SUMMARY/RESUMEN.');
+            return;
+          }
           if (!previewState.items.length) {
             setStatus('Agrega operaciones antes de abrir el wizard.');
             return;
@@ -907,6 +971,10 @@
             setStatus('Activa modo edición para guardar.');
             return;
           }
+          if (!permiteOperacionesSumas()) {
+            setStatus('Las operaciones entre filas solo están disponibles para SUMMARY/RESUMEN.');
+            return;
+          }
           const capitulo = obtenerCapituloSeleccionado();
           const anio = anioEdicionSelect.value || anioOrigenSelect.value;
           const principal = previewPrincipal.value.trim();
@@ -933,7 +1001,7 @@
               method: 'POST',
               headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
               body: JSON.stringify({
-                moduleType: moduloSelect.value,
+                moduleType: getWizardModuleType(),
                 context: { capitulo, principal, secundaria: seccion, anio },
                 formData: {
                   clase,

--- a/vistas/js/insertion-wizard.js
+++ b/vistas/js/insertion-wizard.js
@@ -40,6 +40,7 @@
      * Obtiene la configuración de validación según módulo
      */
     getValidationRules() {
+      const moduleBase = this.getModuleTypeBase();
       const rules = {
         SUMMARY: {
           cuenta: {
@@ -117,7 +118,15 @@
         }
       };
 
-      return rules[this.moduleType] || {};
+      return rules[moduleBase] || {};
+    },
+
+    getModuleTypeBase() {
+      const moduleType = (this.moduleType || '').toString();
+      if (moduleType.startsWith('MODULOS_')) {
+        return 'MODULOS';
+      }
+      return moduleType;
     },
 
     /**
@@ -772,6 +781,7 @@
      * Obtiene tipos disponibles según módulo
      */
     getAvailableTypes() {
+      const moduleBase = this.getModuleTypeBase();
       const types = {
         SUMMARY: [
           {
@@ -859,7 +869,7 @@
         ]
       };
 
-      return types[this.moduleType] || [];
+      return types[moduleBase] || [];
     },
 
     /**
@@ -943,6 +953,7 @@
      * Obtiene texto de ayuda contextual
      */
     getHelpText() {
+      const moduleBase = this.getModuleTypeBase();
       const helps = {
         SUMMARY: {
           1: 'En SUMMARY, las cuentas se organizan en Operaciones, que pertenecen a Secciones Secundarias, que están dentro de Principales.',
@@ -961,7 +972,7 @@
         }
       };
 
-      return helps[this.moduleType]?.[this.currentStep] || '';
+      return helps[moduleBase]?.[this.currentStep] || '';
     },
 
     /**


### PR DESCRIPTION
### Motivation
- Make the Layout Loader fully functional as a layout-by-year template editor showing the final table view (row order, accounts, descriptions, sections). 
- Allow the insertion wizard to work with module keys that map to `MODULOS_*` variants and ensure the wizard/route code addresses the canonical module base correctly. 
- Restrict "operaciones entre filas" (sum-of-multiple-sections) to the modules that support it (`SUMMARY`/`RESUMEN`) and prefer the most recent available year as base. 
- Restore a missing preview helper so preview-related controls (preview inputs, send-to-wizard) operate without errors.

### Description
- Updated `vistas/LayoutLoader.html` to expand the preview table columns (`Orden`, `Tipo`, `Cuenta`, `Descripción`, `Sección principal`, `Sección secundaria`) and implemented a structured `renderLayoutPreview` that outputs ordered section rows and account rows (respecting `orden`).
- Added `renderPreview` helper and preview wiring so preview controls call a defined function instead of causing `renderPreview is not defined` errors. 
- Added helper functions in `LayoutLoader.html` to map the UI module selection into the wizard `moduleType` (returning `MODULOS_<name>` for non-summary/resumen) and to gate sum-operations to `SUMMARY`/`RESUMEN` only. 
- Normalized `moduleType` handling in backend insertion routes (`src/routes/insercion.js`) by introducing `normalizarModuleType` and using a `moduleBase` variable so endpoints/validators accept `MODULOS_*` moduleType variants and apply the correct rules/format.
- Updated `vistas/js/insertion-wizard.js` to use a `getModuleTypeBase()` helper and to pick validation rules, available types and help text based on the canonical module base (`SUMMARY`, `RESUMEN`, `MODULOS`) so the wizard operates correctly for `MODULOS_*` types.
- Changed the year list handling in the Layout Loader to prefer the most recent year as the `anioOrigen` (sorts years descending and picks the first item).

### Testing
- Attempted a visual sanity check via Playwright to open `vistas/LayoutLoader.html` and capture a screenshot, but it failed with `ERR_FILE_NOT_FOUND` so no UI screenshot was produced. 
- Performed code searches and static runtime checks locally while patching (no failing JS syntax introduced); no automated unit/integration test suite was executed. 
- The changes were committed locally and basic runtime wiring was exercised via editing/searching commands in the repository (no automated CI run in this session). 
- Manual inspection of modified files confirms the new preview rendering, module-type normalization, and gating logic for sum operations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad37a1344832da3cd2ff5fe88cbc4)