### PR TITLE
Improve template preview ordering

### DIFF
--- a/vistas/js/layout-controls.js
+++ b/vistas/js/layout-controls.js
@@ -7,6 +7,19 @@
 (() => {
   "use strict";
 
+  const ROW_LABEL_FIELDS =
+    window.ROW_LABEL_FIELDS || [
+      "sum-row",
+      "sum-row-sumavarios",
+      "sum-row-sumavarios-consolidado",
+      "sum-row-operativo",
+      "sum-row-operativo-consolidado",
+      "result-row",
+      "net-row",
+      "net-row-adicional",
+      "result-net-row",
+    ];
+
   window.LayoutControls = {
     /**
      * Agregar controles de visibilidad a una fila de cuenta
@@ -269,8 +282,10 @@
             <tbody>
       `;
 
-      // Organizar cuentas por sección
+      // Organizar cuentas por sección y preparar operaciones ordenadas
       const sections = this._groupBySections(layoutData.cuentas || []);
+      const orderedOps = this._sortOperations(layoutData.operaciones || []);
+      const renderedOps = new Set();
 
       sections.forEach(({ principal, subsections }) => {
         // Fila de sección principal
@@ -298,64 +313,80 @@
             `;
           }
 
-          // Cuentas
-          cuentas.forEach((cuenta) => {
-            const isVisible = cuenta.visible !== false;
-            const hideClass =
-              !isVisible && !showHiddenRows ? "hidden-preview-row" : "";
-            const dimClass = !isVisible ? "text-muted" : "";
+          const matchingOps = this._findInlineOperations(
+            orderedOps,
+            principal,
+            secundaria || principal
+          );
 
-            const sampleValues = showSampleData
-              ? this._generateSampleData(selectedMonths.length)
-              : Array(selectedMonths.length).fill(0);
+          const combinedRows = [
+            ...cuentas.map((cuenta, idx) => ({
+              type: "account",
+              order: cuenta.orden_presentacion ?? cuenta.orden ?? idx + 1,
+              data: cuenta,
+            })),
+            ...matchingOps.map((op, idx) => ({
+              type: "operation",
+              order: this._getOperationOrder(op, idx),
+              data: op,
+            })),
+          ].sort((a, b) => a.order - b.order);
 
-            const total = sampleValues.reduce((a, b) => a + b, 0);
+          combinedRows.forEach((row) => {
+            if (row.type === "account") {
+              const cuenta = row.data;
+              const isVisible = cuenta.visible !== false;
+              const hideClass =
+                !isVisible && !showHiddenRows ? "hidden-preview-row" : "";
+              const dimClass = !isVisible ? "text-muted" : "";
 
-            html += `
-              <tr class="${hideClass} ${dimClass}">
-                <td class="ps-5 small">${
-                  isVisible ? "" : '🔒 '
-                }${this._escapeHtml(cuenta.CUENTA || "")}</td>
-                <td class="ps-5">${this._escapeHtml(
-                  cuenta.NOMBRE || cuenta.nombre || ""
-                )}</td>
-                ${sampleValues
-                  .map((v) => `<td class="text-end">${this._formatMoney(v)}</td>`)
-                  .join("")}
-                <td class="text-end fw-bold">${this._formatMoney(total)}</td>
-              </tr>
-            `;
+              const sampleValues = showSampleData
+                ? this._generateSampleData(selectedMonths.length)
+                : Array(selectedMonths.length).fill(0);
+
+              const total = sampleValues.reduce((a, b) => a + b, 0);
+
+              html += `
+                <tr class="${hideClass} ${dimClass}">
+                  <td class="ps-5 small">${
+                    isVisible ? "" : '🔒 '
+                  }${this._escapeHtml(cuenta.CUENTA || "")}</td>
+                  <td class="ps-5">${this._escapeHtml(
+                    cuenta.NOMBRE || cuenta.nombre || ""
+                  )}</td>
+                  ${sampleValues
+                    .map((v) => `<td class="text-end">${this._formatMoney(v)}</td>`)
+                    .join("")}
+                  <td class="text-end fw-bold">${this._formatMoney(total)}</td>
+                </tr>
+              `;
+            } else {
+              const op = row.data;
+              renderedOps.add(op.Clase || op.SECCION || op.id);
+              html += this._renderOperationRow(
+                op,
+                selectedMonths.length,
+                showSampleData,
+                showHiddenRows,
+                true
+              );
+            }
           });
         });
       });
 
-      // Operaciones
-      (layoutData.operaciones || []).forEach((op) => {
-        const isVisible = op.visible !== false;
-        const hideClass =
-          !isVisible && !showHiddenRows ? "hidden-preview-row" : "";
-
-        const sampleValues = showSampleData
-          ? this._generateSampleData(selectedMonths.length, true)
-          : Array(selectedMonths.length).fill(0);
-
-        const total = sampleValues.reduce((a, b) => a + b, 0);
-
-        html += `
-          <tr class="operation-row ${hideClass}">
-            <td colspan="2" class="fw-bold">
-              ${isVisible ? "" : "🔒 "}
-              <i class="bi bi-calculator me-2"></i>${this._escapeHtml(
-                op.Clase || ""
-              )}
-            </td>
-            ${sampleValues
-              .map((v) => `<td class="text-end">${this._formatMoney(v)}</td>`)
-              .join("")}
-            <td class="text-end fw-bold">${this._formatMoney(total)}</td>
-          </tr>
-        `;
-      });
+      // Operaciones restantes (sección/global) en orden de aparición
+      orderedOps
+        .filter((op) => !renderedOps.has(op.Clase || op.SECCION || op.id))
+        .forEach((op) => {
+          html += this._renderOperationRow(
+            op,
+            selectedMonths.length,
+            showSampleData,
+            showHiddenRows,
+            false
+          );
+        });
 
       html += `
             </tbody>
@@ -415,6 +446,155 @@
       });
 
       return result;
+    },
+
+    _findInlineOperations(operaciones, principal, subseccion) {
+      const principalLower = (principal || "").toLowerCase();
+      const subsectionLower = (subseccion || "").toLowerCase();
+      const isIncomeSection = principalLower.includes("income");
+      const isExpenseSection = principalLower.includes("expense");
+
+      return (operaciones || []).filter((op) => {
+        const clase = (op.Clase || "").toLowerCase();
+        const isIncomeOp = clase.includes("income");
+        const isExpenseOp = clase.includes("expense");
+
+        if (isIncomeSection && isExpenseOp) return false;
+        if (isExpenseSection && isIncomeOp) return false;
+
+        if (
+          op.parentSubsection &&
+          op.parentSubsection.toLowerCase() === subsectionLower
+        ) {
+          if (op.parentSection) {
+            return op.parentSection.toLowerCase() === principalLower;
+          }
+          return true;
+        }
+
+        const claseNorm = clase.replace(/[-_\s]/g, "");
+        const subsectionNorm = subsectionLower.replace(/[-_\s]/g, "");
+
+        if (claseNorm.includes(subsectionNorm) || subsectionNorm.includes(claseNorm)) {
+          if (!op.secciones || op.secciones.length <= 1) {
+            return true;
+          }
+        }
+
+        if (Array.isArray(op.secciones)) {
+          return op.secciones.some(
+            (sec) => sec && sec.toLowerCase() === subseccion.toLowerCase()
+          );
+        }
+
+        return false;
+      });
+    },
+
+    _getOperationOrder(op, fallback = 0) {
+      const raw = op?.orden_presentacion ?? op?.orden ?? op?.Orden ?? op?.index;
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    },
+
+    _sortOperations(list = []) {
+      return [...(list || [])]
+        .map((op, idx) => ({ op, idx }))
+        .sort(
+          (a, b) =>
+            this._getOperationOrder(a.op, a.idx) -
+            this._getOperationOrder(b.op, b.idx)
+        )
+        .map((item) => item.op);
+    },
+
+    _renderOperationRow(op, monthCount, showSampleData, showHiddenRows, isInline) {
+      const isVisible = op.visible !== false;
+      const hideClass = !isVisible && !showHiddenRows ? "hidden-preview-row" : "";
+      const sampleValues = showSampleData
+        ? this._generateSampleData(monthCount, true)
+        : Array(monthCount).fill(0);
+      const total = sampleValues.reduce((a, b) => a + b, 0);
+
+      const label = this._getOperationLabel(op);
+      const badges = this._buildOperationBadges(op);
+      const formula = this._buildFormulaSummary(op);
+
+      return `
+        <tr class="operation-row ${hideClass}">
+          <td colspan="2" class="fw-bold ${isInline ? "ps-5" : ""}">
+            ${isVisible ? "" : "🔒 "}
+            <i class="bi bi-calculator me-2"></i>${label}
+            ${badges}
+            <div class="small text-muted fw-normal">${formula}</div>
+          </td>
+          ${sampleValues
+            .map((v) => `<td class="text-end">${this._formatMoney(v)}</td>`)
+            .join("")}
+          <td class="text-end fw-bold">${this._formatMoney(total)}</td>
+        </tr>
+      `;
+    },
+
+    _getOperationLabel(op) {
+      for (const field of ROW_LABEL_FIELDS) {
+        if (op[field]) {
+          return this._escapeHtml(op[field]);
+        }
+      }
+      return this._escapeHtml(op.Clase || op.SECCION || "Operación");
+    },
+
+    _buildOperationBadges(op) {
+      const badges = [];
+      ROW_LABEL_FIELDS.forEach((field) => {
+        if (op[field]) {
+          const color = field.includes("net")
+            ? "danger"
+            : field.includes("operativo")
+              ? "primary"
+              : field.includes("consolidado")
+                ? "info"
+                : field.includes("sumavarios")
+                  ? "success"
+                  : "secondary";
+          badges.push(
+            `<span class="badge bg-${color} ms-1 text-uppercase">${field}</span>`
+          );
+        }
+      });
+
+      if (!badges.length && op.tipo) {
+        badges.push(
+          `<span class="badge bg-warning text-dark ms-1">${this._escapeHtml(
+            op.tipo
+          )}</span>`
+        );
+      }
+
+      return badges.join("");
+    },
+
+    _buildFormulaSummary(op) {
+      if (Array.isArray(op.formula_terms) && op.formula_terms.length) {
+        return op.formula_terms
+          .map((term, idx) => {
+            const prefix =
+              idx === 0
+                ? term.operator === "-"
+                  ? "-"
+                  : ""
+                : ` ${term.operator} `;
+            return `${prefix}${term.value || term.constValue || ""}`;
+          })
+          .join("");
+      }
+
+      if (Array.isArray(op.secciones) && op.secciones.length) {
+        return op.secciones.join(" + ");
+      }
+
+      return op.SECCION || op.Clase || "";
     },
 
     /**

--- a/vistas/js/plantillas.js
+++ b/vistas/js/plantillas.js
@@ -15,6 +15,21 @@
       ? "http://localhost:3005/api/layouts-config"
       : `${window.location.origin}/api/layouts-config`;
 
+  // Campos de etiquetas especiales generadas por las tablas operativas
+  const ROW_LABEL_FIELDS = [
+    "sum-row",
+    "sum-row-sumavarios",
+    "sum-row-sumavarios-consolidado",
+    "sum-row-operativo",
+    "sum-row-operativo-consolidado",
+    "result-row",
+    "net-row",
+    "net-row-adicional",
+    "result-net-row",
+  ];
+  // Exponer para utilidades compartidas (vista previa realista)
+  window.ROW_LABEL_FIELDS = ROW_LABEL_FIELDS;
+
   // ==========================================
   // STATE
   // ==========================================
@@ -741,6 +756,12 @@
         color: "info",
       },
       {
+        field: "sum-row-operativo-consolidado",
+        type: "operating-consolidated",
+        icon: "bi-graph-up",
+        color: "info",
+      },
+      {
         field: "result-row",
         type: "result",
         icon: "bi-calculator-fill",
@@ -750,6 +771,12 @@
         field: "net-row",
         type: "net-result",
         icon: "bi-cash-stack",
+        color: "danger",
+      },
+      {
+        field: "net-row-adicional",
+        type: "net-additional",
+        icon: "bi-cash-coin",
         color: "danger",
       },
       {
@@ -2336,15 +2363,7 @@
     else if (op.signos && Object.keys(op.signos).length > 0) {
       let i = 0;
       // Only process seccion_n fields, not row-type fields like sum-row, sum-row-sumavarios, etc.
-      const rowTypeFields = [
-        "sum-row",
-        "sum-row-sumavarios",
-        "sum-row-sumavarios-consolidado",
-        "sum-row-operativo",
-        "result-row",
-        "net-row",
-        "result-net-row",
-      ];
+      const rowTypeFields = [...ROW_LABEL_FIELDS];
       Object.entries(op.signos).forEach(([clave, signo]) => {
         // Skip if this is a row-type field, not a formula section reference
         if (rowTypeFields.includes(clave) || !clave.startsWith("seccion_")) {
@@ -2388,15 +2407,7 @@
     }
 
     // Also add references from operation types (sum-row, etc) that may reference sections
-    const opTypes = [
-      "sum-row",
-      "sum-row-sumavarios",
-      "sum-row-sumavarios-consolidado",
-      "sum-row-operativo",
-      "result-row",
-      "net-row",
-      "result-net-row",
-    ];
+    const opTypes = [...ROW_LABEL_FIELDS];
 
     // If we still have no terms, create from SECCION or operation types
     if (formulaTerms.length === 0) {
@@ -2418,6 +2429,85 @@
         });
       }
     }
+
+    const rowLabelMeta = [
+      {
+        field: "sum-row",
+        label: "Suma de subsección",
+        badge: "Suma",
+        color: "secondary",
+        icon: "bi-plus-square",
+      },
+      {
+        field: "sum-row-sumavarios",
+        label: "Suma variaciones",
+        badge: "Suma Varios",
+        color: "success",
+        icon: "bi-collection",
+      },
+      {
+        field: "sum-row-sumavarios-consolidado",
+        label: "Suma variaciones consolidado",
+        badge: "Consolidado",
+        color: "info",
+        icon: "bi-collection-fill",
+      },
+      {
+        field: "sum-row-operativo",
+        label: "Resultado operativo",
+        badge: "Operativo",
+        color: "primary",
+        icon: "bi-graph-up-arrow",
+      },
+      {
+        field: "sum-row-operativo-consolidado",
+        label: "Resultado operativo consolidado",
+        badge: "Operativo Cons.",
+        color: "primary",
+        icon: "bi-graph-up",
+      },
+      {
+        field: "result-row",
+        label: "Resultado final",
+        badge: "Resultado",
+        color: "warning",
+        icon: "bi-calculator-fill",
+      },
+      {
+        field: "net-row",
+        label: "Resultado neto",
+        badge: "Neto",
+        color: "danger",
+        icon: "bi-cash-stack",
+      },
+      {
+        field: "net-row-adicional",
+        label: "Resultado neto adicional",
+        badge: "Neto Adic.",
+        color: "danger",
+        icon: "bi-cash-coin",
+      },
+      {
+        field: "result-net-row",
+        label: "Resultado neto consolidado",
+        badge: "Neto Cons.",
+        color: "danger",
+        icon: "bi-bank",
+      },
+    ];
+
+    const rowLabelPreview = rowLabelMeta
+      .filter(({ field }) => op[field])
+      .map(
+        ({ field, label, badge, color, icon }) => `
+        <div class="row-preview mb-2">
+          <i class="bi ${icon} me-2 text-${color}"></i>
+          <strong class="text-${color}">${escapeHtml(op[field])}</strong>
+          <span class="badge bg-${color} ms-2">${badge}</span>
+          <div class="small text-muted">${escapeHtml(label)}</div>
+        </div>`
+      )
+      .join("");
 
     dom.formEditar.innerHTML = `
       <div class="mb-3">
@@ -2453,47 +2543,13 @@
       <div class="module-preview mt-3">
         <label class="form-label">Vista Previa en Módulos:</label>
         <div class="bg-info bg-opacity-10 p-2 rounded border">
-          <div class="row-preview mb-2">
-            <strong class="text-primary">${escapeHtml(
-              op["sum-row"] || op.Clase
-            )}</strong>
-            <span class="badge bg-secondary ms-2">Fila de Suma</span>
-          </div>
           ${
-            op["sum-row-sumavarios"]
-              ? `
-          <div class="row-preview mb-1">
-            <i class="bi bi-arrow-return-right me-2"></i>
-            <span class="text-success">${escapeHtml(
-              op["sum-row-sumavarios"]
-            )}</span>
-            <span class="badge bg-success ms-2">Consolidado</span>
-          </div>`
-              : ""
-          }
-          ${
-            op["sum-row-sumavarios-consolidado"]
-              ? `
-          <div class="row-preview mb-1">
-            <i class="bi bi-arrow-return-right me-2"></i>
-            <span class="text-info">${escapeHtml(
-              op["sum-row-sumavarios-consolidado"]
-            )}</span>
-            <span class="badge bg-info ms-2">Consolidado Total</span>
-          </div>`
-              : ""
-          }
-          ${
-            op["result-row"] || op["net-row"]
-              ? `
-          <div class="row-preview">
-            <i class="bi bi-calculator me-2"></i>
-            <span class="text-warning">${escapeHtml(
-              op["result-row"] || op["net-row"] || ""
-            )}</span>
-            <span class="badge bg-warning text-dark ms-2">Resultado</span>
-          </div>`
-              : ""
+            rowLabelPreview ||
+            `<div class="row-preview mb-2">
+              <i class="bi bi-calculator text-primary me-2"></i>
+              <strong class="text-primary">${escapeHtml(op.Clase)}</strong>
+              <span class="badge bg-secondary ms-2">Operación</span>
+            </div>`
           }
           <div class="mt-2 small text-muted">
             <i class="bi bi-info-circle me-1"></i>
@@ -3446,16 +3502,6 @@
     });
 
     // Etiquetas generadas por filas especiales (sum-row, net-row, etc.)
-    const rowLabelFields = [
-      "sum-row",
-      "sum-row-sumavarios",
-      "sum-row-sumavarios-consolidado",
-      "sum-row-operativo",
-      "result-row",
-      "net-row",
-      "result-net-row",
-    ];
-
     state.operaciones.forEach((op) => {
       // Poblar secciones aún cuando no existan cuentas cargadas
       [op.SECCION, op.parentSection, op.parentSubsection]
@@ -3463,7 +3509,7 @@
         .forEach((sec) => sections.add(sec));
 
       // Poblar operaciones con etiquetas de filas generadas
-      rowLabelFields.forEach((field) => {
+      ROW_LABEL_FIELDS.forEach((field) => {
         const label = op[field];
         if (label && label.trim()) {
           operations.add(label.trim());


### PR DESCRIPTION
## Summary
- expose the operational row label catalog globally and show the full set in the operation editor preview
- render realistic template previews interleaving accounts with matching operations and ordered badges for every row label type
- honor presentation ordering when listing inline, section-level, and consolidated operations in the preview output

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e5a877d0832d99953a16dd76928e)