### PR TITLE
Centralize toast management to avoid duplicate notices

### DIFF
--- a/vistas/js/export-utils.js
+++ b/vistas/js/export-utils.js
@@ -513,14 +513,17 @@
      * Mostrar toast de notificación
      */
     _showToast(message, type = "success") {
-      // Intentar usar toast global
+      const bgClass =
+        type === "error"
+          ? "text-bg-danger"
+          : type === "warning"
+          ? "text-bg-warning"
+          : "text-bg-success";
+      if (window.ToastManager?.show) {
+        window.ToastManager.show(message, bgClass);
+        return;
+      }
       if (typeof showToast === "function") {
-        const bgClass =
-          type === "error"
-            ? "text-bg-danger"
-            : type === "warning"
-            ? "text-bg-warning"
-            : "text-bg-success";
         showToast(message, bgClass);
         return;
       }

--- a/vistas/js/flujo-autorizacion.js
+++ b/vistas/js/flujo-autorizacion.js
@@ -649,8 +649,6 @@
         hayCambios: false,
       };
       this.tableElement = null;
-      this.toastInstance = null;
-      this.toastBody = null;
       this.buttons = {};
       this._contextRetry = 0;
       this._modalConfirmacionActiva = false;
@@ -929,23 +927,11 @@
     }
 
     _prepareToast() {
-      const toastElement = document.getElementById("actionToast");
-      const toastBody = document.getElementById("actionToastBody");
-      if (toastElement && toastBody && window.bootstrap?.Toast) {
-        const wrapper = toastElement.closest(".position-fixed, .toast-global");
-        if (wrapper) {
-          wrapper.classList.add("toast-global");
-          document.body.appendChild(wrapper);
-        } else if (toastElement.parentElement !== document.body) {
-          toastElement.classList.add("toast-global");
-          document.body.appendChild(toastElement);
-        }
-        this.toastInstance = window.bootstrap.Toast.getOrCreateInstance(
-          toastElement,
-          { delay: 3200 }
-        );
-        this.toastBody = toastBody;
+      if (window.ToastManager?.ensure) {
+        const ctx = window.ToastManager.ensure();
+        if (ctx?.instance) return;
       }
+      console.warn("Bootstrap no está cargado correctamente para toasts.");
     }
 
     _bindGlobalEvents() {
@@ -1817,18 +1803,8 @@
 
     _toast(mensaje, tipo = "success") {
       if (!mensaje) return;
-      if (this.toastInstance && this.toastBody) {
-        const clase =
-          tipo === "danger"
-            ? "text-bg-danger"
-            : tipo === "warning"
-            ? "text-bg-warning"
-            : "text-bg-success";
-        const toastEl = this.toastInstance._element;
-        if (toastEl)
-          toastEl.className = `toast align-items-center border-0 ${clase}`;
-        this.toastBody.textContent = mensaje;
-        this.toastInstance.show();
+      if (window.ToastManager?.show) {
+        window.ToastManager.show(mensaje, tipo);
         return;
       }
       console.info(`[Flujo AUT] ${mensaje}`);

--- a/vistas/js/planeacion-modulo-vista.js
+++ b/vistas/js/planeacion-modulo-vista.js
@@ -358,18 +358,11 @@
       workflowBadge: document.getElementById("workflowBadge"),
       workflowMeta: document.getElementById("workflowMeta"),
       workflowHistory: document.getElementById("workflowHistory"),
-      toastElement: document.getElementById("actionToast"),
-      toastBody: document.getElementById("actionToastBody"),
       yearLabel: document.getElementById("yearLabel"),
       yearColumn: document.getElementById("yearColumn"),
       empresaLabel: document.getElementById("empresaLabel"),
       yearSelect: obtenerSelectEjercicio(),
     };
-
-    const toastInstance = window.bootstrap?.Toast.getOrCreateInstance(
-      elementos.toastElement,
-      { delay: 3000 }
-    );
 
     const EVENTO_CONTEXTO = "planeacion:contexto-actualizado";
     const workflowControlExterno = true; // workflow lo maneja flujo-autorizacion.js
@@ -518,14 +511,11 @@
     actualizarEncabezadosMes();
 
     const showToast = (mensaje, clase = "text-bg-success") => {
-      if (!elementos.toastElement || !toastInstance) {
+      if (window.ToastManager?.show) {
+        window.ToastManager.show(mensaje, clase);
         return;
       }
-      elementos.toastElement.className = `toast align-items-center border-0 ${clase}`;
-      if (elementos.toastBody) {
-        elementos.toastBody.textContent = mensaje;
-      }
-      toastInstance.show();
+      console.warn("[PlaneacionVista] Toast no disponible", mensaje);
     };
 
     const actualizarEncabezadoEmpresa = () => {

--- a/vistas/js/presupuesto-vista.js
+++ b/vistas/js/presupuesto-vista.js
@@ -146,8 +146,6 @@
       authorizeBudgetBtn: document.getElementById('authorizeBudgetBtn'),
       approveBudgetBtn: document.getElementById('approveBudgetBtn'),
       budgetFileInput: document.getElementById('budgetFileInput'),
-      toastElement: document.getElementById('actionToast'),
-      toastBody: document.getElementById('actionToastBody'),
       presupuestoStatus: document.getElementById('presupuestoStatus'),
       yearLabel: document.getElementById('yearLabel'),
       yearColumn: document.getElementById('yearColumn'),
@@ -158,8 +156,6 @@
       moduleTitle: document.getElementById('moduleTitle'),
       moduleDescription: document.getElementById('moduleDescription')
     };
-
-    const toastInstance = window.bootstrap?.Toast.getOrCreateInstance(elementos.toastElement, { delay: 3000 });
 
     if (elementos.yearLabel) elementos.yearLabel.textContent = anio;
     if (elementos.yearColumn) elementos.yearColumn.textContent = anio;
@@ -179,10 +175,11 @@
     let moduloReadyDispatched = false;
 
     const showToast = (mensaje, clase = 'text-bg-success') => {
-      if (!elementos.toastElement || !toastInstance || !elementos.toastBody) return;
-      elementos.toastElement.className = `toast align-items-center ${clase} border-0`;
-      elementos.toastBody.textContent = mensaje;
-      toastInstance.show();
+      if (window.ToastManager?.show) {
+        window.ToastManager.show(mensaje, clase);
+        return;
+      }
+      console.warn('[PresupuestoVista] Toast no disponible', mensaje);
     };
 
     const mostrarEstado = (mensaje, tipo = 'info') => {

--- a/vistas/js/resumen-view.js
+++ b/vistas/js/resumen-view.js
@@ -2298,12 +2298,6 @@
   const btnRevisar = document.getElementById("btnMarcarRevisado");
   const btnAutorizar = document.getElementById("btnAutorizar");
   const btnGuardarCoi = document.getElementById("saveBudgetBtn");
-  const toastEl = document.getElementById("actionToast");
-  const toastBody = document.getElementById("actionToastBody");
-  const toastInst = toastEl
-    ? window.bootstrap?.Toast.getOrCreateInstance(toastEl, { delay: 3000 })
-    : null;
-
   // Normalizar estado del backend (MAYÚSCULAS) a formato frontend (minúsculas-guiones)
   const normalizarEstado = (estado) => {
     if (!estado) return "sin-cargar";
@@ -2332,10 +2326,11 @@
   };
 
   const showToast = (msg, variant = "text-bg-success") => {
-    if (!toastEl || !toastInst) return;
-    toastEl.className = `toast align-items-center border-0 ${variant}`;
-    if (toastBody) toastBody.textContent = msg;
-    toastInst.show();
+    if (window.ToastManager?.show) {
+      window.ToastManager.show(msg, variant);
+      return;
+    }
+    console.warn("[ResumenView] Toast no disponible", msg);
   };
 
   const workflowEstado = {

--- a/vistas/js/sesion.js
+++ b/vistas/js/sesion.js
@@ -299,6 +299,92 @@
     redirigir(redirectTo, usarTop);
   };
 
+  // Gestor centralizado de toasts para evitar duplicados y mantener
+  // un solo punto de control sobre los avisos visuales.
+  const ToastManager = (() => {
+    const TOAST_ID = "actionToast";
+    const BODY_ID = "actionToastBody";
+    const DEDUP_MS = 600;
+    const opcionesPorDefecto = { delay: 3200 };
+
+    let cache = null;
+    let ultimoMensaje = "";
+    let ultimaClase = "";
+    let ultimaEmision = 0;
+
+    const normalizarClase = (variant = "success") => {
+      const raw = variant.toString().trim();
+      if (!raw) return "text-bg-success";
+      if (raw.includes("bg-")) return raw;
+      switch (raw.toLowerCase()) {
+        case "error":
+        case "danger":
+          return "text-bg-danger";
+        case "warn":
+        case "warning":
+          return "text-bg-warning";
+        case "info":
+          return "text-bg-info";
+        default:
+          return "text-bg-success";
+      }
+    };
+
+    const resolverElementos = () => {
+      const toastEl = document.getElementById(TOAST_ID);
+      const toastBody = document.getElementById(BODY_ID);
+      if (!toastEl || !toastBody) return null;
+
+      const wrapper = toastEl.closest(".position-fixed, .toast-global") || toastEl;
+      if (wrapper.parentElement && wrapper.parentElement !== document.body) {
+        wrapper.classList.add("toast-global");
+        document.body.appendChild(wrapper);
+      }
+
+      const instance =
+        typeof window.bootstrap?.Toast?.getOrCreateInstance === "function"
+          ? window.bootstrap.Toast.getOrCreateInstance(toastEl, opcionesPorDefecto)
+          : null;
+
+      return { element: toastEl, body: toastBody, instance };
+    };
+
+    const obtenerToast = () => {
+      if (!cache || !document.body.contains(cache.element)) {
+        cache = resolverElementos();
+      }
+      return cache;
+    };
+
+    const mostrar = (mensaje, variante = "success") => {
+      const toast = obtenerToast();
+      if (!toast?.instance || !toast.body) {
+        console.info("[ToastManager] Toast no disponible", mensaje);
+        return;
+      }
+
+      const clase = normalizarClase(variante);
+      const ahora = Date.now();
+      if (mensaje === ultimoMensaje && clase === ultimaClase && ahora - ultimaEmision < DEDUP_MS) {
+        return;
+      }
+
+      ultimoMensaje = mensaje;
+      ultimaClase = clase;
+      ultimaEmision = ahora;
+
+      toast.element.className = `toast align-items-center border-0 ${clase}`;
+      toast.body.textContent = mensaje || "Aviso";
+      toast.instance.show();
+    };
+
+    const ensure = () => obtenerToast();
+
+    return { show: mostrar, ensure };
+  })();
+
+  window.ToastManager = ToastManager;
+
   window.Sesion = {
     obtener,
     guardar,

--- a/vistas/js/summary-view.js
+++ b/vistas/js/summary-view.js
@@ -1073,10 +1073,7 @@
   const btnRevisar = document.getElementById('btnMarcarRevisado');
   const btnAutorizar = document.getElementById('btnAutorizar');
   const btnGuardarCoi = document.getElementById('saveBudgetBtn');
-  const toastEl = document.getElementById('actionToast');
-  const toastBody = document.getElementById('actionToastBody');
-  const toastInst = toastEl ? window.bootstrap?.Toast.getOrCreateInstance(toastEl, { delay: 3000 }) : null;
-  
+
   // Normalizar estado del backend (MAYÚSCULAS) a formato frontend (minúsculas-guiones)
   const normalizarEstado = (estado) => {
     if (!estado) return 'sin-cargar';
@@ -1105,10 +1102,11 @@
   };
 
   const showToast = (msg, variant = 'text-bg-success') => {
-    if (!toastEl || !toastInst) return;
-    toastEl.className = `toast align-items-center border-0 ${variant}`;
-    if (toastBody) toastBody.textContent = msg;
-    toastInst.show();
+    if (window.ToastManager?.show) {
+      window.ToastManager.show(msg, variant);
+      return;
+    }
+    console.warn('[SummaryView] Toast no disponible', msg);
   };
 
   const workflowEstado = {


### PR DESCRIPTION
## Summary
- add a shared ToastManager in `sesion.js` to control the global action toast, deduplicate repeated messages, and keep the toast element anchored in one place
- update the planeación, resumen/summary, presupuesto, flujo de autorización, and export utilities to rely on the centralized toast helper instead of instantiating their own toasts
- simplify workflow notifications so all modules reuse the same toast pipeline, reducing redundant code

## Testing
- npm test --silent *(fails: better-sqlite3 binary built for a different Node version; requires rebuild in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e4846c74832da6e4f188a83195a8)