### PR TITLE
Agregar vista 'Gestor', seed de configuración de gráficas y persistencia de fórmulas de operaciones

### DIFF
--- a/src/config/graficasDefaults.js
+++ b/src/config/graficasDefaults.js
@@ -1,0 +1,268 @@
+const DEFAULT_GRAFICAS_CONFIG = {
+  version: 2,
+  series: [
+    {
+      key: "actualYTD",
+      label: "Real acumulado",
+      color: "#0d47a1",
+      enabled: true,
+    },
+    {
+      key: "planYTD",
+      label: "Ppto. acumulado",
+      color: "#60a5fa",
+      enabled: true,
+    },
+    {
+      key: "prevYTD",
+      label: "Real acumulado AA",
+      color: "#94a3b8",
+      enabled: true,
+    },
+  ],
+  charts: {
+    operating: {
+      enabled: true,
+      title: "Resultado Operativo por Capitulo",
+      subtitle: "Real Acum / Ppto. Acum / Real Acum AA",
+      chartType: "inherit",
+    },
+    net: {
+      enabled: true,
+      title: "Resumen Neto por Capitulo",
+      subtitle: "Real Acum / Ppto. Acum / Real Acum AA",
+      chartType: "inherit",
+    },
+    consolidated: {
+      enabled: true,
+      title: "Consolidados Operativos vs Netos",
+      subtitle: "Real Acum / Ppto. Acum / Real Acum AA",
+      chartType: "inherit",
+    },
+  },
+  consolidatedSeries: {
+    operating: {
+      label: "CONSOLIDATED OPERATING RESULTS",
+      color: "#0d47a1",
+    },
+    net: {
+      label: "CONSOLIDATED NET RESULTS",
+      color: "#94a3b8",
+    },
+  },
+  legend: {
+    show: true,
+    position: "bottom",
+  },
+  chart: {
+    type: "bar",
+    stacked: false,
+  },
+  ingreso: {
+    enabled: true,
+    title: "Ingreso por capitulo",
+    subtitle: "Real acumulado por mes",
+    chartType: "inherit",
+    series: {
+      mex: { label: "CDMX INCOME", color: "#0d47a1", enabled: true },
+      gdl: { label: "GUADALAJARA INCOME", color: "#60a5fa", enabled: true },
+      mty: { label: "MONTERREY INCOME", color: "#22c55e", enabled: true },
+      nw: { label: "NORTHWEST INCOME", color: "#f59e0b", enabled: true },
+    },
+  },
+  ingresoNacional: {
+    enabled: true,
+    title: "Ingreso nacional",
+    subtitle: "Real acumulado por mes",
+    chartType: "inherit",
+    series: {
+      committees: { label: "Committees", color: "#0d47a1", enabled: true },
+      membership: { label: "Membership", color: "#60a5fa", enabled: true },
+      events: { label: "Events", color: "#22c55e", enabled: true },
+      services: { label: "Services to Members", color: "#f59e0b", enabled: true },
+      tic: { label: "T&IC", color: "#a855f7", enabled: true },
+    },
+  },
+  sources: {
+    summary: {
+      cdmx: {
+        operating: [
+          {
+            label: "Ciudad de Mexico",
+            variants: ["OPERATING RESULTS MEXICO"],
+          },
+          {
+            label: "Guadalajara",
+            variants: ["OPERATING RESULTS GUADALAJARA", "GDL OPERATING RESULTS"],
+          },
+          {
+            label: "Noreste",
+            variants: ["OPERATING RESULTS MONTERREY", "MTY OPERATING RESULTS"],
+          },
+          {
+            label: "Noroeste",
+            variants: [
+              "OPERATING RESULTS NORTHWEST",
+              "OPERATING RESULTS NO",
+              "NO OPERATING RESULTS",
+            ],
+          },
+        ],
+        net: [
+          { label: "Ciudad de Mexico", variants: ["NET RESULTS MEXICO"] },
+          {
+            label: "Guadalajara",
+            variants: ["NET RESULTS GUADALAJARA", "GDL NET RESULTS"],
+          },
+          {
+            label: "Noreste",
+            variants: ["NET RESULTS MONTERREY", "MTY NET RESULTS"],
+          },
+          {
+            label: "Noroeste",
+            variants: ["NET RESULTS NORTHWEST", "NET RESULTS NO", "NO NET RESULTS"],
+          },
+        ],
+      },
+      gdl: {
+        operating: [
+          {
+            label: "{capitulo}",
+            variants: [
+              "GDL OPERATING RESULTS",
+              "OPERATING RESULTS GUADALAJARA",
+              "OPERATING RESULTS",
+            ],
+          },
+        ],
+        net: [
+          {
+            label: "{capitulo}",
+            variants: ["NET RESULTS", "GDL NET RESULTS", "NET RESULTS GUADALAJARA"],
+          },
+        ],
+      },
+      ne: {
+        operating: [
+          {
+            label: "{capitulo}",
+            variants: [
+              "NE OPERATING RESULTS",
+              "OPERATING RESULTS MONTERREY",
+              "OPERATING RESULTS",
+            ],
+          },
+        ],
+        net: [
+          {
+            label: "{capitulo}",
+            variants: ["NET RESULTS", "NE NET RESULTS", "NET RESULTS MONTERREY"],
+          },
+        ],
+      },
+      no: {
+        operating: [
+          {
+            label: "{capitulo}",
+            variants: [
+              "NO OPERATING RESULTS",
+              "OPERATING RESULTS NORTHWEST",
+              "OPERATING RESULTS",
+            ],
+          },
+        ],
+        net: [
+          {
+            label: "{capitulo}",
+            variants: ["NET RESULTS", "NO NET RESULTS", "NET RESULTS NORTHWEST"],
+          },
+        ],
+      },
+      generic: {
+        operating: [
+          {
+            label: "{capitulo}",
+            variants: ["OPERATING RESULTS", "RESULTADO OPERATIVO"],
+          },
+        ],
+        net: [
+          { label: "{capitulo}", variants: ["NET RESULTS", "RESULTADO NETO"] },
+        ],
+      },
+    },
+    consolidated: {
+      operating: {
+        label: "CONSOLIDATED OPERATING RESULTS",
+        variants: [
+          "CONSOLIDATED OPERATING RESULTS",
+          "CONSOLIDATED OPERATING RESULT",
+        ],
+      },
+      net: {
+        label: "CONSOLIDATED NET RESULTS",
+        variants: ["CONSOLIDATED NET RESULTS", "CONSOLIDATED NET RESULT"],
+      },
+    },
+    ingreso: {
+      mex: ["CDMX INCOME", "MEXICO INCOME", "CIUDAD DE MEXICO INCOME"],
+      gdl: ["GUADALAJARA INCOME", "GDL INCOME", "GUADALAJARA INCOMEA"],
+      mty: ["MONTERREY INCOME", "MTY INCOME"],
+      nw: ["NORTHWEST INCOME", "NW INCOME", "NOROESTE INCOME", "NO INCOME"],
+    },
+    ingresoNacional: {
+      committees: ["COMMITTEES", "COMITES", "COMITÉS", "COMMITTEES (INCOME)"],
+      membership: ["MEMBERSHIP", "MEMBERSHIP (INCOME)"],
+      events: ["EVENTS", "EVENTS (INCOME)"],
+      services: [
+        "SERVICES TO MEMBERS",
+        "SERVICES MEMBERS",
+        "SERVICES TO MEMBERS (INCOME)",
+      ],
+      tic: ["T&IC", "T&IC (INCOME)", "T&IC INCOME"],
+    },
+  },
+  operativo: {
+    enabled: true,
+    title: "Ppto. Acumulado vs Real + {annual}",
+    chartType: "bar",
+    datasets: {
+      budget: { label: "Ppto. Acumulado", color: "#4472c4", enabled: true },
+      real: { label: "Real Acumulado", color: "#ffc000", enabled: true },
+      annual: { label: "Presupuesto {year}", color: "#22c55e", enabled: true },
+    },
+  },
+  gastosGenerales: {
+    enabled: true,
+    subtitleTemplate: "Real {year} vs {prev}",
+    charts: {
+      rendimientos: {
+        enabled: true,
+        title: "Rendimientos de Inversion",
+        chartType: "line",
+        series: {
+          actual: { label: "Real {year}", color: "#ffc000", enabled: true },
+          prev: { label: "Real {prev}", color: "#2f5496", enabled: true },
+        },
+      },
+      plusvalia: {
+        enabled: true,
+        title: "Plusvalia/Minusvalia",
+        chartType: "line",
+        series: {
+          actual: { label: "Real {year}", color: "#ffc000", enabled: true },
+          prev: { label: "Real {prev}", color: "#2f5496", enabled: true },
+        },
+      },
+    },
+  },
+  customCharts: [],
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const getDefaultGraficasConfig = () => clone(DEFAULT_GRAFICAS_CONFIG);
+
+module.exports = {
+  DEFAULT_GRAFICAS_CONFIG,
+  getDefaultGraficasConfig,
+};

--- a/src/routes/graficas-config.js
+++ b/src/routes/graficas-config.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { db } = require("../db/sqlite");
+const { getDefaultGraficasConfig } = require("../config/graficasDefaults");
 const { requireAuth, extraerEmpresaActiva } = require("../middleware/auth");
 
 const obtenerEmpresa = (req) => extraerEmpresaActiva(req) || "EMPRESA01";
@@ -17,10 +18,31 @@ const leerConfig = (empresaId) => {
   }
 };
 
+const guardarConfig = (empresaId, config) => {
+  const payload = JSON.stringify(config);
+  db.prepare(
+    `
+      INSERT INTO graficas_config (empresa_id, config_json, updated_at)
+      VALUES (?, ?, CURRENT_TIMESTAMP)
+      ON CONFLICT(empresa_id) DO UPDATE SET
+        config_json = excluded.config_json,
+        updated_at = CURRENT_TIMESTAMP
+    `
+  ).run(empresaId, payload);
+};
+
+const obtenerConfigInicial = (empresaId) => {
+  const existente = leerConfig(empresaId);
+  if (existente) return existente;
+  const defaults = getDefaultGraficasConfig();
+  guardarConfig(empresaId, defaults);
+  return defaults;
+};
+
 router.get("/", requireAuth, (req, res) => {
   try {
     const empresaId = obtenerEmpresa(req);
-    const config = leerConfig(empresaId);
+    const config = obtenerConfigInicial(empresaId);
     return res.json({ success: true, empresaId, config });
   } catch (error) {
     console.error("Error al cargar graficas-config:", error);
@@ -47,16 +69,7 @@ router.post("/", requireAuth, (req, res) => {
         mensaje: "Configuracion invalida.",
       });
     }
-    const payload = JSON.stringify(config);
-    db.prepare(
-      `
-      INSERT INTO graficas_config (empresa_id, config_json, updated_at)
-      VALUES (?, ?, CURRENT_TIMESTAMP)
-      ON CONFLICT(empresa_id) DO UPDATE SET
-        config_json = excluded.config_json,
-        updated_at = CURRENT_TIMESTAMP
-    `
-    ).run(empresaId, payload);
+    guardarConfig(empresaId, config);
     return res.json({ success: true, empresaId, config });
   } catch (error) {
     console.error("Error al guardar graficas-config:", error);

--- a/src/services/layoutService.js
+++ b/src/services/layoutService.js
@@ -37,6 +37,12 @@ const obtenerEmpresaCanonica = (empresaId = CANONICAL_EMPRESA_DEFAULT) => {
   );
 };
 
+const construirFormulaSeccion = (seccion) => {
+  const valor = (seccion || "").toString().trim();
+  if (!valor) return null;
+  return JSON.stringify([{ operator: "+", type: "section", value: valor }]);
+};
+
 const existeLayoutAnio = ({ empresaId, modulo, anio }) => {
   const row = db
     .prepare(
@@ -543,6 +549,7 @@ const obtenerLayout = ({ empresaId = "EMPRESA01", modulo, anio, capitulo }) => {
     .prepare(
       `
     SELECT 
+      id,
       capitulo AS CAPITULO,
       clase AS OperacionId,
       operacion_etiqueta,
@@ -560,6 +567,24 @@ const obtenerLayout = ({ empresaId = "EMPRESA01", modulo, anio, capitulo }) => {
   `,
     )
     .all(empresaConsulta, modulo, anioUsado, capituloObjetivo);
+
+  const operacionesSinFormula = operaciones.filter(
+    (op) => !op.formula_json && op.SECCION,
+  );
+  if (operacionesSinFormula.length) {
+    const updateFormula = db.prepare(
+      "UPDATE layout_operaciones SET formula_json = ? WHERE id = ?",
+    );
+    const transaction = db.transaction((rows) => {
+      rows.forEach((op) => {
+        const formulaJson = construirFormulaSeccion(op.SECCION);
+        if (!formulaJson) return;
+        updateFormula.run(formulaJson, op.id);
+        op.formula_json = formulaJson;
+      });
+    });
+    transaction(operacionesSinFormula);
+  }
 
   const operacionesMap = {};
   operaciones.forEach((op, idx) => {
@@ -908,7 +933,7 @@ const guardarOperaciones = ({
         .filter((key) => !/^operacion_\d+$/i.test(key))
         .filter((key) => !tiposOperacionBase.includes(key));
       const tiposOperacion = [...tiposOperacionBase, ...tiposOperacionExtra];
-      const formulaJson =
+      let formulaJson =
         typeof op.formula_json === "string"
           ? op.formula_json
           : op.formula_json != null
@@ -916,6 +941,9 @@ const guardarOperaciones = ({
             : Array.isArray(op.formula_terms)
               ? JSON.stringify(op.formula_terms)
               : null;
+      if (!formulaJson) {
+        formulaJson = construirFormulaSeccion(op.SECCION || op.seccion);
+      }
 
       const ordenPresentacion = Number.isFinite(Number(op.orden_presentacion))
         ? Number(op.orden_presentacion)

--- a/vistas/Gestor.html
+++ b/vistas/Gestor.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gestor</title>
+    <meta http-equiv="refresh" content="0; url=plantillas.html" />
+    <link rel="icon" type="image/x-icon" href="icono/icono.ico" />
+    <style>
+      body {
+        font-family: "Manrope", system-ui, -apple-system, sans-serif;
+        background: #f2f2f2;
+        color: #2f5496;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+      }
+      .card {
+        background: #ffffff;
+        border-radius: 16px;
+        box-shadow: 0 16px 30px rgba(47, 84, 150, 0.18);
+        padding: 2rem 2.5rem;
+        text-align: center;
+        max-width: 420px;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        margin: 0;
+        color: rgba(47, 84, 150, 0.7);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Gestor</h1>
+      <p>Redirigiendo al Gestor de Plantillas...</p>
+    </div>
+    <script>
+      window.location.replace("plantillas.html");
+    </script>
+  </body>
+</html>

--- a/vistas/js/react-app.js
+++ b/vistas/js/react-app.js
@@ -154,9 +154,9 @@
           requiresAdmin: true,
         },
         {
-          id: "plantillas",
-          label: "Gestor de Plantillas",
-          path: "plantillas.html",
+          id: "gestor",
+          label: "Gestor",
+          path: "Gestor.html",
           requiresAdmin: true,
           permiso: "Layouts",
         },

--- a/vistas/js/react-app.jsx
+++ b/vistas/js/react-app.jsx
@@ -50,7 +50,7 @@ const MODULE_GROUPS = [
       { id: 'perfil', label: 'Mi Perfil', path: 'perfil.html', badge: 'perfil', public: true },
       { id: 'usuarios', label: 'Administrar usuarios', path: 'usuarios.html', badge: 'Permisos', requiresAdmin: true },
       { id: 'crear-usuario', label: 'Crear usuario', path: 'crear_usuario.html', requiresAdmin: true },
-      { id: 'plantillas', label: 'Gestor de Plantillas', path: 'plantillas.html', requiresAdmin: true, permiso: 'Layouts' },
+      { id: 'gestor', label: 'Gestor', path: 'Gestor.html', requiresAdmin: true, permiso: 'Layouts' },
       { id: 'firebird-conexiones', label: 'Administrar conexiones', path: 'firebird-config.html', requiresAdminGlobal: true }
     ]
   }


### PR DESCRIPTION
### Motivation
- Proveer una entrada «Gestor» en la interfaz que redirija al editor de plantillas existente y facilite el acceso administrativo a la edición de layouts. 
- Asegurar que la configuración de las gráficas tenga valores por defecto almacenados en la base de datos para cada empresa. 
- Garantizar que las operaciones del layout tengan una `formula_json` consistente cuando solo exista la sección, para que las fórmulas se rendericen y persistan correctamente.

### Description
- Añadida la vista de redirección `vistas/Gestor.html` y actualizada la navegación admin para apuntar a `Gestor.html` desde `vistas/js/react-app.js` y `vistas/js/react-app.jsx`.
- Agregado `src/config/graficasDefaults.js` que expone `DEFAULT_GRAFICAS_CONFIG` y `getDefaultGraficasConfig` y usado para inicializar/sembrar la configuración de gráficas en la ruta API `src/routes/graficas-config.js` cuando no existía una configuración previa.
- Refactor en `src/routes/graficas-config.js` para extraer la lógica de guardado (`guardarConfig`) y usar `obtenerConfigInicial` al obtener la configuración vía `GET`.
- En `src/services/layoutService.js` se añadió `construirFormulaSeccion` y se implementó lógica para: (a) rellenar en la base de datos las operaciones que no tenían `formula_json` a partir de su `SECCION`, y (b) asegurar que al guardar operaciones se persista una `formula_json` por defecto cuando no haya `formula_terms` ni `formula_json` explícita.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio; no se solicitaron ejecuciones de CI en el rollout. 
- Se verificaron localmente cambios de archivos (archivos creados/actualizados) y se hizo un commit con los cambios mencionados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697254bfed78832dab6042404cee496d)