### PR TITLE
Retry plantillas init until required DOM selects are present

### DIFF
--- a/vistas/js/plantillas.js
+++ b/vistas/js/plantillas.js
@@ -64,9 +64,13 @@
   let initDone = false;
   function init() {
     if (initDone) return;
+    cacheDOMElements();
+    if (!dom.moduloSelect || !dom.anioSelect || !dom.capituloSelect) {
+      setTimeout(init, 80);
+      return;
+    }
     initDone = true;
     try {
-      cacheDOMElements();
       bindEventListeners();
     } catch (error) {
       console.error("Error inicializando el gestor de plantillas:", error);
@@ -102,8 +106,6 @@
       setTimeout(ensureContext, 1200);
     });
   };
-
-  bootstrapEarly();
 
   function cacheDOMElements() {
     // Selectors
@@ -9508,6 +9510,8 @@
         saveContextToURL();
       };
     }
+
+    bootstrapEarly();
 
     // Cargar contexto al iniciar
     loadContextFromURL();


### PR DESCRIPTION
### Motivation
- Evitar que la inicialización prematura deje la UI en "Cargando..." por falta de los selects (`moduloSelect`, `anioSelect`, `capituloSelect`).
- Asegurar que el gestor de plantillas solo enlace handlers y dispare cargas iniciales cuando el DOM necesario exista.

### Description
- Cambiada la función `init()` para llamar a `cacheDOMElements()` primero y reintentar la inicialización con `setTimeout(init, 80)` hasta que los selects requeridos existan. 
- Se mueve la marca `initDone` para ejecutarse solo después de que los elementos DOM estén presentes y se elimina la llamada duplicada a `cacheDOMElements()`.
- `bindEventListeners()`, `loadInitialData()` y `checkAuthState()` se mantienen pero ahora solo se ejecutan una vez que hay DOM válido.
- La invocación temprana de `bootstrapEarly()` fue reubicada para ejecutarse después de envolver el contexto y asegurar que helpers/contextos estén disponibles.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724eeeba28832d9f412e81e1a13055)