### PR TITLE
Defer plantillas bootstrap to avoid early initialization errors

### DIFF
--- a/vistas/js/plantillas.js
+++ b/vistas/js/plantillas.js
@@ -103,8 +103,6 @@
     });
   };
 
-  bootstrapEarly();
-
   function cacheDOMElements() {
     // Selectors
     dom.moduloSelect = document.getElementById("moduloSelect");
@@ -9508,6 +9506,8 @@
         saveContextToURL();
       };
     }
+
+    bootstrapEarly();
 
     // Cargar contexto al iniciar
     loadContextFromURL();


### PR DESCRIPTION
### Motivation
- Avoid ReferenceError/temporal dead zone initialization failures that prevented the years/capítulos selects and helper functions from being available by deferring the early bootstrap.

### Description
- Move the call to `bootstrapEarly()` later in `vistas/js/plantillas.js` (after helper/context wrappers are defined) so helpers like `expandAll`, `setStatus`, `showToast` and `fetchWithAuth` are available before the bootstrap runs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724eeeba28832d9f412e81e1a13055)